### PR TITLE
[codex] Implement dynamic bill sync slice

### DIFF
--- a/dashboard/modules/dynamic-bill/DynamicBillPage.tsx
+++ b/dashboard/modules/dynamic-bill/DynamicBillPage.tsx
@@ -1,39 +1,87 @@
-import { useState } from 'preact/hooks';
+import { useEffect, useState } from "preact/hooks";
+import type {
+  DynamicBillOverview,
+  DynamicSyncResult,
+  DynamicSyncStatus,
+} from "../../../src/shared/types/dynamic-bill";
+import { requestSW } from "../../utils/messaging";
 
-type DynamicBillStatus = 'unopened' | 'opened' | 'consumed' | 'processed';
+type DynamicBillStatus = "unopened" | "opened" | "consumed" | "processed";
 
 const STATUS_FILTERS: Array<{
   key: DynamicBillStatus;
   label: string;
   detail: string;
 }> = [
-  { key: 'unopened', label: '未打开', detail: '尚未从动态账单打开新投稿' },
-  { key: 'opened', label: '已打开', detail: '打开过，但尚未确认有效观看' },
-  { key: 'consumed', label: '已消费', detail: '由观看历史或播放器事件确认' },
-  { key: 'processed', label: '已处理', detail: '用户手动完成或忽略，不等同于消费' },
+  { key: "unopened", label: "未打开", detail: "尚未从动态账单打开新投稿" },
+  { key: "opened", label: "已打开", detail: "打开过，但尚未确认有效观看" },
+  { key: "consumed", label: "已消费", detail: "由观看历史或播放器事件确认" },
+  {
+    key: "processed",
+    label: "已处理",
+    detail: "用户手动完成或忽略，不等同于消费",
+  },
 ];
 
 const BILL_COLUMNS = [
   {
-    title: '久违更新',
-    detail: '过去有正反馈、近期冷却的已关注 UP 新投稿。',
-    accent: 'pink',
+    title: "久违更新",
+    detail: "过去有正反馈、近期冷却的已关注 UP 新投稿。",
+    accent: "pink",
   },
   {
-    title: '换换口味',
-    detail: '长期兴趣中近期占比下降的分区或标签新投稿。',
-    accent: 'blue',
+    title: "换换口味",
+    detail: "长期兴趣中近期占比下降的分区或标签新投稿。",
+    accent: "blue",
   },
   {
-    title: '被淹没的关注',
-    detail: '关注关系稳定、近期几乎没有消费的 UP 新投稿。',
-    accent: 'mint',
+    title: "被淹没的关注",
+    detail: "关注关系稳定、近期几乎没有消费的 UP 新投稿。",
+    accent: "mint",
   },
 ] as const;
 
 export function DynamicBillPage() {
-  const [status, setStatus] = useState<DynamicBillStatus>('unopened');
-  const activeStatus = STATUS_FILTERS.find(item => item.key === status) ?? STATUS_FILTERS[0];
+  const [status, setStatus] = useState<DynamicBillStatus>("unopened");
+  const [overview, setOverview] = useState<DynamicBillOverview | null>(null);
+  const [syncing, setSyncing] = useState(false);
+  const [notice, setNotice] = useState("");
+  const activeStatus =
+    STATUS_FILTERS.find((item) => item.key === status) ?? STATUS_FILTERS[0];
+  const syncState = overview?.syncState;
+  const isSyncing = syncing || syncState?.status === "syncing";
+  const overviewNotice = overview
+    ? describeOverview(overview)
+    : "正在读取动态账单同步状态。";
+  const emptyCopy = getEmptyCopy(overview, activeStatus.label);
+
+  useEffect(() => {
+    refreshOverview().catch((error) => {
+      setNotice(`读取动态账单状态失败：${describeError(error)}`);
+    });
+  }, []);
+
+  async function refreshOverview() {
+    const next = await requestSW<DynamicBillOverview>(
+      "GET_DYNAMIC_BILL_OVERVIEW",
+    );
+    setOverview(next);
+  }
+
+  async function handleSync() {
+    setSyncing(true);
+    setNotice("");
+    try {
+      const result = await requestSW<DynamicSyncResult>("SYNC_DYNAMIC_UPDATES");
+      setOverview(result.overview);
+      setNotice(describeSyncResult(result));
+    } catch (error) {
+      setNotice(`动态同步请求失败：${describeError(error)}`);
+      await refreshOverview().catch(() => {});
+    } finally {
+      setSyncing(false);
+    }
+  }
 
   return (
     <div className="dynamic-bill-page">
@@ -42,28 +90,68 @@ export function DynamicBillPage() {
           <span className="dynamic-bill-kicker">消费前 / 已关注视频投稿</span>
           <h2>动态账单</h2>
           <p>
-            这里将作为 Bili-Bill 的一级入口，用本地规则和必要解释帮助用户看见被近期口味覆盖的长期关注。
+            这里将作为 Bili-Bill
+            的一级入口，用本地规则和必要解释帮助用户看见被近期口味覆盖的长期关注。
           </p>
         </div>
         <div className="dynamic-bill-scope">
-          <strong>当前任务范围</strong>
-          <span>Shell、导航、四态文案与结构占位</span>
+          <strong>同步范围</strong>
+          <span>
+            只同步已关注 UP 最近 7 天的视频投稿动态；非视频动态不会进入账单池。
+          </span>
+          <button
+            type="button"
+            className="dynamic-bill-sync-button"
+            disabled={isSyncing}
+            onClick={handleSync}
+          >
+            {isSyncing ? "同步中..." : "同步关注动态"}
+          </button>
         </div>
       </header>
 
-      <section className="dynamic-bill-status-grid" aria-label="动态账单数据状态">
-        <StatusMetric label="动态同步" value="待接入" detail="后续任务会同步最近 7 天视频投稿" />
-        <StatusMetric label="长期窗口" value="180 天" detail="用于识别耐久兴趣，不足时需明确提示" />
-        <StatusMetric label="近期窗口" value="30 天" detail="用于判断近期消费结构变化" />
-        <StatusMetric label="AI 解释" value="可选增强" detail="不参与入选规则或排序" />
+      <section
+        className="dynamic-bill-status-grid"
+        aria-label="动态账单数据状态"
+      >
+        <StatusMetric
+          label="动态同步"
+          value={syncStatusLabel(syncState?.status ?? "idle")}
+          detail={lastSyncDetail(overview)}
+        />
+        <StatusMetric
+          label="已关注 UP"
+          value={String(overview?.activeFollowedCreatorCount ?? 0)}
+          detail="关注快照写入本地仓库"
+        />
+        <StatusMetric
+          label="最近投稿"
+          value={String(overview?.recentVideoUpdateCount ?? 0)}
+          detail={`最近 ${overview?.updateWindowDays ?? 7} 天视频投稿池`}
+        />
+        <StatusMetric
+          label="关注时间"
+          value={`${overview?.followAgeKnownCount ?? 0} / ${overview?.followAgeUnknownCount ?? 0}`}
+          detail="已知 / 未知；未知时不展示虚假时长"
+        />
+      </section>
+
+      <section
+        className="dynamic-bill-status-copy"
+        aria-label="动态账单同步说明"
+      >
+        <strong>{notice || overviewNotice}</strong>
+        <span>
+          本任务只同步数据池，不生成久违更新、换换口味或被淹没的关注规则账单。
+        </span>
       </section>
 
       <section className="dynamic-bill-filters" aria-label="账单状态筛选">
-        {STATUS_FILTERS.map(item => (
+        {STATUS_FILTERS.map((item) => (
           <button
             key={item.key}
             type="button"
-            className={status === item.key ? 'is-selected' : ''}
+            className={status === item.key ? "is-selected" : ""}
             onClick={() => setStatus(item.key)}
           >
             <span>{item.label}</span>
@@ -74,8 +162,11 @@ export function DynamicBillPage() {
 
       <section className="dynamic-bill-layout">
         <div className="dynamic-bill-board" aria-label="动态账单栏目">
-          {BILL_COLUMNS.map(column => (
-            <article className={`dynamic-bill-column tone-${column.accent}`} key={column.title}>
+          {BILL_COLUMNS.map((column) => (
+            <article
+              className={`dynamic-bill-column tone-${column.accent}`}
+              key={column.title}
+            >
               <div className="dynamic-bill-column-head">
                 <div>
                   <h3>{column.title}</h3>
@@ -84,8 +175,8 @@ export function DynamicBillPage() {
                 <span>0</span>
               </div>
               <div className="dynamic-bill-empty">
-                <strong>{activeStatus.label}账单项将在这里显示</strong>
-                <p>当前页面只建立入口结构；同步、规则引擎和真实账单项由后续任务接入。</p>
+                <strong>{emptyCopy.title}</strong>
+                <p>{emptyCopy.detail}</p>
               </div>
             </article>
           ))}
@@ -95,23 +186,154 @@ export function DynamicBillPage() {
           <span className="dynamic-bill-kicker">选中账单项</span>
           <h3>详情结构占位</h3>
           <p>
-            真实账单项接入后，这里会展示 UP 主、新投稿、本地证据事实、AI 解释、本地历史代表视频与操作入口。
+            真实账单项接入后，这里会展示 UP 主、新投稿、本地证据事实、AI
+            解释、本地历史代表视频与操作入口。
           </p>
           <div className="dynamic-bill-status-copy">
             <strong>当前筛选：{activeStatus.label}</strong>
             <span>{activeStatus.detail}</span>
           </div>
           <div className="dynamic-bill-action-grid">
-            <button type="button" disabled>打开新视频</button>
-            <button type="button" disabled>打开 UP 主页</button>
-            <button type="button" disabled>标记已处理</button>
-            <button type="button" disabled>少提醒这个 UP</button>
-            <button type="button" disabled>少提醒这个主题</button>
+            <button type="button" disabled>
+              打开新视频
+            </button>
+            <button type="button" disabled>
+              打开 UP 主页
+            </button>
+            <button type="button" disabled>
+              标记已处理
+            </button>
+            <button type="button" disabled>
+              少提醒这个 UP
+            </button>
+            <button type="button" disabled>
+              少提醒这个主题
+            </button>
           </div>
         </aside>
       </section>
     </div>
   );
+}
+
+function syncStatusLabel(status: DynamicSyncStatus) {
+  switch (status) {
+    case "syncing":
+      return "同步中";
+    case "success":
+      return "已同步";
+    case "not_logged_in":
+      return "未登录";
+    case "failed":
+      return "同步失败";
+    default:
+      return "待同步";
+  }
+}
+
+function lastSyncDetail(overview: DynamicBillOverview | null): string {
+  const state = overview?.syncState;
+  if (!state) return "正在读取状态";
+  if (state.status === "syncing") return `阶段：${stageLabel(state.stage)}`;
+  if (state.lastSuccessAt > 0)
+    return `最后成功：${formatTime(state.lastSuccessAt)}`;
+  if (state.lastFinishedAt > 0)
+    return `最后尝试：${formatTime(state.lastFinishedAt)}`;
+  return "尚未完成同步";
+}
+
+function describeOverview(overview: DynamicBillOverview): string {
+  const state = overview.syncState;
+  if (state.status === "not_logged_in") {
+    return "需要先登录 B 站账号，Bili-Bill 才能同步你的关注关系和关注动态。";
+  }
+  if (state.status === "failed") {
+    return `动态同步失败：${state.lastError ?? "未知错误"}。已保留本地已有动态数据。`;
+  }
+  if (state.status === "success") {
+    return `已同步 ${overview.activeFollowedCreatorCount} 个关注 UP，最近 ${overview.updateWindowDays} 天视频投稿 ${overview.recentVideoUpdateCount} 条。`;
+  }
+  if (state.status === "syncing") {
+    return `正在同步动态账单数据，当前阶段：${stageLabel(state.stage)}。`;
+  }
+  return "尚未同步动态账单数据；可以手动同步关注关系和最近视频投稿。";
+}
+
+function describeSyncResult(result: DynamicSyncResult): string {
+  if (result.status === "not_logged_in") {
+    return "同步未完成：当前没有可用的 B 站登录态。";
+  }
+  if (result.status === "failed") {
+    return `同步失败：${result.error ?? "未知错误"}。已保留本地已有动态数据。`;
+  }
+  return `同步完成：关注 UP ${result.followedCreatorsStored} 个，最近视频投稿 ${result.videoUpdatesStored} 条，过滤非视频动态 ${result.filteredNonVideoCount} 条。`;
+}
+
+function getEmptyCopy(
+  overview: DynamicBillOverview | null,
+  statusLabel: string,
+): { title: string; detail: string } {
+  if (!overview) {
+    return {
+      title: "正在读取账单数据",
+      detail: "同步状态加载后会显示关注快照和最近视频投稿池数量。",
+    };
+  }
+  if (overview.syncState.status === "not_logged_in") {
+    return {
+      title: "需要登录 B 站后同步",
+      detail: "未登录时页面不会崩溃，也不会尝试生成虚假的账单项。",
+    };
+  }
+  if (overview.activeFollowedCreatorCount === 0) {
+    return {
+      title: "还没有关注快照",
+      detail:
+        "完成同步后，这里会基于已关注 UP 的视频投稿池等待后续规则引擎生成账单项。",
+    };
+  }
+  if (overview.recentVideoUpdateCount === 0) {
+    return {
+      title: "最近 7 天暂无已关注视频投稿",
+      detail: "非视频动态已被过滤，不会进入动态账单候选池。",
+    };
+  }
+  return {
+    title: `${statusLabel}账单项将在后续任务生成`,
+    detail:
+      "当前任务只准备已关注视频投稿池；三栏兴趣再平衡规则由后续 issue 接入。",
+  };
+}
+
+function stageLabel(stage: string): string {
+  switch (stage) {
+    case "following":
+      return "关注关系";
+    case "dynamic-feed":
+      return "动态 feed";
+    case "video-detail":
+      return "视频详情补全";
+    case "storage":
+      return "本地写入";
+    case "complete":
+      return "完成";
+    default:
+      return "等待";
+  }
+}
+
+function formatTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleString("zh-CN");
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
 }
 
 function StatusMetric({

--- a/docs/spikes/dynamic-feed-api.md
+++ b/docs/spikes/dynamic-feed-api.md
@@ -1,0 +1,261 @@
+# 动态账单 API Spike：动态 feed
+
+日期：2026-06-04
+
+范围：验证动态账单 v1 是否可以 API-first 获取最近 7 天已关注 UP 的视频投稿动态。本文只记录只读 API spike，不实现正式同步功能，不调用 AI，不上传完整历史或完整关注列表，不改写 B 站关注关系。
+
+## 结论
+
+API-first 可进入正式实现，但需要在后续实现前做一次登录账号 smoke test。当前代码已有 `biliGet`、登录态 Cookie 透传、限流、超时、WBI fallback 和 `-101` 未登录错误处理，适合承接动态 feed 拉取。
+
+DOM fallback 暂不作为首选实现。应保留方案，但只在登录态 API 连续失败、字段结构发生破坏性变化，或 B 站限制扩展 background 请求时启用。
+
+## 候选端点
+
+主端点：
+
+```text
+GET https://api.bilibili.com/x/polymer/web-dynamic/v1/feed/all
+```
+
+建议参数：
+
+```text
+type=video
+offset=<上一页返回的 offset，第一页为空>
+timezone_offset=-480
+```
+
+说明：
+
+- 需要登录 Cookie；未登录返回 `code=-101`。
+- `type=video` 可作为第一层服务端过滤，但正式实现仍必须在客户端二次识别视频投稿。
+- 分页以响应中的 `offset` 和 `has_more` 为准，不依赖 `page`。
+- endpoint host 已被 `public/manifest.json` 的 `*://*.bilibili.com/*` 覆盖。
+- 现有 `src/background/api/client.ts` 的 `biliGet` 会带 `credentials: 'include'`、`Referer: https://www.bilibili.com/` 和统一限流。
+
+## 本地探测记录
+
+当前命令行环境未读取浏览器 Cookie。只做无登录探测，避免导出用户 Cookie 或关注数据。
+
+探测结果：
+
+| 端点 | 样本参数 | 结果 |
+| --- | --- | --- |
+| `/x/web-interface/nav` | 无 | `code=-101`, `message=账号未登录`, `data.isLogin=false` |
+| `/x/polymer/web-dynamic/v1/feed/all` | `type=video&page=1` | `code=-101`, `message=账号未登录` |
+
+这确认动态 feed 不能无登录获取，也说明后续实现要把 `NOT_LOGGED_IN` 当作正常可解释状态处理。当前环境没有做登录态 7 天覆盖率采样，因此“稳定获取最近 7 天”仍需要在扩展 background 中用真实登录账号完成 smoke test。
+
+## Smoke test 记录（2026-06-04）
+
+本轮 issue #4 开发前尝试做登录态 smoke test。Codex CLI 环境没有可复用的 B 站浏览器登录 Cookie；为避免导出或复制 Cookie，只执行不带 Cookie 的只读请求。
+
+结果：
+
+| 端点 | 参数 | 结果 |
+| --- | --- | --- |
+| `/x/web-interface/nav` | 无 | `code=-101`, `message=账号未登录`, `data.isLogin=false` |
+| `/x/polymer/web-dynamic/v1/feed/all` | `type=video&timezone_offset=-480` | `code=-101`, `message=账号未登录` |
+
+结论：
+
+- 未登录降级路径已确认，正式实现必须把 `NOT_LOGGED_IN` 显示成可解释状态。
+- 当前环境未能确认登录态下 `items/offset/has_more` 的真实字段表现。
+- 正式实现仍按 API-first 推进，并通过扩展 background 的 `credentials: include` 使用用户现有登录态。
+- 后续在用户已登录 B 站并加载扩展后，需要再次点击动态账单同步按钮，确认 `DYNAMIC_TYPE_AV` / `MAJOR_TYPE_ARCHIVE` 过滤命中和最近 7 天覆盖率。
+
+## 视频投稿识别
+
+不要只信任 `type=video`。正式实现应同时满足：
+
+- `item.type === 'DYNAMIC_TYPE_AV'`，或等价的视频动态类型。
+- `item.modules.module_dynamic.major.type === 'MAJOR_TYPE_ARCHIVE'`。
+- `item.modules.module_dynamic.major.archive.bvid` 存在。
+
+建议字段映射：
+
+| 本地字段 | API 字段候选 | 备注 |
+| --- | --- | --- |
+| `dynamicId` | `item.id_str` | 用字符串，避免大整数精度问题。 |
+| `dynamicTime` | `modules.module_author.pub_ts` | 秒级时间戳，用于 7 天窗口。 |
+| `authorMid` | `modules.module_author.mid` | 与关注列表 join。 |
+| `authorName` | `modules.module_author.name` | 展示用。 |
+| `authorFace` | `modules.module_author.face` | 展示用。 |
+| `bvid` | `major.archive.bvid` | 必填。 |
+| `avid` | `major.archive.aid` | 可选补充。 |
+| `title` | `major.archive.title` | 必填。 |
+| `intro` | `major.archive.desc` 或详情接口 `desc` | 可能为空。 |
+| `cover` | `major.archive.cover` | 展示用。 |
+| `duration` | `major.archive.duration_text` 或 `/x/web-interface/view` | 若只有文本，正式入库前转秒或补全。 |
+| `pubtime` | `/x/web-interface/view` 的发布时间字段 | feed 中不一定稳定。 |
+| `tagName` | `/x/web-interface/view` 的 `tname` | 用于换换口味。 |
+
+建议仍复用 `src/background/api/video-info.ts` 的 `batchFetchVideoInfo` 为候选视频补全详情。补全失败不能阻断动态同步，缺失字段记录为空或 unknown。
+
+## 7 天窗口策略
+
+同步流程建议：
+
+1. 用 `biliGet` 请求第一页 `feed/all?type=video`。
+2. 对每条 item 做客户端视频投稿识别。
+3. 以 `dynamicTime` 判断是否属于最近 7 天。
+4. 写入候选池前生成稳定 key：`${dynamicId}:${bvid}`。
+5. 使用响应 `offset` 拉下一页。
+6. 当当前页最老 `dynamicTime < now - 7 days` 且后续页只会更旧时停止。
+7. 设置安全上限，例如最多 20 页或最多 1000 条原始动态，防止 offset 异常循环。
+
+排序和入选不要使用点击率、推荐理由或互动数。动态 feed 只提供“已关注 UP 最近视频投稿池”，后续账单栏目仍由本地兴趣再平衡规则决定。
+
+## 失败和降级
+
+| 场景 | 处理 |
+| --- | --- |
+| 未登录 `-101` | 返回 `NOT_LOGGED_IN`，Dashboard 展示可解释状态，不刷红错误。 |
+| HTTP 412 或疑似限流 | 复用现有 60 秒 backoff；动态同步建议低频、用户触发优先。 |
+| 请求超时 | 保留旧账单或旧同步时间，提示本次动态同步失败。 |
+| `type=video` 返回非视频 | 客户端二次过滤，丢弃非 `MAJOR_TYPE_ARCHIVE`。 |
+| 字段缺失 | 记录 raw 关键片段到本地 debug 日志或返回 warning，不让单条异常中断整页。 |
+| 详情补全失败 | 保留 feed 原始标题、封面、bvid；`tagName/tags/duration/pubtime` 降级为空。 |
+
+## DOM fallback 方案
+
+只在 API-first 失败后启用。
+
+候选页面：`https://t.bilibili.com/` 或 B 站当前动态页。
+
+原则：
+
+- 只在用户明确打开动态页或手动触发同步后采集。
+- 只采集可见或有限滚动后的最近 7 天视频投稿卡片。
+- 只提取动态 ID、UP、bvid、标题、封面、发布时间等最小字段。
+- 不读取评论、弹幕、推荐卡、广告卡或非关注内容。
+- 不使用 DOM fallback 改写页面排序。
+
+风险：
+
+- DOM class 和嵌套结构更容易变化。
+- 滚动加载会增加用户可见页面扰动。
+- 时间文案可能是相对时间，需要额外转换。
+
+因此 DOM fallback 是兜底，不应阻塞 API-first 正式实现。
+
+## 后续正式实现入口
+
+建议新增：
+
+```text
+src/background/api/dynamic.ts
+```
+
+核心方法：
+
+```ts
+fetchFollowedVideoDynamics(options: {
+  windowDays: number;
+  maxPages: number;
+  signal?: AbortSignal;
+}): Promise<FollowedVideoUpdate[]>
+```
+
+实现要求：
+
+- 复用 `biliGet`，不新建独立 fetch client。
+- 只读 B 站 API。
+- 不调用 AI。
+- 不上传 feed 原始列表。
+- 对每次同步记录 `syncedAt`、页数、候选数、过滤数、失败原因。
+
+## 仍需人工验证
+
+后续 issue #4 开始前，需要在登录 B 站的扩展环境完成：
+
+- `type=video` 是否稳定返回已关注账号的视频投稿动态。
+- `offset` 是否能覆盖最近 7 天，尤其是高关注量账号。
+- `module_author.pub_ts` 是否可作为动态发布时间。
+- `major.archive` 字段是否覆盖 `bvid/aid/title/cover/desc/duration`。
+- 非视频动态是否会混入，以及客户端过滤命中率。
+
+## 真实扩展 smoke attempt（2026-06-04）
+
+已执行：
+
+- 使用 `dist` 装载本地扩展，并打开 `chrome-extension://.../dashboard/index.html#dynamic-bill`。
+- 在同一浏览器会话中打开 `https://www.bilibili.com/`。
+- 在 Dashboard 点击“同步关注动态”。
+- 仅通过页面上下文请求 `/x/web-interface/nav` 判断登录态；未读取、复制或导出 Cookie。
+
+结果：
+
+- `/x/web-interface/nav` 返回 `code=-101`，`isLogin=false`。
+- Dashboard 最终显示“未登录”和“同步未完成：当前没有可用的 B 站登录态。”，页面未崩溃。
+- 因当前会话未登录，未能完成登录态下的 `/x/polymer/web-dynamic/v1/feed/all?type=video` 验证。
+- 因未进入登录态，本次无法确认 `DYNAMIC_TYPE_AV` / `MAJOR_TYPE_ARCHIVE` 的真实返回覆盖，也无法确认最近 7 天动态覆盖情况。
+
+结论：
+
+- 扩展装载与页面入口可用，但真实登录态 dynamic feed smoke test 仍阻塞在用户登录。
+- 后续复跑时仍只记录汇总字段：接口 code、首屏 item 数、动态 type/major type 计数、最近 7 天 archive 数、最早/最新 archive 时间；不记录完整动态列表。
+
+## 真实扩展登录态 smoke test（2026-06-04）
+
+测试边界：
+
+- 使用已装载的 `dist` 扩展，在 Dashboard 动态账单页点击“同步关注动态”。
+- 只记录 API 和本地同步汇总字段。
+- 未读取、复制或导出 Cookie。
+- 未记录完整动态列表，未调用 AI，未上传观看历史或关注列表，未写回 B 站关注关系。
+
+登录态 API 汇总：
+
+| 字段 | 结果 |
+| --- | --- |
+| nav code / isLogin | `0 / true` |
+| dynamic feed 首页 code | `0` |
+| dynamic feed 首页 items | `20` |
+| 首页 `DYNAMIC_TYPE_AV` 命中数 | `20` |
+| 首页 `MAJOR_TYPE_ARCHIVE` 命中数 | `20` |
+| 首页严格视频投稿命中数 | `20` |
+| 首页最近 7 天严格视频投稿数 | `20` |
+
+分页覆盖汇总：
+
+| 字段 | 结果 |
+| --- | --- |
+| 探测页数 | `49` |
+| 扫描 items | `980` |
+| `DYNAMIC_TYPE_AV` 命中数 | `980` |
+| `MAJOR_TYPE_ARCHIVE` 命中数 | `980` |
+| 严格视频投稿命中数 | `980` |
+| 最近 7 天严格视频投稿数 | `976` |
+| 是否到达 7 天边界 | `true` |
+| 最早严格视频投稿时间 | `2026-05-28 17:07:38 +08:00` |
+| 最新严格视频投稿时间 | `2026-06-04 17:02:22 +08:00` |
+
+实现修正：
+
+- smoke 发现原 `DYNAMIC_FEED_MAX_PAGES=20` 只能同步到 `400` 条，未覆盖完整 7 天窗口。
+- 已将 `DYNAMIC_FEED_MAX_PAGES` 调整为 `80`，保留安全上限；真实登录态复跑后同步池覆盖到 7 天边界。
+- 详情补全改为先写入动态池，再限量、限时 best-effort 补全，避免 `/x/web-interface/view` 慢请求阻断同步完成。
+
+Dashboard 同步结果：
+
+| 字段 | 结果 |
+| --- | --- |
+| 同步状态 | `success / complete` |
+| 最后成功同步时间 | `2026-06-04 17:24:34 +08:00` |
+| 关注 UP 数 | `533` |
+| 最近视频投稿数 | `976` |
+| 本地投稿池最近 7 天覆盖 | `976 / 976` |
+| 本地最早投稿时间 | `2026-05-28 17:29:53 +08:00` |
+| 本地最新投稿时间 | `2026-06-04 17:20:01 +08:00` |
+| 未登录状态 | 本轮登录态下未触发；前置未登录 smoke 已确认页面不崩溃并显示可解释状态。 |
+| 失败状态 | 旧同步超时会被 stale recovery 转为失败并保留本地数据；本轮最终同步未失败。 |
+| 空状态 | 同步池非空；三栏规则项仍为空，页面正确说明后续规则引擎生成。 |
+
+结论：
+
+- dynamic feed API-first 可用于 #4 正式同步。
+- 客户端仍必须二次过滤 `DYNAMIC_TYPE_AV` / `MAJOR_TYPE_ARCHIVE` / `bvid`。
+- 当前账号高动态量场景下，7 天窗口需要超过 20 页；正式实现使用 `80` 页安全上限。
+- DOM fallback 本轮不需要。

--- a/docs/spikes/following-api.md
+++ b/docs/spikes/following-api.md
@@ -1,0 +1,249 @@
+# 动态账单 API Spike：关注关系
+
+日期：2026-06-04
+
+范围：验证动态账单 v1 是否可以 API-first 获取当前登录用户的关注 UP 列表和已关注时间。本文只记录只读 API spike，不实现正式同步功能，不调用 AI，不上传完整关注列表，不改写 B 站关注关系。
+
+## 结论
+
+关注列表 API-first 可进入正式实现；已关注时间需要谨慎建模。
+
+`/x/relation/followings` 是主候选端点，预计可返回关注 UP 基础信息和 `mtime` 字段。`mtime` 可以作为“已关注时间”的候选字段，但当前环境没有登录态样本，不能把它无条件写成“原始首次关注时间”。正式实现应保存 `followedAt?: number` 和 `followAgeKnown: boolean`，并在字段缺失、为 0 或语义不稳时降级展示“已关注，关注时长未知”。
+
+DOM fallback 不适合作为关注关系列表的常规方案。关注关系应优先 API 同步；若 API 无法确认 `mtime`，仍可用“关注关系存在但关注时长未知”支撑被淹没的关注栏目。
+
+## 候选端点
+
+当前登录用户：
+
+```text
+GET https://api.bilibili.com/x/web-interface/nav
+```
+
+关注列表：
+
+```text
+GET https://api.bilibili.com/x/relation/followings
+```
+
+建议参数：
+
+```text
+vmid=<当前登录用户 mid>
+pn=<页码，从 1 开始>
+ps=50
+order=desc
+order_type=attention
+```
+
+说明：
+
+- `vmid` 来自现有 `fetchCurrentUserMid` 使用的 nav 接口。
+- 关注列表需要登录 Cookie；无登录时返回 `code=-101`。
+- 分页以 `pn/ps` 和返回的 `total/list.length` 判断。
+- `ps` 建议先用 50，降低单页失败重试成本。
+- 不调用任何 `/x/relation/modify`、取关、批量取关或分组写入接口。
+
+## 本地探测记录
+
+当前命令行环境未读取浏览器 Cookie。只做无登录探测，避免导出用户 Cookie 或关注数据。
+
+探测结果：
+
+| 端点 | 样本参数 | 结果 |
+| --- | --- | --- |
+| `/x/web-interface/nav` | 无 | `code=-101`, `message=账号未登录`, `data.isLogin=false` |
+| `/x/relation/followings` | `vmid=2&pn=1&ps=5&order=desc&order_type=attention` | `code=-101`, `message=账号未登录` |
+
+这确认关注关系不能无登录获取，也说明正式实现要把 `NOT_LOGGED_IN` 作为正常同步状态。当前环境没有做登录账号关注列表采样，因此 `mtime` 的字段单位和语义仍需登录态 smoke test 确认。
+
+## Smoke test 记录（2026-06-04）
+
+本轮 issue #4 开发前尝试做登录态 smoke test。Codex CLI 环境没有可复用的 B 站浏览器登录 Cookie；为避免导出或复制 Cookie，只执行不带 Cookie 的只读请求。
+
+结果：
+
+| 端点 | 参数 | 结果 |
+| --- | --- | --- |
+| `/x/web-interface/nav` | 无 | `code=-101`, `message=账号未登录`, `data.isLogin=false` |
+| `/x/relation/followings` | `vmid=2&pn=1&ps=5&order=desc&order_type=attention` | `code=-101`, `message=账号未登录` |
+
+结论：
+
+- 未登录降级路径已确认，正式实现必须把 `NOT_LOGGED_IN` 显示成可解释状态。
+- 当前环境未能确认登录态下关注列表分页、`total/list` 和 `mtime` 的真实字段表现。
+- `mtime` 仍只能作为已关注时间候选字段；实现必须在缺失、为 0、未来时间或异常单位时记录 `followAgeKnown=false`。
+- 后续在用户已登录 B 站并加载扩展后，需要再次点击动态账单同步按钮，确认 `mtime` 是否为秒级 Unix 时间戳，以及它在互关、特别关注、分组变化后的语义。
+
+## 字段映射
+
+建议字段：
+
+| 本地字段 | API 字段候选 | 备注 |
+| --- | --- | --- |
+| `mid` | `item.mid` | UP 主 mid，主键。 |
+| `name` | `item.uname` | 展示名。 |
+| `face` | `item.face` | 头像。 |
+| `sign` | `item.sign` | 个性签名，可为空。 |
+| `followedAt` | `item.mtime` | 候选已关注时间，预期为秒级 Unix 时间戳。必须实测确认。 |
+| `followAgeKnown` | `Boolean(item.mtime)` | `mtime` 缺失、0 或异常时为 false。 |
+| `special` | `item.special` | 特别关注标记，只做解释辅助，不决定入选。 |
+| `attribute` | `item.attribute` | 关系属性，只做 debug/兼容保留。 |
+| `tagId` | `item.tagid` 或 `item.tag` | 分组相关，v1 不依赖。 |
+| `syncedAt` | 本地时间 | 本地同步时间。 |
+
+`mtime` 处理规则：
+
+- 若为正整数，先按秒级 Unix 时间戳保存。
+- 若明显是毫秒级，转换为秒或统一本地毫秒格式，但必须记录转换逻辑。
+- 若缺失、为 0、晚于当前时间，或和响应语义不一致，保存 `followedAt=undefined`、`followAgeKnown=false`。
+- 即使可用，也只作为 taste-memory 辅助信号，不单独决定账单项入选。
+
+## 同步策略
+
+建议流程：
+
+1. 调用 `/x/web-interface/nav` 获取当前登录用户 `mid`。
+2. 从 `pn=1` 开始拉 `/x/relation/followings`。
+3. 每页只映射最小字段，不把完整响应传给 AI 或外部服务。
+4. 根据 `total`、`list.length < ps` 或空页停止。
+5. 对 `mid` upsert 本地 `followedCreators`。
+6. 当前快照中缺失的历史关注对象不要直接删除；可在正式数据模型中增加 `lastSeenAt` 或 `missingInLatestSync`，避免一次失败误判。
+
+建议安全上限：
+
+- `ps=50`。
+- `maxPages=200`，覆盖最多 10000 个关注关系。
+- 每页复用现有 `biliGet` 限流；关注同步不需要高频运行。
+
+## 失败和降级
+
+| 场景 | 处理 |
+| --- | --- |
+| 未登录 `-101` | 返回 `NOT_LOGGED_IN`，Dashboard 展示“需要登录 B 站后同步”。 |
+| 关注列表为空 | 区分真实 0 关注和 API 失败；只有 `code=0` 且 total/list 为空才展示空状态。 |
+| `mtime` 不可用 | `followAgeKnown=false`，解释文案使用“已关注，关注时长未知”。 |
+| 分页中断 | 保留上一份本地关注快照，展示本次同步失败和最后成功时间。 |
+| 限流或 412 | 复用现有 backoff，降低同步频率。 |
+| 关系字段语义变化 | 不影响 v1 最小闭环；被淹没的关注栏目降级为“稳定关注关系 + 近期缺席”。 |
+
+## DOM fallback 评估
+
+关注关系 DOM fallback 不建议进入 v1 主线。
+
+原因：
+
+- 关注页通常需要滚动和分页，完整性比动态 feed 更难保证。
+- 页面展示的关注时间未必可见，常见 DOM 信息只能证明“关注关系存在”。
+- DOM 采集完整关注列表更容易触碰隐私边界。
+
+若必须 fallback，只允许做非常有限的人工辅助：
+
+- 用户打开自己的关注页后，content script 读取当前可见 UP 的 `mid/name/face`。
+- 不推断关注时间。
+- 不自动滚完整列表。
+- 不做任何取关、分组或关系写入。
+
+关注时间不可用时，优先采用 API 降级语义，而不是 DOM fallback。
+
+## 后续正式实现入口
+
+建议新增：
+
+```text
+src/background/api/following.ts
+```
+
+核心方法：
+
+```ts
+fetchFollowingCreators(options: {
+  maxPages: number;
+  signal?: AbortSignal;
+}): Promise<FollowedCreator[]>
+```
+
+实现要求：
+
+- 复用 `fetchCurrentUserMid` 或抽出共享 nav helper。
+- 复用 `biliGet`，不新建独立 fetch client。
+- 只读 B 站 API。
+- 不调用关注关系写接口。
+- 不调用 AI。
+- 不上传完整关注列表。
+- 返回同步摘要：页数、关注数、`followAgeKnown` 数量、缺失 `mtime` 数量、失败原因。
+
+## 仍需人工验证
+
+后续 issue #4 开始前，需要在登录 B 站的扩展环境完成：
+
+- `/x/relation/followings` 是否能返回当前登录用户完整关注列表。
+- `total`、`pn/ps` 分页是否稳定。
+- `mtime` 是否存在、是否为秒级 Unix 时间戳。
+- `mtime` 在互关、特别关注、关注分组变化后是否仍代表首次关注时间。
+- 隐藏关注列表或隐私设置是否影响“当前用户读取自己的关注列表”。
+- 特别关注、分组字段是否会影响普通关注列表覆盖范围。
+
+## 真实扩展 smoke attempt（2026-06-04）
+
+已执行：
+
+- 使用 `dist` 装载本地扩展，并打开 `chrome-extension://.../dashboard/index.html#dynamic-bill`。
+- 在同一浏览器会话中打开 `https://www.bilibili.com/`。
+- 在 Dashboard 点击“同步关注动态”。
+- 仅通过页面上下文请求 `/x/web-interface/nav` 判断登录态；未读取、复制或导出 Cookie。
+
+结果：
+
+- `/x/web-interface/nav` 返回 `code=-101`，`isLogin=false`。
+- Dashboard 最终显示“未登录”和“同步未完成：当前没有可用的 B 站登录态。”，页面未崩溃。
+- 因当前会话未登录，未能完成登录态下的 `/x/relation/followings` 验证。
+- 因未进入登录态，本次无法确认关注列表返回、`mtime` 是否存在、以及 `mtime` 是否为秒级 Unix 时间戳。
+
+结论：
+
+- 扩展装载与页面入口可用，但真实登录态 following smoke test 仍阻塞在用户登录。
+- 后续复跑时仍只记录汇总字段：接口 code、total、首屏数量、`mtime` 存在性、字段类型、位数、是否落在合理秒级 Unix 时间范围；不记录完整关注列表。
+
+## 真实扩展登录态 smoke test（2026-06-04）
+
+测试边界：
+
+- 使用已装载的 `dist` 扩展，在 Dashboard 动态账单页点击“同步关注动态”。
+- 只记录 API 和本地同步汇总字段。
+- 未读取、复制或导出 Cookie。
+- 未记录完整关注列表，未调用 AI，未上传观看历史或关注列表，未写回 B 站关注关系。
+
+登录态 API 汇总：
+
+| 字段 | 结果 |
+| --- | --- |
+| nav code / isLogin | `0 / true` |
+| `/x/relation/followings` code | `0` |
+| reported total | `533` |
+| 首页 list length | `20` |
+| 首页 `mtime` 是否存在 | `20 / 20` 存在 |
+| 首页 `mtime` 类型 | `number` |
+| 首页 `mtime` 位数 | `10` |
+| 首页 `mtime` 是否落在合理 Unix 秒级范围 | `20 / 20` 是 |
+
+本地同步结果：
+
+| 字段 | 结果 |
+| --- | --- |
+| 同步状态 | `success / complete` |
+| 最后成功同步时间 | `2026-06-04 17:24:34 +08:00` |
+| 关注快照总数 | `533` |
+| active 关注 UP 数 | `533` |
+| followAgeKnown / followAgeUnknown | `533 / 0` |
+
+`mtime` 结论：
+
+- 本轮真实登录态下，`mtime` 存在、类型为 `number`、10 位，落在合理 Unix 秒级时间范围。
+- 本轮可将 `mtime` 作为“已关注时间候选字段”写入本地，`followAgeKnown=true`。
+- 仍不把 `mtime` 语义写死为绝对可靠的首次关注时间；字段缺失、异常、未来时间或非正值时继续降级为 `followAgeKnown=false`，不展示虚假时长。
+
+结论：
+
+- 关注关系 API-first 可用于 #4 正式同步。
+- DOM fallback 本轮不需要。

--- a/src/background/api/dynamic.ts
+++ b/src/background/api/dynamic.ts
@@ -1,0 +1,159 @@
+import { DYNAMIC_FEED_ENDPOINT, DYNAMIC_FEED_MAX_PAGES, DYNAMIC_UPDATE_WINDOW_DAYS } from '../../shared/constants';
+import type { FollowedVideoUpdate } from '../../shared/types/dynamic-bill';
+import { biliGet } from './client';
+
+interface DynamicFeedData {
+  items?: unknown[];
+  has_more?: boolean;
+  offset?: string;
+}
+
+export interface DynamicFeedFetchResult {
+  updates: FollowedVideoUpdate[];
+  pagesFetched: number;
+  itemsScanned: number;
+  filteredNonVideoCount: number;
+  filteredNonFollowedCount: number;
+  filteredOutsideWindowCount: number;
+  syncedAt: number;
+}
+
+export async function fetchFollowedVideoDynamics(options: {
+  followingMids: Set<number>;
+  windowDays?: number;
+  maxPages?: number;
+  signal?: AbortSignal;
+}): Promise<DynamicFeedFetchResult> {
+  const windowDays = Math.max(1, Math.floor(options.windowDays ?? DYNAMIC_UPDATE_WINDOW_DAYS));
+  const maxPages = Math.max(1, Math.floor(options.maxPages ?? DYNAMIC_FEED_MAX_PAGES));
+  const cutoffSeconds = Math.floor(Date.now() / 1000) - windowDays * 86_400;
+  const syncedAt = Date.now();
+  const updates: FollowedVideoUpdate[] = [];
+  const seenOffsets = new Set<string>();
+  let offset = '';
+  let pagesFetched = 0;
+  let itemsScanned = 0;
+  let filteredNonVideoCount = 0;
+  let filteredNonFollowedCount = 0;
+  let filteredOutsideWindowCount = 0;
+
+  for (let page = 0; page < maxPages; page++) {
+    const params: Record<string, string> = {
+      type: 'video',
+      timezone_offset: '-480',
+    };
+    if (offset) params.offset = offset;
+
+    const data = await biliGet<DynamicFeedData>(DYNAMIC_FEED_ENDPOINT, params, 3, false, options.signal);
+    pagesFetched++;
+    const items = Array.isArray(data.items) ? data.items : [];
+    if (items.length === 0) break;
+
+    let oldestDynamicTime = Number.POSITIVE_INFINITY;
+    for (const item of items) {
+      itemsScanned++;
+      const update = toVideoUpdate(item, syncedAt);
+      if (!update) {
+        filteredNonVideoCount++;
+        continue;
+      }
+
+      if (update.dynamicTime <= 0) {
+        filteredOutsideWindowCount++;
+        continue;
+      }
+
+      oldestDynamicTime = Math.min(oldestDynamicTime, update.dynamicTime);
+      if (update.dynamicTime < cutoffSeconds) {
+        filteredOutsideWindowCount++;
+        continue;
+      }
+
+      if (!options.followingMids.has(update.authorMid)) {
+        filteredNonFollowedCount++;
+        continue;
+      }
+
+      updates.push(update);
+    }
+
+    const nextOffset = String(data.offset ?? '');
+    if (oldestDynamicTime < cutoffSeconds || data.has_more === false || !nextOffset || seenOffsets.has(nextOffset)) {
+      break;
+    }
+    seenOffsets.add(nextOffset);
+    offset = nextOffset;
+  }
+
+  return {
+    updates,
+    pagesFetched,
+    itemsScanned,
+    filteredNonVideoCount,
+    filteredNonFollowedCount,
+    filteredOutsideWindowCount,
+    syncedAt,
+  };
+}
+
+function toVideoUpdate(item: unknown, syncedAt: number): FollowedVideoUpdate | null {
+  const record = asRecord(item);
+  const modules = asRecord(record.modules);
+  const author = asRecord(modules.module_author);
+  const dynamic = asRecord(modules.module_dynamic);
+  const major = asRecord(dynamic.major);
+  const archive = asRecord(major.archive);
+
+  const itemType = stringValue(record.type);
+  const majorType = stringValue(major.type);
+  const bvid = stringValue(archive.bvid);
+  if (itemType !== 'DYNAMIC_TYPE_AV' || majorType !== 'MAJOR_TYPE_ARCHIVE' || !bvid) {
+    return null;
+  }
+
+  const authorMid = numberValue(author.mid);
+  if (!authorMid) return null;
+
+  const dynamicId = stringValue(record.id_str) || stringValue(record.id) || bvid;
+  const dynamicTime = numberValue(author.pub_ts) || numberValue(archive.pub_ts) || numberValue(archive.ctime);
+  const avid = numberValue(archive.aid);
+
+  return {
+    updateKey: `${dynamicId}:${bvid}`,
+    dynamicId,
+    bvid,
+    avid,
+    title: stringValue(archive.title),
+    intro: stringValue(archive.desc),
+    cover: stringValue(archive.cover),
+    duration: numberValue(archive.duration) || parseDurationText(stringValue(archive.duration_text)),
+    pubtime: numberValue(archive.pubdate) || numberValue(archive.ctime) || dynamicTime,
+    dynamicTime,
+    authorMid,
+    authorName: stringValue(author.name),
+    authorFace: stringValue(author.face),
+    tagName: '',
+    tags: [],
+    syncedAt,
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? value as Record<string, unknown> : {};
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value : value == null ? '' : String(value);
+}
+
+function numberValue(value: unknown): number {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+function parseDurationText(value: string): number {
+  if (!value) return 0;
+  const parts = value.split(':').map(part => Number(part));
+  if (parts.some(part => !Number.isFinite(part) || part < 0)) return 0;
+  return parts.reduce((total, part) => total * 60 + part, 0);
+}

--- a/src/background/api/following.ts
+++ b/src/background/api/following.ts
@@ -1,0 +1,118 @@
+import { FOLLOWING_PAGE_SIZE, FOLLOWINGS_ENDPOINT, MAX_FOLLOWING_SYNC_PAGES } from '../../shared/constants';
+import type { FollowedCreator } from '../../shared/types/dynamic-bill';
+import { biliGet } from './client';
+import { fetchCurrentUserMid } from './favorites';
+
+interface FollowingApiItem {
+  mid?: number;
+  uname?: string;
+  name?: string;
+  face?: string;
+  sign?: string;
+  mtime?: number | string;
+  special?: number | boolean;
+  attribute?: number;
+  tagid?: number;
+  tag?: number;
+}
+
+interface FollowingsData {
+  list?: FollowingApiItem[];
+  total?: number;
+}
+
+export interface FollowingFetchResult {
+  creators: FollowedCreator[];
+  pagesFetched: number;
+  reportedTotal: number;
+  followAgeKnownCount: number;
+  followAgeUnknownCount: number;
+  syncedAt: number;
+}
+
+export async function fetchFollowingCreators(options: {
+  maxPages?: number;
+  pageSize?: number;
+  signal?: AbortSignal;
+} = {}): Promise<FollowingFetchResult> {
+  const maxPages = Math.max(1, Math.floor(options.maxPages ?? MAX_FOLLOWING_SYNC_PAGES));
+  const pageSize = Math.max(1, Math.floor(options.pageSize ?? FOLLOWING_PAGE_SIZE));
+  const syncedAt = Date.now();
+  const mid = await fetchCurrentUserMid(options.signal);
+  const creators: FollowedCreator[] = [];
+  let pagesFetched = 0;
+  let reportedTotal = 0;
+
+  for (let pn = 1; pn <= maxPages; pn++) {
+    const data = await biliGet<FollowingsData>(
+      FOLLOWINGS_ENDPOINT,
+      {
+        vmid: String(mid),
+        pn: String(pn),
+        ps: String(pageSize),
+        order: 'desc',
+        order_type: 'attention',
+      },
+      3,
+      false,
+      options.signal,
+    );
+
+    pagesFetched++;
+    reportedTotal = Number(data.total ?? reportedTotal ?? 0);
+    const list = Array.isArray(data.list) ? data.list : [];
+    if (list.length === 0) break;
+
+    for (const item of list) {
+      const creator = toFollowedCreator(item, syncedAt);
+      if (creator) creators.push(creator);
+    }
+
+    if ((reportedTotal > 0 && creators.length >= reportedTotal) || list.length < pageSize) {
+      break;
+    }
+  }
+
+  const followAgeKnownCount = creators.filter(creator => creator.followAgeKnown).length;
+
+  return {
+    creators,
+    pagesFetched,
+    reportedTotal,
+    followAgeKnownCount,
+    followAgeUnknownCount: creators.length - followAgeKnownCount,
+    syncedAt,
+  };
+}
+
+function toFollowedCreator(item: FollowingApiItem, syncedAt: number): FollowedCreator | null {
+  const mid = Number(item.mid ?? 0);
+  if (!Number.isFinite(mid) || mid <= 0) return null;
+
+  const followedAt = normalizeFollowedAt(item.mtime);
+
+  return {
+    mid,
+    name: String(item.uname ?? item.name ?? ''),
+    face: String(item.face ?? ''),
+    sign: String(item.sign ?? ''),
+    followedAt,
+    followAgeKnown: followedAt !== undefined,
+    special: item.special === true || Number(item.special ?? 0) > 0,
+    attribute: Number(item.attribute ?? 0),
+    tagId: Number(item.tagid ?? item.tag ?? 0),
+    isActive: true,
+    syncedAt,
+    lastSeenAt: syncedAt,
+  };
+}
+
+function normalizeFollowedAt(value: unknown): number | undefined {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) return undefined;
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const asSeconds = numeric > 10_000_000_000 ? Math.floor(numeric / 1000) : Math.floor(numeric);
+  if (asSeconds <= 0 || asSeconds > nowSeconds + 86_400) return undefined;
+  return asSeconds;
+}

--- a/src/background/dynamic-bill/sync.ts
+++ b/src/background/dynamic-bill/sync.ts
@@ -1,0 +1,253 @@
+import { DYNAMIC_FEED_MAX_PAGES, DYNAMIC_UPDATE_WINDOW_DAYS, MAX_FOLLOWING_SYNC_PAGES } from '../../shared/constants';
+import type {
+  DynamicBillOverview,
+  DynamicSyncResult,
+  DynamicSyncStage,
+  DynamicSyncState,
+  FollowedVideoUpdate,
+} from '../../shared/types/dynamic-bill';
+import type { VideoInfo } from '../../shared/types/video-info';
+import { fetchFollowedVideoDynamics, type DynamicFeedFetchResult } from '../api/dynamic';
+import { fetchFollowingCreators, type FollowingFetchResult } from '../api/following';
+import { batchFetchVideoInfo } from '../api/video-info';
+import {
+  getDynamicBillOverview,
+  getDynamicSyncState,
+  pruneFollowedVideoUpdatesOlderThan,
+  replaceFollowedCreatorSnapshot,
+  setDynamicSyncState,
+  upsertFollowedVideoUpdates,
+} from '../storage/dynamic-bill-repo';
+
+const VIDEO_UPDATE_RETENTION_DAYS = 30;
+const VIDEO_DETAIL_ENRICHMENT_LIMIT = 40;
+const VIDEO_DETAIL_ENRICHMENT_TIMEOUT_MS = 30_000;
+
+interface SyncPartial {
+  following?: FollowingFetchResult;
+  dynamicFeed?: DynamicFeedFetchResult;
+  followedCreatorsStored?: number;
+  videoUpdatesStored?: number;
+  detailEnrichedCount?: number;
+}
+
+export async function getDynamicOverview(): Promise<DynamicBillOverview> {
+  return getDynamicBillOverview(DYNAMIC_UPDATE_WINDOW_DAYS);
+}
+
+export async function syncDynamicBillUpdates(signal?: AbortSignal): Promise<DynamicSyncResult> {
+  const startedAt = Date.now();
+  const previousState = await getDynamicSyncState();
+  const partial: SyncPartial = {};
+
+  await setDynamicSyncState({
+    status: 'syncing',
+    stage: 'following',
+    lastStartedAt: startedAt,
+    lastFinishedAt: previousState.lastFinishedAt,
+    lastSuccessAt: previousState.lastSuccessAt,
+  });
+
+  try {
+    partial.following = await fetchFollowingCreators({
+      maxPages: MAX_FOLLOWING_SYNC_PAGES,
+      signal,
+    });
+
+    await patchSyncStage('storage', startedAt, previousState.lastSuccessAt);
+    partial.followedCreatorsStored = await replaceFollowedCreatorSnapshot(
+      partial.following.creators,
+      partial.following.syncedAt,
+    );
+  } catch (error) {
+    return finishFailure(startedAt, 'following', error, partial, previousState.lastSuccessAt);
+  }
+
+  try {
+    const followingMids = new Set(partial.following.creators.map(creator => creator.mid));
+    await patchSyncStage('dynamic-feed', startedAt, previousState.lastSuccessAt);
+    partial.dynamicFeed = followingMids.size > 0
+      ? await fetchFollowedVideoDynamics({
+        followingMids,
+        windowDays: DYNAMIC_UPDATE_WINDOW_DAYS,
+        maxPages: DYNAMIC_FEED_MAX_PAGES,
+        signal,
+      })
+      : emptyDynamicFeedResult();
+
+    await patchSyncStage('storage', startedAt, previousState.lastSuccessAt);
+    partial.videoUpdatesStored = await upsertFollowedVideoUpdates(partial.dynamicFeed.updates);
+    await pruneFollowedVideoUpdatesOlderThan(VIDEO_UPDATE_RETENTION_DAYS);
+
+    await patchSyncStage('video-detail', startedAt, previousState.lastSuccessAt);
+    const { updates, enrichedCount } = await enrichVideoUpdates(partial.dynamicFeed.updates, signal);
+    partial.detailEnrichedCount = enrichedCount;
+    if (enrichedCount > 0) {
+      await patchSyncStage('storage', startedAt, previousState.lastSuccessAt);
+      partial.videoUpdatesStored = await upsertFollowedVideoUpdates(updates);
+    }
+  } catch (error) {
+    return finishFailure(startedAt, 'dynamic-feed', error, partial, previousState.lastSuccessAt);
+  }
+
+  const finishedAt = Date.now();
+  await setDynamicSyncState({
+    status: 'success',
+    stage: 'complete',
+    lastStartedAt: startedAt,
+    lastFinishedAt: finishedAt,
+    lastSuccessAt: finishedAt,
+  });
+
+  return buildResult('success', 'complete', startedAt, finishedAt, partial);
+}
+
+async function enrichVideoUpdates(
+  updates: FollowedVideoUpdate[],
+  signal?: AbortSignal,
+): Promise<{ updates: FollowedVideoUpdate[]; enrichedCount: number }> {
+  const bvids = updates.map(update => update.bvid).filter(Boolean).slice(0, VIDEO_DETAIL_ENRICHMENT_LIMIT);
+  if (bvids.length === 0) return { updates, enrichedCount: 0 };
+
+  const infoMap = await fetchVideoInfoBestEffort(bvids, signal);
+  let enrichedCount = 0;
+  const enriched = updates.map(update => {
+    const info = infoMap.get(update.bvid);
+    if (!info) return update;
+    enrichedCount++;
+    return mergeVideoInfo(update, info);
+  });
+
+  return { updates: enriched, enrichedCount };
+}
+
+async function fetchVideoInfoBestEffort(bvids: string[], signal?: AbortSignal): Promise<Map<string, VideoInfo>> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), VIDEO_DETAIL_ENRICHMENT_TIMEOUT_MS);
+  const abortParent = (): void => controller.abort();
+  signal?.addEventListener('abort', abortParent, { once: true });
+
+  try {
+    return await batchFetchVideoInfo(bvids, controller.signal);
+  } catch (error) {
+    if (signal?.aborted && error instanceof Error && error.message === 'SYNC_CANCELLED') {
+      throw error;
+    }
+    console.warn('[BiliViz] Dynamic bill video detail enrichment skipped:', error);
+    return new Map<string, VideoInfo>();
+  } finally {
+    clearTimeout(timeoutId);
+    signal?.removeEventListener('abort', abortParent);
+  }
+}
+
+function mergeVideoInfo(update: FollowedVideoUpdate, info: VideoInfo): FollowedVideoUpdate {
+  return {
+    ...update,
+    avid: update.avid || Number(info.avid ?? 0),
+    bvid: update.bvid || info.bvid || '',
+    title: update.title || info.title || '',
+    intro: update.intro || info.desc || '',
+    cover: update.cover || info.pic || '',
+    duration: update.duration || Number(info.duration ?? 0),
+    pubtime: update.pubtime || Number(info.pubdate ?? info.ctime ?? 0) || update.dynamicTime,
+    authorMid: update.authorMid || Number(info.owner?.mid ?? 0),
+    authorName: update.authorName || info.owner?.name || '',
+    authorFace: update.authorFace || info.owner?.face || '',
+    tagName: info.tname || update.tagName,
+    tags: Array.isArray(info.tags) && info.tags.length > 0 ? info.tags : update.tags,
+  };
+}
+
+async function patchSyncStage(stage: DynamicSyncStage, startedAt: number, lastSuccessAt: number): Promise<void> {
+  await setDynamicSyncState({
+    status: 'syncing',
+    stage,
+    lastStartedAt: startedAt,
+    lastFinishedAt: 0,
+    lastSuccessAt,
+  });
+}
+
+async function finishFailure(
+  startedAt: number,
+  stage: DynamicSyncStage,
+  error: unknown,
+  partial: SyncPartial,
+  lastSuccessAt: number,
+): Promise<DynamicSyncResult> {
+  const finishedAt = Date.now();
+  const status = isNotLoggedIn(error) ? 'not_logged_in' : 'failed';
+  const message = describeError(error);
+  const state: DynamicSyncState = {
+    status,
+    stage,
+    lastStartedAt: startedAt,
+    lastFinishedAt: finishedAt,
+    lastSuccessAt,
+    lastError: message,
+  };
+  await setDynamicSyncState(state);
+  return buildResult(status, stage, startedAt, finishedAt, partial, message);
+}
+
+async function buildResult(
+  status: DynamicSyncResult['status'],
+  stage: DynamicSyncStage,
+  startedAt: number,
+  finishedAt: number,
+  partial: SyncPartial,
+  error?: string,
+): Promise<DynamicSyncResult> {
+  const overview = await getDynamicBillOverview(DYNAMIC_UPDATE_WINDOW_DAYS);
+  const following = partial.following;
+  const dynamicFeed = partial.dynamicFeed ?? emptyDynamicFeedResult();
+
+  return {
+    status,
+    stage,
+    startedAt,
+    finishedAt,
+    followedCreatorsFetched: following?.creators.length ?? 0,
+    followedCreatorsStored: partial.followedCreatorsStored ?? 0,
+    followAgeKnownCount: following?.followAgeKnownCount ?? 0,
+    followAgeUnknownCount: following?.followAgeUnknownCount ?? 0,
+    followingPagesFetched: following?.pagesFetched ?? 0,
+    dynamicPagesFetched: dynamicFeed.pagesFetched,
+    dynamicItemsScanned: dynamicFeed.itemsScanned,
+    videoUpdatesFetched: dynamicFeed.updates.length,
+    videoUpdatesStored: partial.videoUpdatesStored ?? 0,
+    filteredNonVideoCount: dynamicFeed.filteredNonVideoCount,
+    filteredNonFollowedCount: dynamicFeed.filteredNonFollowedCount,
+    filteredOutsideWindowCount: dynamicFeed.filteredOutsideWindowCount,
+    detailEnrichedCount: partial.detailEnrichedCount ?? 0,
+    error,
+    overview,
+  };
+}
+
+function emptyDynamicFeedResult(): DynamicFeedFetchResult {
+  return {
+    updates: [],
+    pagesFetched: 0,
+    itemsScanned: 0,
+    filteredNonVideoCount: 0,
+    filteredNonFollowedCount: 0,
+    filteredOutsideWindowCount: 0,
+    syncedAt: Date.now(),
+  };
+}
+
+function isNotLoggedIn(error: unknown): boolean {
+  return error instanceof Error && error.message === 'NOT_LOGGED_IN';
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -25,6 +25,7 @@ import { getDeviceData } from '../analytics/device';
 import { abortCurrentHistorySync, hasActiveHistorySyncAbortScope } from '../sync/sync-control';
 import { syncFavorites } from '../favorites/sync';
 import { buildSmartFavoriteIndex, getSmartFavoriteOverview, getSmartFavoritesByPath, searchSmartFavorites } from '../favorites/smart';
+import { getDynamicOverview, syncDynamicBillUpdates } from '../dynamic-bill/sync';
 
 const EXPORT_PAGE_LIMIT_MAX = 1000;
 
@@ -222,6 +223,10 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
         data: await searchSmartFavorites(query, Number.isFinite(limit) ? limit : undefined) as T,
       };
     }
+    case 'GET_DYNAMIC_BILL_OVERVIEW':
+      return { success: true, data: await getDynamicOverview() as T };
+    case 'SYNC_DYNAMIC_UPDATES':
+      return { success: true, data: await syncDynamicBillUpdates() as T };
     default:
       return { success: false, error: `Unknown action: ${request.action}` };
   }

--- a/src/background/storage/db.ts
+++ b/src/background/storage/db.ts
@@ -1,6 +1,7 @@
 import Dexie, { type Table } from 'dexie';
 import type { WatchHistoryRecord, PlayerEvent, DailyAggregate } from '../../shared/types/watch-event';
 import type { FavoriteFolder, FavoriteItem, SmartFavoriteIndex } from '../../shared/types/favorite';
+import type { FollowedCreator, FollowedVideoUpdate } from '../../shared/types/dynamic-bill';
 
 export class BiliAnalyticsDB extends Dexie {
   watchHistory!: Table<WatchHistoryRecord, number>;
@@ -9,6 +10,8 @@ export class BiliAnalyticsDB extends Dexie {
   favoriteFolders!: Table<FavoriteFolder, number>;
   favoriteItems!: Table<FavoriteItem, number>;
   smartFavoriteIndex!: Table<SmartFavoriteIndex, number>;
+  followedCreators!: Table<FollowedCreator, number>;
+  followedVideoUpdates!: Table<FollowedVideoUpdate, number>;
 
   constructor() {
     super('BiliAnalyticsDB');
@@ -52,6 +55,25 @@ export class BiliAnalyticsDB extends Dexie {
         '++id, &itemKey, mediaId, avid, bvid, authorMid, tagName, favTime, syncedAt',
       smartFavoriteIndex:
         '++id, &itemKey, status, indexedAt, contentHash',
+    });
+
+    this.version(4).stores({
+      watchHistory:
+        '++id, kid, &sessionKey, avid, bvid, [avid+cid+viewAt], authorMid, tagName, viewAt, dt',
+      playerEvents:
+        '++id, [bvid+cid], eventType, timestamp, tabId',
+      dailyAggregates:
+        '++id, &date',
+      favoriteFolders:
+        '++id, &mediaId, title, syncedAt',
+      favoriteItems:
+        '++id, &itemKey, mediaId, avid, bvid, authorMid, tagName, favTime, syncedAt',
+      smartFavoriteIndex:
+        '++id, &itemKey, status, indexedAt, contentHash',
+      followedCreators:
+        '++id, &mid, followedAt, followAgeKnown, isActive, syncedAt, lastSeenAt',
+      followedVideoUpdates:
+        '++id, &updateKey, dynamicId, bvid, authorMid, dynamicTime, pubtime, syncedAt',
     });
   }
 }

--- a/src/background/storage/dynamic-bill-repo.ts
+++ b/src/background/storage/dynamic-bill-repo.ts
@@ -1,0 +1,130 @@
+import { DYNAMIC_UPDATE_WINDOW_DAYS } from '../../shared/constants';
+import type {
+  DynamicBillOverview,
+  DynamicSyncState,
+  FollowedCreator,
+  FollowedVideoUpdate,
+} from '../../shared/types/dynamic-bill';
+import { db } from './db';
+
+const DYNAMIC_SYNC_STATE_KEY = 'dynamicBillSyncState';
+const DYNAMIC_SYNC_STALE_TIMEOUT_MS = 5 * 60 * 1000;
+const DEFAULT_SYNC_STATE: DynamicSyncState = {
+  status: 'idle',
+  stage: 'idle',
+  lastStartedAt: 0,
+  lastFinishedAt: 0,
+  lastSuccessAt: 0,
+};
+
+export async function replaceFollowedCreatorSnapshot(creators: FollowedCreator[], syncedAt: number): Promise<number> {
+  const activeMids = new Set(creators.map(creator => creator.mid));
+
+  await db.transaction('rw', db.followedCreators, async () => {
+    const existing = await db.followedCreators.toArray();
+    const existingByMid = new Map(existing.map(creator => [creator.mid, creator]));
+    const nextCreators = creators.map(creator => ({
+      ...creator,
+      id: existingByMid.get(creator.mid)?.id,
+      isActive: true,
+      syncedAt,
+      lastSeenAt: syncedAt,
+    }));
+
+    if (nextCreators.length > 0) {
+      await db.followedCreators.bulkPut(nextCreators);
+    }
+
+    await db.followedCreators
+      .filter(creator => creator.isActive !== false && !activeMids.has(creator.mid))
+      .modify({
+        isActive: false,
+        syncedAt,
+      });
+  });
+
+  return creators.length;
+}
+
+export async function upsertFollowedVideoUpdates(updates: FollowedVideoUpdate[]): Promise<number> {
+  if (updates.length === 0) return 0;
+
+  await db.transaction('rw', db.followedVideoUpdates, async () => {
+    const existing = await db.followedVideoUpdates
+      .where('updateKey')
+      .anyOf(updates.map(update => update.updateKey))
+      .toArray();
+    const existingByKey = new Map(existing.map(update => [update.updateKey, update]));
+    await db.followedVideoUpdates.bulkPut(updates.map(update => ({
+      ...update,
+      id: existingByKey.get(update.updateKey)?.id,
+    })));
+  });
+
+  return updates.length;
+}
+
+export async function pruneFollowedVideoUpdatesOlderThan(days: number): Promise<number> {
+  const cutoff = Math.floor(Date.now() / 1000) - Math.max(1, Math.floor(days)) * 86_400;
+  return db.followedVideoUpdates.where('dynamicTime').below(cutoff).delete();
+}
+
+export async function getRecentFollowedVideoUpdates(windowDays = DYNAMIC_UPDATE_WINDOW_DAYS): Promise<FollowedVideoUpdate[]> {
+  const cutoff = Math.floor(Date.now() / 1000) - Math.max(1, Math.floor(windowDays)) * 86_400;
+  return db.followedVideoUpdates
+    .where('dynamicTime')
+    .aboveOrEqual(cutoff)
+    .reverse()
+    .sortBy('dynamicTime');
+}
+
+export async function getDynamicBillOverview(windowDays = DYNAMIC_UPDATE_WINDOW_DAYS): Promise<DynamicBillOverview> {
+  const [syncState, creators, recentUpdates] = await Promise.all([
+    getDynamicSyncState(),
+    db.followedCreators.toArray(),
+    getRecentFollowedVideoUpdates(windowDays),
+  ]);
+  const activeCreators = creators.filter(creator => creator.isActive !== false);
+  const followAgeKnownCount = activeCreators.filter(creator => creator.followAgeKnown).length;
+  const lastVideoDynamicTime = recentUpdates.reduce((latest, update) => Math.max(latest, update.dynamicTime), 0);
+
+  return {
+    syncState,
+    followedCreatorCount: creators.length,
+    activeFollowedCreatorCount: activeCreators.length,
+    followAgeKnownCount,
+    followAgeUnknownCount: activeCreators.length - followAgeKnownCount,
+    recentVideoUpdateCount: recentUpdates.length,
+    lastVideoDynamicTime,
+    updateWindowDays: windowDays,
+  };
+}
+
+export async function getDynamicSyncState(): Promise<DynamicSyncState> {
+  const result = await chrome.storage.local.get(DYNAMIC_SYNC_STATE_KEY);
+  const state: DynamicSyncState = {
+    ...DEFAULT_SYNC_STATE,
+    ...(result[DYNAMIC_SYNC_STATE_KEY] ?? {}),
+  };
+  if (isStaleSyncState(state)) {
+    const failedState: DynamicSyncState = {
+      ...state,
+      status: 'failed',
+      lastFinishedAt: Date.now(),
+      lastError: 'SYNC_STALE_TIMEOUT',
+    };
+    await setDynamicSyncState(failedState);
+    return failedState;
+  }
+  return state;
+}
+
+export async function setDynamicSyncState(state: DynamicSyncState): Promise<void> {
+  await chrome.storage.local.set({ [DYNAMIC_SYNC_STATE_KEY]: state });
+}
+
+function isStaleSyncState(state: DynamicSyncState): boolean {
+  return state.status === 'syncing'
+    && state.lastStartedAt > 0
+    && Date.now() - state.lastStartedAt > DYNAMIC_SYNC_STALE_TIMEOUT_MS;
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -4,11 +4,17 @@ export const VIDEO_INFO_ENDPOINT = '/x/web-interface/view';
 export const NAV_ENDPOINT = '/x/web-interface/nav';
 export const FAVORITE_FOLDERS_ENDPOINT = '/x/v3/fav/folder/created/list-all';
 export const FAVORITE_RESOURCES_ENDPOINT = '/x/v3/fav/resource/list';
+export const DYNAMIC_FEED_ENDPOINT = '/x/polymer/web-dynamic/v1/feed/all';
+export const FOLLOWINGS_ENDPOINT = '/x/relation/followings';
 
 export const HISTORY_PAGE_SIZE = 30;
 export const MAX_BACKFILL_PAGES = 300;
 export const FAVORITE_PAGE_SIZE = 20;
 export const MAX_FAVORITE_SYNC_PAGES = 500;
+export const DYNAMIC_UPDATE_WINDOW_DAYS = 7;
+export const DYNAMIC_FEED_MAX_PAGES = 80;
+export const FOLLOWING_PAGE_SIZE = 50;
+export const MAX_FOLLOWING_SYNC_PAGES = 200;
 export const SYNC_INTERVAL_MINUTES = 5;
 export const AGGREGATE_INTERVAL_MINUTES = 60;
 export const CLEANUP_INTERVAL_MINUTES = 1440;

--- a/src/shared/types/dynamic-bill.ts
+++ b/src/shared/types/dynamic-bill.ts
@@ -1,0 +1,80 @@
+export interface FollowedCreator {
+  id?: number;
+  mid: number;
+  name: string;
+  face: string;
+  sign: string;
+  followedAt?: number;
+  followAgeKnown: boolean;
+  special: boolean;
+  attribute: number;
+  tagId: number;
+  isActive: boolean;
+  syncedAt: number;
+  lastSeenAt: number;
+}
+
+export interface FollowedVideoUpdate {
+  id?: number;
+  updateKey: string;
+  dynamicId: string;
+  bvid: string;
+  avid: number;
+  title: string;
+  intro: string;
+  cover: string;
+  duration: number;
+  pubtime: number;
+  dynamicTime: number;
+  authorMid: number;
+  authorName: string;
+  authorFace: string;
+  tagName: string;
+  tags: string[];
+  syncedAt: number;
+}
+
+export type DynamicSyncStatus = 'idle' | 'syncing' | 'success' | 'not_logged_in' | 'failed';
+export type DynamicSyncStage = 'idle' | 'following' | 'dynamic-feed' | 'video-detail' | 'storage' | 'complete';
+
+export interface DynamicSyncState {
+  status: DynamicSyncStatus;
+  stage: DynamicSyncStage;
+  lastStartedAt: number;
+  lastFinishedAt: number;
+  lastSuccessAt: number;
+  lastError?: string;
+}
+
+export interface DynamicBillOverview {
+  syncState: DynamicSyncState;
+  followedCreatorCount: number;
+  activeFollowedCreatorCount: number;
+  followAgeKnownCount: number;
+  followAgeUnknownCount: number;
+  recentVideoUpdateCount: number;
+  lastVideoDynamicTime: number;
+  updateWindowDays: number;
+}
+
+export interface DynamicSyncResult {
+  status: DynamicSyncStatus;
+  stage: DynamicSyncStage;
+  startedAt: number;
+  finishedAt: number;
+  followedCreatorsFetched: number;
+  followedCreatorsStored: number;
+  followAgeKnownCount: number;
+  followAgeUnknownCount: number;
+  followingPagesFetched: number;
+  dynamicPagesFetched: number;
+  dynamicItemsScanned: number;
+  videoUpdatesFetched: number;
+  videoUpdatesStored: number;
+  filteredNonVideoCount: number;
+  filteredNonFollowedCount: number;
+  filteredOutsideWindowCount: number;
+  detailEnrichedCount: number;
+  error?: string;
+  overview: DynamicBillOverview;
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -3,3 +3,4 @@ export * from './video-info';
 export * from './analytics';
 export * from './messages';
 export * from './config';
+export * from './dynamic-bill';

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -1,4 +1,5 @@
 import type { QuickStats, DashboardOverview, CategoryDistribution, InterestDrift, DurationBucket, CreatorRanking, NewCreator, BehaviorMetrics, WeeklyTip, BlindBoxItem } from './analytics';
+import type { DynamicBillOverview, DynamicSyncResult } from './dynamic-bill';
 import type { FavoriteSyncResult, SmartFavoriteOverview, SmartFavoriteResult, SmartFavoriteSearchResponse, SmartIndexResult } from './favorite';
 
 // Popup / Dashboard → Service Worker
@@ -21,7 +22,9 @@ export type RequestAction =
   | 'GET_SMART_FAVORITES_BY_PATH'
   | 'SYNC_FAVORITES'
   | 'BUILD_SMART_FAVORITE_INDEX'
-  | 'SEARCH_SMART_FAVORITES';
+  | 'SEARCH_SMART_FAVORITES'
+  | 'GET_DYNAMIC_BILL_OVERVIEW'
+  | 'SYNC_DYNAMIC_UPDATES';
 
 // Content Script → Service Worker
 export type ContentAction =
@@ -135,3 +138,5 @@ export type FavoriteSyncResponse = BiliVizResponse<FavoriteSyncResult>;
 export type SmartFavoriteIndexResponse = BiliVizResponse<SmartIndexResult>;
 export type SmartFavoriteSearchMessageResponse = BiliVizResponse<SmartFavoriteSearchResponse>;
 export type SmartFavoritePathResponse = BiliVizResponse<SmartFavoriteResult[]>;
+export type DynamicBillOverviewResponse = BiliVizResponse<DynamicBillOverview>;
+export type DynamicSyncResponse = BiliVizResponse<DynamicSyncResult>;

--- a/src/shared/types/video-info.ts
+++ b/src/shared/types/video-info.ts
@@ -2,7 +2,10 @@ export interface VideoInfo {
   avid: number;
   bvid: string;
   title: string;
+  desc?: string;
   duration: number;
+  pubdate?: number;
+  ctime?: number;
   owner: {
     mid: number;
     name: string;


### PR DESCRIPTION
﻿## Scope

Implements issue #4 dynamic bill sync slice only:

- API-first sync for followed creators via `/x/relation/followings`
- API-first sync for followed video dynamics via `/x/polymer/web-dynamic/v1/feed/all?type=video`
- Local IndexedDB/repo storage for followed creator snapshots and recent followed video updates
- Background message/types/constants wiring for `GET_DYNAMIC_BILL_OVERVIEW` and `SYNC_DYNAMIC_UPDATES`
- Necessary `DynamicBillPage` hookup for sync status, last success time, not logged in/failure/empty states
- Spike docs updated with real extension smoke test results

This PR does not include #3 shell/branding/popup/sidebar changes beyond the base branch, does not implement the three-column rules engine, does not call AI, does not upload full watch history or following lists, and does not write back to Bilibili follow relationships.

## Smoke Test

Real logged-in extension smoke test was run with the built `dist` extension loaded in Edge. The test clicked Dashboard -> Dynamic Bill -> `同步关注动态` and recorded summary fields only. No Cookie was read, copied, exported, or recorded.

Summary:

- `nav`: `code=0`, `isLogin=true`
- `followings`: `code=0`, `total=533`, first page `list length=20`
- `mtime`: present on `20/20` first-page followings, type `number`, `10` digits, `20/20` in plausible Unix seconds range
- dynamic feed first page: `code=0`, `items=20`, `DYNAMIC_TYPE_AV=20`, `MAJOR_TYPE_ARCHIVE=20`, recent 7-day strict archive count `20`
- pagination probe: reached 7-day cutoff after `49` pages / `980` items; `976` strict video archive items were inside the 7-day window
- Dashboard final state: `success / complete`, `533` followed UPs, `976` recent video updates, no not-logged-in/failure state in logged-in run

Follow-up implementation adjustment from smoke: `DYNAMIC_FEED_MAX_PAGES` is `80` because `20` pages did not cover the real 7-day window for this account. Video detail enrichment is now best-effort after initial update storage, with a limit/timeout so `/x/web-interface/view` cannot block sync completion.

## Validation

- `git diff --check origin/codex/bili-bill-vnext..HEAD`
- `npm run typecheck`
- `npm run build`

`npm run build` passes with the existing Vite large chunk warning for `chunks/theme-BXY0bwcN.js`.
