### PR TITLE
[codex] Implement local AFK dynamic bill

### DIFF
--- a/dashboard/modules/dynamic-bill/DynamicBillPage.tsx
+++ b/dashboard/modules/dynamic-bill/DynamicBillPage.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useState } from "preact/hooks";
+import { useEffect, useMemo, useState } from "preact/hooks";
 import type {
+  DynamicBillGenerateResult,
+  DynamicBillItem,
   DynamicBillOverview,
+  DynamicBillStatus,
   DynamicSyncResult,
   DynamicSyncStatus,
 } from "../../../src/shared/types/dynamic-bill";
 import { requestSW } from "../../utils/messaging";
-
-type DynamicBillStatus = "unopened" | "opened" | "consumed" | "processed";
 
 const STATUS_FILTERS: Array<{
   key: DynamicBillStatus;
@@ -25,26 +26,35 @@ const STATUS_FILTERS: Array<{
 
 const BILL_COLUMNS = [
   {
+    key: "afk_update",
     title: "久违更新",
-    detail: "过去有正反馈、近期冷却的已关注 UP 新投稿。",
+    detail: "长期窗口有正反馈、近期冷却、最近 7 天有新投稿的已关注 UP。",
     accent: "pink",
+    enabled: true,
   },
   {
+    key: "variety",
     title: "换换口味",
-    detail: "长期兴趣中近期占比下降的分区或标签新投稿。",
+    detail: "后续切片接入；本 PR 不生成该栏目。",
     accent: "blue",
+    enabled: false,
   },
   {
+    key: "buried_follow",
     title: "被淹没的关注",
-    detail: "关注关系稳定、近期几乎没有消费的 UP 新投稿。",
+    detail: "后续切片接入；本 PR 不生成该栏目。",
     accent: "mint",
+    enabled: false,
   },
 ] as const;
 
 export function DynamicBillPage() {
   const [status, setStatus] = useState<DynamicBillStatus>("unopened");
   const [overview, setOverview] = useState<DynamicBillOverview | null>(null);
+  const [items, setItems] = useState<DynamicBillItem[]>([]);
+  const [selectedBillKey, setSelectedBillKey] = useState("");
   const [syncing, setSyncing] = useState(false);
+  const [generating, setGenerating] = useState(false);
   const [notice, setNotice] = useState("");
   const activeStatus =
     STATUS_FILTERS.find((item) => item.key === status) ?? STATUS_FILTERS[0];
@@ -53,11 +63,26 @@ export function DynamicBillPage() {
   const overviewNotice = overview
     ? describeOverview(overview)
     : "正在读取动态账单同步状态。";
-  const emptyCopy = getEmptyCopy(overview, activeStatus.label);
+  const afkItems = useMemo(
+    () => items.filter((item) => item.column === "afk_update"),
+    [items],
+  );
+  const visibleAfkItems = useMemo(
+    () => afkItems.filter((item) => item.status === status),
+    [afkItems, status],
+  );
+  const selectedItem =
+    visibleAfkItems.find((item) => item.billKey === selectedBillKey) ??
+    visibleAfkItems[0] ??
+    null;
+  const statusCounts = useMemo(() => countByStatus(afkItems), [afkItems]);
 
   useEffect(() => {
     refreshOverview().catch((error) => {
       setNotice(`读取动态账单状态失败：${describeError(error)}`);
+    });
+    refreshBillItems().catch((error) => {
+      setNotice(`读取久违更新账单失败：${describeError(error)}`);
     });
   }, []);
 
@@ -68,17 +93,69 @@ export function DynamicBillPage() {
     setOverview(next);
   }
 
+  async function refreshBillItems() {
+    const next = await requestSW<DynamicBillItem[]>("GET_DYNAMIC_BILL_ITEMS");
+    setItems(next);
+    setSelectedBillKey((current) =>
+      current && next.some((item) => item.billKey === current)
+        ? current
+        : next[0]?.billKey ?? "",
+    );
+  }
+
+  async function generateLocalBill(): Promise<DynamicBillGenerateResult> {
+    const result = await requestSW<DynamicBillGenerateResult>(
+      "GENERATE_DYNAMIC_BILL",
+    );
+    setOverview(result.overview);
+    setItems(result.items);
+    setSelectedBillKey((current) =>
+      current && result.items.some((item) => item.billKey === current)
+        ? current
+        : result.items[0]?.billKey ?? "",
+    );
+    return result;
+  }
+
+  async function handleGenerate() {
+    setGenerating(true);
+    setNotice("");
+    try {
+      const result = await generateLocalBill();
+      setNotice(describeGenerateResult(result));
+    } catch (error) {
+      setNotice(`生成久违更新账单失败：${describeError(error)}`);
+    } finally {
+      setGenerating(false);
+    }
+  }
+
   async function handleSync() {
     setSyncing(true);
     setNotice("");
     try {
       const result = await requestSW<DynamicSyncResult>("SYNC_DYNAMIC_UPDATES");
       setOverview(result.overview);
-      setNotice(describeSyncResult(result));
+      let nextNotice = describeSyncResult(result);
+      if (result.status === "success") {
+        try {
+          setGenerating(true);
+          const generated = await generateLocalBill();
+          nextNotice = `${nextNotice} ${describeGenerateResult(generated)}`;
+        } catch (generateError) {
+          await refreshBillItems().catch(() => {});
+          nextNotice = `${nextNotice} 但生成久违更新账单失败：${describeError(generateError)}`;
+        }
+      } else {
+        await refreshBillItems().catch(() => {});
+      }
+      setNotice(nextNotice);
     } catch (error) {
       setNotice(`动态同步请求失败：${describeError(error)}`);
       await refreshOverview().catch(() => {});
+      await refreshBillItems().catch(() => {});
     } finally {
+      setGenerating(false);
       setSyncing(false);
     }
   }
@@ -90,23 +167,32 @@ export function DynamicBillPage() {
           <span className="dynamic-bill-kicker">消费前 / 已关注视频投稿</span>
           <h2>动态账单</h2>
           <p>
-            这里将作为 Bili-Bill
-            的一级入口，用本地规则和必要解释帮助用户看见被近期口味覆盖的长期关注。
+            久违更新用本地观看历史、关注快照和最近投稿池生成，不接 AI，也不上传完整历史或完整关注列表。
           </p>
         </div>
         <div className="dynamic-bill-scope">
-          <strong>同步范围</strong>
+          <strong>本地证据范围</strong>
           <span>
-            只同步已关注 UP 最近 7 天的视频投稿动态；非视频动态不会进入账单池。
+            同步已关注 UP 最近 7 天视频投稿；生成时要求长期正反馈、近期冷却，并排除近期已看过的同一新视频。
           </span>
-          <button
-            type="button"
-            className="dynamic-bill-sync-button"
-            disabled={isSyncing}
-            onClick={handleSync}
-          >
-            {isSyncing ? "同步中..." : "同步关注动态"}
-          </button>
+          <div className="dynamic-bill-scope-actions">
+            <button
+              type="button"
+              className="dynamic-bill-sync-button"
+              disabled={isSyncing || generating}
+              onClick={handleSync}
+            >
+              {isSyncing ? "同步中..." : "同步并刷新"}
+            </button>
+            <button
+              type="button"
+              className="dynamic-bill-sync-button is-secondary"
+              disabled={isSyncing || generating}
+              onClick={handleGenerate}
+            >
+              {generating ? "生成中..." : "生成本地账单"}
+            </button>
+          </div>
         </div>
       </header>
 
@@ -122,7 +208,7 @@ export function DynamicBillPage() {
         <StatusMetric
           label="已关注 UP"
           value={String(overview?.activeFollowedCreatorCount ?? 0)}
-          detail="关注快照写入本地仓库"
+          detail={`关注时间已知 ${overview?.followAgeKnownCount ?? 0} / 未知 ${overview?.followAgeUnknownCount ?? 0}`}
         />
         <StatusMetric
           label="最近投稿"
@@ -130,9 +216,9 @@ export function DynamicBillPage() {
           detail={`最近 ${overview?.updateWindowDays ?? 7} 天视频投稿池`}
         />
         <StatusMetric
-          label="关注时间"
-          value={`${overview?.followAgeKnownCount ?? 0} / ${overview?.followAgeUnknownCount ?? 0}`}
-          detail="已知 / 未知；未知时不展示虚假时长"
+          label="久违更新"
+          value={String(afkItems.length)}
+          detail="本地规则生成的可展示账单项"
         />
       </section>
 
@@ -142,7 +228,7 @@ export function DynamicBillPage() {
       >
         <strong>{notice || overviewNotice}</strong>
         <span>
-          本任务只同步数据池，不生成久违更新、换换口味或被淹没的关注规则账单。
+          本切片只启用久违更新栏目；换换口味、被淹没的关注、状态推进、反馈和取关提示均未接入。
         </span>
       </section>
 
@@ -155,64 +241,159 @@ export function DynamicBillPage() {
             onClick={() => setStatus(item.key)}
           >
             <span>{item.label}</span>
-            <strong>0</strong>
+            <strong>{statusCounts[item.key] ?? 0}</strong>
           </button>
         ))}
       </section>
 
       <section className="dynamic-bill-layout">
         <div className="dynamic-bill-board" aria-label="动态账单栏目">
-          {BILL_COLUMNS.map((column) => (
-            <article
-              className={`dynamic-bill-column tone-${column.accent}`}
-              key={column.title}
-            >
-              <div className="dynamic-bill-column-head">
-                <div>
-                  <h3>{column.title}</h3>
-                  <p>{column.detail}</p>
+          {BILL_COLUMNS.map((column) => {
+            const columnItems =
+              column.key === "afk_update" ? visibleAfkItems : [];
+            const columnCount = column.key === "afk_update" ? afkItems.length : 0;
+            const emptyCopy = getColumnEmptyCopy(
+              column.enabled,
+              overview,
+              activeStatus.label,
+              afkItems.length,
+            );
+
+            return (
+              <article
+                className={`dynamic-bill-column tone-${column.accent}`}
+                key={column.key}
+              >
+                <div className="dynamic-bill-column-head">
+                  <div>
+                    <h3>{column.title}</h3>
+                    <p>{column.detail}</p>
+                  </div>
+                  <span>{columnCount}</span>
                 </div>
-                <span>0</span>
-              </div>
-              <div className="dynamic-bill-empty">
-                <strong>{emptyCopy.title}</strong>
-                <p>{emptyCopy.detail}</p>
-              </div>
-            </article>
-          ))}
+                {columnItems.length > 0 ? (
+                  <div className="dynamic-bill-item-list">
+                    {columnItems.map((item) => (
+                      <button
+                        type="button"
+                        className={`dynamic-bill-item-card ${
+                          selectedItem?.billKey === item.billKey
+                            ? "is-selected"
+                            : ""
+                        }`}
+                        key={item.billKey}
+                        onClick={() => setSelectedBillKey(item.billKey)}
+                      >
+                        <span className="dynamic-bill-card-meta">
+                          #{item.localRank} · {statusLabel(item.status)}
+                        </span>
+                        <strong>{item.creatorName}</strong>
+                        <span className="dynamic-bill-card-title">
+                          {item.evidence.newVideo.title || item.evidence.newVideo.bvid}
+                        </span>
+                        <span className="dynamic-bill-card-fact">
+                          长期正反馈 {item.evidence.longWindow.positiveWatchCount} 次 · 近期正反馈 {item.evidence.recentWindow.positiveWatchCount} 次
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="dynamic-bill-empty">
+                    <strong>{emptyCopy.title}</strong>
+                    <p>{emptyCopy.detail}</p>
+                  </div>
+                )}
+              </article>
+            );
+          })}
         </div>
 
-        <aside className="dynamic-bill-detail" aria-label="账单项详情占位">
-          <span className="dynamic-bill-kicker">选中账单项</span>
-          <h3>详情结构占位</h3>
-          <p>
-            真实账单项接入后，这里会展示 UP 主、新投稿、本地证据事实、AI
-            解释、本地历史代表视频与操作入口。
-          </p>
-          <div className="dynamic-bill-status-copy">
-            <strong>当前筛选：{activeStatus.label}</strong>
-            <span>{activeStatus.detail}</span>
-          </div>
-          <div className="dynamic-bill-action-grid">
-            <button type="button" disabled>
-              打开新视频
-            </button>
-            <button type="button" disabled>
-              打开 UP 主页
-            </button>
-            <button type="button" disabled>
-              标记已处理
-            </button>
-            <button type="button" disabled>
-              少提醒这个 UP
-            </button>
-            <button type="button" disabled>
-              少提醒这个主题
-            </button>
-          </div>
+        <aside className="dynamic-bill-detail" aria-label="账单项详情">
+          {selectedItem ? (
+            <BillItemDetail item={selectedItem} />
+          ) : (
+            <EmptyDetail status={activeStatus} />
+          )}
         </aside>
       </section>
     </div>
+  );
+}
+
+function BillItemDetail({ item }: { item: DynamicBillItem }) {
+  const evidence = item.evidence;
+  return (
+    <>
+      <span className="dynamic-bill-kicker">
+        久违更新 / {statusLabel(item.status)}
+      </span>
+      <h3>{item.creatorName}</h3>
+      <p>
+        新投稿：{evidence.newVideo.title || evidence.newVideo.bvid}
+      </p>
+      <div className="dynamic-bill-evidence-grid">
+        <EvidenceStat
+          label={`长期 ${evidence.longWindow.windowDays} 天`}
+          value={`${evidence.longWindow.positiveWatchCount} 次正反馈`}
+          detail={`${evidence.longWindow.watchedCount} 次观看 · 平均完成度 ${formatPercent(evidence.longWindow.avgCompletion)}`}
+        />
+        <EvidenceStat
+          label={`近期 ${evidence.recentWindow.windowDays} 天`}
+          value={`${evidence.recentWindow.positiveWatchCount} 次正反馈`}
+          detail={`${evidence.recentWindow.watchedCount} 次观看 · 冷却比 ${formatPercent(evidence.cooldownRatio)}`}
+        />
+      </div>
+      <div className="dynamic-bill-status-copy">
+        <strong>规则阈值</strong>
+        <span>
+          长期正反馈不少于 {evidence.thresholds.minCreatorPositiveViews} 次；
+          正反馈为完成度 ≥ {formatPercent(evidence.thresholds.positiveCompletionRate)}
+          、观看 ≥ {formatDuration(evidence.thresholds.minPositiveWatchSeconds)}
+          或已收藏；近期同一新视频排除窗口为 {evidence.thresholds.recentSameVideoWindowDays} 天。
+        </span>
+      </div>
+      <ul className="dynamic-bill-fact-list">
+        {evidence.facts.map((fact) => (
+          <li key={fact}>{fact}</li>
+        ))}
+      </ul>
+      <div className="dynamic-bill-status-copy">
+        <strong>本地历史代表视频</strong>
+        <span>
+          {item.historyBvids.length > 0
+            ? item.historyBvids.join("、")
+            : "长期窗口中没有可展示的近期以前代表 bvid。"}
+        </span>
+      </div>
+      <div className="dynamic-bill-action-grid">
+        <a href={videoUrl(evidence.newVideo.bvid)} target="_blank" rel="noreferrer">
+          打开新视频
+        </a>
+        <a href={spaceUrl(item.creatorMid)} target="_blank" rel="noreferrer">
+          打开 UP 主页
+        </a>
+      </div>
+    </>
+  );
+}
+
+function EmptyDetail({
+  status,
+}: {
+  status: { key: DynamicBillStatus; label: string; detail: string };
+}) {
+  return (
+    <>
+      <span className="dynamic-bill-kicker">选中账单项</span>
+      <h3>暂无{status.label}项</h3>
+      <p>
+        生成本地账单后，选择久违更新卡片即可查看长期窗口、近期窗口、新投稿和排除同视频观看的证据事实。
+      </p>
+      <div className="dynamic-bill-status-copy">
+        <strong>当前筛选：{status.label}</strong>
+        <span>{status.detail}</span>
+      </div>
+    </>
   );
 }
 
@@ -245,10 +426,10 @@ function lastSyncDetail(overview: DynamicBillOverview | null): string {
 function describeOverview(overview: DynamicBillOverview): string {
   const state = overview.syncState;
   if (state.status === "not_logged_in") {
-    return "需要先登录 B 站账号，Bili-Bill 才能同步你的关注关系和关注动态。";
+    return "需要先登录 B 站账号，Bili-Bill 才能同步你的关注关系和关注动态；已存在的本地证据仍可读取。";
   }
   if (state.status === "failed") {
-    return `动态同步失败：${state.lastError ?? "未知错误"}。已保留本地已有动态数据。`;
+    return `动态同步失败：${state.lastError ?? "未知错误"}。已保留本地已有动态数据和账单项。`;
   }
   if (state.status === "success") {
     return `已同步 ${overview.activeFollowedCreatorCount} 个关注 UP，最近 ${overview.updateWindowDays} 天视频投稿 ${overview.recentVideoUpdateCount} 条。`;
@@ -269,27 +450,38 @@ function describeSyncResult(result: DynamicSyncResult): string {
   return `同步完成：关注 UP ${result.followedCreatorsStored} 个，最近视频投稿 ${result.videoUpdatesStored} 条，过滤非视频动态 ${result.filteredNonVideoCount} 条。`;
 }
 
-function getEmptyCopy(
+function describeGenerateResult(result: DynamicBillGenerateResult): string {
+  return `久违更新生成 ${result.itemCount} 项；扫描最近投稿 ${result.candidatesScanned} 条，排除近期已看同视频 ${result.excludedRecentSameVideoCount} 条，长期证据不足 ${result.excludedNoLongSignalCount} 个 UP，近期仍活跃 ${result.excludedRecentActiveCount} 个 UP。`;
+}
+
+function getColumnEmptyCopy(
+  enabled: boolean,
   overview: DynamicBillOverview | null,
   statusLabel: string,
+  afkItemCount: number,
 ): { title: string; detail: string } {
+  if (!enabled) {
+    return {
+      title: "后续切片未启用",
+      detail: "为保持 #5 范围干净，本 PR 不生成该栏目账单项。",
+    };
+  }
   if (!overview) {
     return {
       title: "正在读取账单数据",
-      detail: "同步状态加载后会显示关注快照和最近视频投稿池数量。",
+      detail: "同步状态加载后会显示关注快照、最近视频投稿池和本地账单项数量。",
     };
   }
-  if (overview.syncState.status === "not_logged_in") {
+  if (overview.syncState.status === "not_logged_in" && afkItemCount === 0) {
     return {
       title: "需要登录 B 站后同步",
-      detail: "未登录时页面不会崩溃，也不会尝试生成虚假的账单项。",
+      detail: "未登录时不会生成虚假账单；若本地已有证据，仍可直接展示。",
     };
   }
   if (overview.activeFollowedCreatorCount === 0) {
     return {
       title: "还没有关注快照",
-      detail:
-        "完成同步后，这里会基于已关注 UP 的视频投稿池等待后续规则引擎生成账单项。",
+      detail: "完成同步后，会从已关注 UP 的视频投稿池中寻找久违更新候选。",
     };
   }
   if (overview.recentVideoUpdateCount === 0) {
@@ -299,9 +491,17 @@ function getEmptyCopy(
     };
   }
   return {
-    title: `${statusLabel}账单项将在后续任务生成`,
-    detail:
-      "当前任务只准备已关注视频投稿池；三栏兴趣再平衡规则由后续 issue 接入。",
+    title: `暂无${statusLabel}久违更新`,
+    detail: "可能是长期正反馈不足、近期仍在观看，或同一新视频已在近期观看历史中出现。",
+  };
+}
+
+function countByStatus(items: DynamicBillItem[]): Record<DynamicBillStatus, number> {
+  return {
+    unopened: items.filter((item) => item.status === "unopened").length,
+    opened: items.filter((item) => item.status === "opened").length,
+    consumed: items.filter((item) => item.status === "consumed").length,
+    processed: items.filter((item) => item.status === "processed").length,
   };
 }
 
@@ -322,8 +522,29 @@ function stageLabel(stage: string): string {
   }
 }
 
+function statusLabel(status: DynamicBillStatus): string {
+  return STATUS_FILTERS.find((item) => item.key === status)?.label ?? "未打开";
+}
+
+function videoUrl(bvid: string): string {
+  return `https://www.bilibili.com/video/${encodeURIComponent(bvid)}`;
+}
+
+function spaceUrl(mid: number): string {
+  return `https://space.bilibili.com/${mid}`;
+}
+
 function formatTime(timestamp: number): string {
   return new Date(timestamp).toLocaleString("zh-CN");
+}
+
+function formatPercent(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds} 秒`;
+  return `${Math.round(seconds / 60)} 分钟`;
 }
 
 function describeError(error: unknown): string {
@@ -347,6 +568,24 @@ function StatusMetric({
 }) {
   return (
     <div className="dynamic-bill-metric">
+      <span>{label}</span>
+      <strong>{value}</strong>
+      <small>{detail}</small>
+    </div>
+  );
+}
+
+function EvidenceStat({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <div className="dynamic-bill-evidence-stat">
       <span>{label}</span>
       <strong>{value}</strong>
       <small>{detail}</small>

--- a/dashboard/styles/dashboard.css
+++ b/dashboard/styles/dashboard.css
@@ -338,6 +338,22 @@ button {
   font-weight: 800;
 }
 
+.dynamic-bill-scope-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+  margin-top: 4px;
+}
+
+.dynamic-bill-scope-actions .dynamic-bill-sync-button {
+  margin-top: 0;
+}
+
+.dynamic-bill-sync-button.is-secondary {
+  border-color: rgba(0, 161, 214, 0.44);
+  background: rgba(0, 161, 214, 0.18);
+}
+
 .dynamic-bill-sync-button:disabled {
   cursor: wait;
   opacity: 0.62;
@@ -528,6 +544,75 @@ button {
   line-height: 1.6;
 }
 
+.dynamic-bill-item-list {
+  display: grid;
+  gap: 9px;
+  padding: 10px;
+}
+
+.dynamic-bill-item-card {
+  display: grid;
+  gap: 6px;
+  width: 100%;
+  min-height: 126px;
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  color: #D8DCE6;
+  background: rgba(26, 26, 46, 0.48);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+}
+
+.dynamic-bill-item-card:hover,
+.dynamic-bill-item-card.is-selected {
+  border-color: rgba(251, 114, 153, 0.52);
+  background: rgba(251, 114, 153, 0.11);
+}
+
+.dynamic-bill-item-card:hover {
+  transform: translateY(-1px);
+}
+
+.dynamic-bill-card-meta,
+.dynamic-bill-card-title,
+.dynamic-bill-card-fact {
+  display: block;
+  min-width: 0;
+}
+
+.dynamic-bill-card-meta {
+  color: #8FDDF6;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.dynamic-bill-item-card strong {
+  overflow: hidden;
+  color: #FFFFFF;
+  font-size: 14px;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dynamic-bill-card-title {
+  display: -webkit-box;
+  overflow: hidden;
+  color: #B8C0CE;
+  font-size: 12px;
+  line-height: 1.45;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.dynamic-bill-card-fact {
+  color: #8995A8;
+  font-size: 11px;
+  line-height: 1.45;
+}
+
 .dynamic-bill-detail {
   position: sticky;
   top: 18px;
@@ -546,6 +631,40 @@ button {
   color: var(--text-secondary);
   font-size: 13px;
   line-height: 1.7;
+}
+
+.dynamic-bill-evidence-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.dynamic-bill-evidence-stat {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.dynamic-bill-evidence-stat span {
+  color: #8FDDF6;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.dynamic-bill-evidence-stat strong {
+  color: #FFFFFF;
+  font-size: 13px;
+  line-height: 1.25;
+}
+
+.dynamic-bill-evidence-stat small {
+  color: #8995A8;
+  font-size: 11px;
+  line-height: 1.45;
 }
 
 .dynamic-bill-status-copy {
@@ -574,14 +693,36 @@ button {
   gap: 7px;
 }
 
-.dynamic-bill-action-grid button {
+.dynamic-bill-action-grid button,
+.dynamic-bill-action-grid a {
+  display: grid;
+  align-items: center;
   min-height: 34px;
+  padding: 0 10px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 7px;
   color: #9DA8B8;
   background: rgba(255, 255, 255, 0.04);
   font-size: 12px;
   font-weight: 750;
+  text-align: center;
+  text-decoration: none;
+}
+
+.dynamic-bill-action-grid a {
+  color: #FFFFFF;
+  border-color: rgba(0, 161, 214, 0.42);
+  background: rgba(0, 161, 214, 0.16);
+}
+
+.dynamic-bill-fact-list {
+  display: grid;
+  gap: 7px;
+  margin: 0;
+  padding: 0 0 0 18px;
+  color: #B8C0CE;
+  font-size: 12px;
+  line-height: 1.55;
 }
 
 @media (max-width: 1180px) {
@@ -694,6 +835,11 @@ button {
 
   .dynamic-bill-scope {
     min-width: 0;
+  }
+
+  .dynamic-bill-scope-actions,
+  .dynamic-bill-evidence-grid {
+    grid-template-columns: 1fr;
   }
 
   .dynamic-bill-status-grid,

--- a/src/background/dynamic-bill/rules.ts
+++ b/src/background/dynamic-bill/rules.ts
@@ -1,0 +1,342 @@
+import type {
+  DynamicBillGenerateResult,
+  DynamicBillItem,
+  DynamicBillWindowEvidence,
+  FollowedCreator,
+  FollowedVideoUpdate,
+} from '../../shared/types/dynamic-bill';
+import type { WatchHistoryRecord } from '../../shared/types/watch-event';
+import { getRecordsSince } from '../storage/watch-history-repo';
+import {
+  getActiveFollowedCreators,
+  getDynamicBillOverview,
+  getRecentFollowedVideoUpdates,
+  replaceDynamicBillItemsForColumn,
+} from '../storage/dynamic-bill-repo';
+import { DYNAMIC_BILL_STRATEGY, getDynamicBillThresholdEvidence } from './strategy';
+
+const SECONDS_PER_DAY = 86_400;
+const AFK_UPDATE_COLUMN = 'afk_update';
+
+interface CreatorWindowStats extends DynamicBillWindowEvidence {
+  records: WatchHistoryRecord[];
+}
+
+interface Candidate {
+  creator: FollowedCreator;
+  update: FollowedVideoUpdate;
+  longStats: CreatorWindowStats;
+  recentStats: CreatorWindowStats;
+  cooldownRatio: number;
+  daysSinceLastWatch: number | null;
+  score: number;
+  historyBvids: string[];
+}
+
+export async function generateAfkUpdateBillItems(): Promise<DynamicBillGenerateResult> {
+  const generatedAt = Date.now();
+  const nowSeconds = Math.floor(generatedAt / 1000);
+  const thresholds = getDynamicBillThresholdEvidence();
+  const longCutoff = nowSeconds - DYNAMIC_BILL_STRATEGY.longWindowDays * SECONDS_PER_DAY;
+  const recentCutoff = nowSeconds - DYNAMIC_BILL_STRATEGY.recentWindowDays * SECONDS_PER_DAY;
+  const recentSameVideoCutoff = nowSeconds - DYNAMIC_BILL_STRATEGY.recentSameVideoWindowDays * SECONDS_PER_DAY;
+
+  const [creators, updates, longRecords] = await Promise.all([
+    getActiveFollowedCreators(),
+    getRecentFollowedVideoUpdates(DYNAMIC_BILL_STRATEGY.updateWindowDays),
+    getRecordsSince(longCutoff),
+  ]);
+
+  const activeCreatorsByMid = new Map(creators.map(creator => [creator.mid, creator]));
+  const recordsByCreator = groupRecordsByCreator(longRecords);
+  const recentlyWatchedBvids = new Set(
+    longRecords
+      .filter(record => record.viewAt >= recentSameVideoCutoff)
+      .map(record => record.bvid)
+      .filter(Boolean),
+  );
+
+  let excludedRecentSameVideoCount = 0;
+  const newestUnwatchedUpdateByCreator = new Map<number, FollowedVideoUpdate>();
+  for (const update of updates) {
+    if (!activeCreatorsByMid.has(update.authorMid)) continue;
+    if (recentlyWatchedBvids.has(update.bvid)) {
+      excludedRecentSameVideoCount++;
+      continue;
+    }
+
+    const existing = newestUnwatchedUpdateByCreator.get(update.authorMid);
+    if (!existing || update.dynamicTime > existing.dynamicTime) {
+      newestUnwatchedUpdateByCreator.set(update.authorMid, update);
+    }
+  }
+
+  const candidates: Candidate[] = [];
+  let excludedNoLongSignalCount = 0;
+  let excludedRecentActiveCount = 0;
+
+  for (const [creatorMid, update] of newestUnwatchedUpdateByCreator) {
+    const creator = activeCreatorsByMid.get(creatorMid);
+    if (!creator) continue;
+
+    const creatorRecords = recordsByCreator.get(creatorMid) ?? [];
+    const longStats = buildWindowStats(
+      creatorRecords,
+      DYNAMIC_BILL_STRATEGY.longWindowDays,
+      longCutoff,
+      nowSeconds,
+    );
+    if (longStats.positiveWatchCount < DYNAMIC_BILL_STRATEGY.minCreatorPositiveViews) {
+      excludedNoLongSignalCount++;
+      continue;
+    }
+
+    const recentStats = buildWindowStats(
+      creatorRecords.filter(record => record.viewAt >= recentCutoff),
+      DYNAMIC_BILL_STRATEGY.recentWindowDays,
+      recentCutoff,
+      nowSeconds,
+    );
+    const expectedRecentPositive = longStats.positiveWatchCount
+      * (DYNAMIC_BILL_STRATEGY.recentWindowDays / DYNAMIC_BILL_STRATEGY.longWindowDays);
+    const recentPositiveLimit = Math.floor(expectedRecentPositive * DYNAMIC_BILL_STRATEGY.recentCooldownRatio);
+    if (recentStats.positiveWatchCount > recentPositiveLimit) {
+      excludedRecentActiveCount++;
+      continue;
+    }
+
+    const daysSinceLastWatch = longStats.lastWatchedAt > 0
+      ? Math.floor((nowSeconds - longStats.lastWatchedAt) / SECONDS_PER_DAY)
+      : null;
+    const cooldownRatio = expectedRecentPositive > 0
+      ? recentStats.positiveWatchCount / expectedRecentPositive
+      : 0;
+    const historyBvids = selectHistoryHighlights(creatorRecords, update.bvid, recentCutoff);
+
+    candidates.push({
+      creator,
+      update,
+      longStats,
+      recentStats,
+      cooldownRatio,
+      daysSinceLastWatch,
+      historyBvids,
+      score: scoreCandidate({
+        creator,
+        update,
+        longStats,
+        recentStats,
+        cooldownRatio,
+        daysSinceLastWatch,
+        historyBvids,
+      }, nowSeconds),
+    });
+  }
+
+  const items = candidates
+    .sort((a, b) => b.score - a.score || b.update.dynamicTime - a.update.dynamicTime)
+    .slice(0, DYNAMIC_BILL_STRATEGY.maxItemsPerColumn)
+    .map((candidate, index) => toBillItem(candidate, index + 1, generatedAt));
+
+  const storedItems = await replaceDynamicBillItemsForColumn(AFK_UPDATE_COLUMN, items);
+  const overview = await getDynamicBillOverview(DYNAMIC_BILL_STRATEGY.updateWindowDays);
+
+  return {
+    generatedAt,
+    itemCount: storedItems.length,
+    candidatesScanned: updates.length,
+    eligibleCreatorCount: candidates.length,
+    excludedNoLongSignalCount,
+    excludedRecentActiveCount,
+    excludedRecentSameVideoCount,
+    items: storedItems,
+    thresholds,
+    overview,
+  };
+}
+
+function groupRecordsByCreator(records: WatchHistoryRecord[]): Map<number, WatchHistoryRecord[]> {
+  const groups = new Map<number, WatchHistoryRecord[]>();
+  for (const record of records) {
+    if (!record.authorMid) continue;
+    const bucket = groups.get(record.authorMid) ?? [];
+    bucket.push(record);
+    groups.set(record.authorMid, bucket);
+  }
+  return groups;
+}
+
+function buildWindowStats(
+  records: WatchHistoryRecord[],
+  windowDays: number,
+  startedAt: number,
+  endedAt: number,
+): CreatorWindowStats {
+  const watchedCount = records.length;
+  const positiveWatchCount = records.filter(isPositiveWatch).length;
+  const totalWatchTimeSeconds = records.reduce((sum, record) => sum + positiveProgress(record), 0);
+  const avgCompletion = watchedCount > 0
+    ? records.reduce((sum, record) => sum + completionRate(record), 0) / watchedCount
+    : 0;
+  const lastWatchedAt = records.reduce((latest, record) => Math.max(latest, record.viewAt), 0);
+
+  return {
+    windowDays,
+    startedAt,
+    endedAt,
+    watchedCount,
+    positiveWatchCount,
+    totalWatchTimeSeconds,
+    avgCompletion,
+    lastWatchedAt,
+    records,
+  };
+}
+
+function isPositiveWatch(record: WatchHistoryRecord): boolean {
+  return record.isFavorite
+    || completionRate(record) >= DYNAMIC_BILL_STRATEGY.positiveCompletionRate
+    || positiveProgress(record) >= DYNAMIC_BILL_STRATEGY.minPositiveWatchSeconds;
+}
+
+function completionRate(record: WatchHistoryRecord): number {
+  if (Number.isFinite(record.actualCompletion)) {
+    return clamp01(record.actualCompletion);
+  }
+  return record.duration > 0 ? clamp01(record.progress / record.duration) : 0;
+}
+
+function positiveProgress(record: WatchHistoryRecord): number {
+  return Math.max(0, Number(record.progress ?? 0));
+}
+
+function selectHistoryHighlights(
+  records: WatchHistoryRecord[],
+  currentBvid: string,
+  recentCutoff: number,
+): string[] {
+  const seen = new Set<string>();
+  return records
+    .filter(record => record.bvid && record.bvid !== currentBvid && record.viewAt < recentCutoff)
+    .sort((a, b) => {
+      const positiveDelta = Number(isPositiveWatch(b)) - Number(isPositiveWatch(a));
+      if (positiveDelta !== 0) return positiveDelta;
+      const completionDelta = completionRate(b) - completionRate(a);
+      if (completionDelta !== 0) return completionDelta;
+      const progressDelta = positiveProgress(b) - positiveProgress(a);
+      if (progressDelta !== 0) return progressDelta;
+      return b.viewAt - a.viewAt;
+    })
+    .map(record => record.bvid)
+    .filter((bvid) => {
+      if (seen.has(bvid)) return false;
+      seen.add(bvid);
+      return true;
+    })
+    .slice(0, DYNAMIC_BILL_STRATEGY.maxHighlightsPerItem);
+}
+
+function scoreCandidate(candidate: Omit<Candidate, 'score'>, nowSeconds: number): number {
+  const followAgeDays = getFollowAgeDays(candidate.creator, nowSeconds) ?? 0;
+  const updateAgeDays = Math.max(0, (nowSeconds - candidate.update.dynamicTime) / SECONDS_PER_DAY);
+  const watchStrength = candidate.longStats.positiveWatchCount * 10
+    + Math.min(candidate.longStats.totalWatchTimeSeconds / 3600, 12)
+    + candidate.longStats.avgCompletion * 8;
+  const cooldownStrength = (1 - Math.min(candidate.cooldownRatio, 1)) * 18
+    + Math.min(candidate.daysSinceLastWatch ?? DYNAMIC_BILL_STRATEGY.longWindowDays, 90) / 6;
+  const followAgeBoost = Math.min(followAgeDays / 365, 1) * 4;
+  const freshnessBoost = Math.max(0, DYNAMIC_BILL_STRATEGY.updateWindowDays - updateAgeDays)
+    / DYNAMIC_BILL_STRATEGY.updateWindowDays
+    * 3;
+
+  return Math.round((watchStrength + cooldownStrength + followAgeBoost + freshnessBoost) * 100) / 100;
+}
+
+function toBillItem(candidate: Candidate, localRank: number, generatedAt: number): DynamicBillItem {
+  const nowSeconds = Math.floor(generatedAt / 1000);
+  const followAgeDays = getFollowAgeDays(candidate.creator, nowSeconds);
+  const thresholds = getDynamicBillThresholdEvidence();
+  const facts = buildFacts(candidate, followAgeDays);
+
+  return {
+    billKey: `${AFK_UPDATE_COLUMN}:${candidate.update.updateKey}`,
+    column: AFK_UPDATE_COLUMN,
+    status: 'unopened',
+    updateKey: candidate.update.updateKey,
+    creatorMid: candidate.creator.mid,
+    creatorName: candidate.creator.name || candidate.update.authorName,
+    creatorFace: candidate.creator.face || candidate.update.authorFace,
+    historyBvids: candidate.historyBvids,
+    localRank,
+    score: candidate.score,
+    generatedAt,
+    evidence: {
+      kind: AFK_UPDATE_COLUMN,
+      longWindow: stripRecords(candidate.longStats),
+      recentWindow: stripRecords(candidate.recentStats),
+      newVideo: {
+        updateKey: candidate.update.updateKey,
+        dynamicId: candidate.update.dynamicId,
+        bvid: candidate.update.bvid,
+        avid: candidate.update.avid,
+        title: candidate.update.title,
+        cover: candidate.update.cover,
+        duration: candidate.update.duration,
+        pubtime: candidate.update.pubtime,
+        dynamicTime: candidate.update.dynamicTime,
+        tagName: candidate.update.tagName,
+        tags: candidate.update.tags,
+      },
+      follow: {
+        followedAt: candidate.creator.followedAt,
+        followAgeKnown: candidate.creator.followAgeKnown,
+        followAgeDays,
+      },
+      cooldownRatio: Math.round(candidate.cooldownRatio * 100) / 100,
+      daysSinceLastWatch: candidate.daysSinceLastWatch,
+      facts,
+      thresholds,
+    },
+  };
+}
+
+function buildFacts(candidate: Candidate, followAgeDays?: number): string[] {
+  const long = candidate.longStats;
+  const recent = candidate.recentStats;
+  const facts = [
+    `长期 ${long.windowDays} 天内观看 ${long.watchedCount} 次，正反馈 ${long.positiveWatchCount} 次，平均完成度 ${formatPercent(long.avgCompletion)}。`,
+    `近期 ${recent.windowDays} 天内观看 ${recent.watchedCount} 次，正反馈 ${recent.positiveWatchCount} 次，冷却比 ${formatPercent(candidate.cooldownRatio)}。`,
+    `最近 ${DYNAMIC_BILL_STRATEGY.updateWindowDays} 天有新投稿《${candidate.update.title || candidate.update.bvid}》。`,
+    `本地最近 ${DYNAMIC_BILL_STRATEGY.recentSameVideoWindowDays} 天未发现同一新视频 ${candidate.update.bvid} 的观看记录。`,
+  ];
+
+  if (candidate.daysSinceLastWatch !== null) {
+    facts.push(`距上次观看该 UP 已约 ${candidate.daysSinceLastWatch} 天。`);
+  }
+  if (followAgeDays !== undefined) {
+    facts.push(`已关注约 ${followAgeDays} 天；该信息只参与排序加权，不单独决定入选。`);
+  } else {
+    facts.push('关注时间未知；入选不依赖关注时长。');
+  }
+
+  return facts;
+}
+
+function stripRecords(stats: CreatorWindowStats): DynamicBillWindowEvidence {
+  const { records: _records, ...evidence } = stats;
+  return evidence;
+}
+
+function getFollowAgeDays(creator: FollowedCreator, nowSeconds: number): number | undefined {
+  if (!creator.followAgeKnown || !creator.followedAt) return undefined;
+  return Math.max(0, Math.floor((nowSeconds - creator.followedAt) / SECONDS_PER_DAY));
+}
+
+function formatPercent(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(value, 1));
+}

--- a/src/background/dynamic-bill/strategy.ts
+++ b/src/background/dynamic-bill/strategy.ts
@@ -1,0 +1,28 @@
+import { DYNAMIC_UPDATE_WINDOW_DAYS } from '../../shared/constants';
+import type { DynamicBillThresholdEvidence } from '../../shared/types/dynamic-bill';
+
+export const DYNAMIC_BILL_STRATEGY = {
+  longWindowDays: 180,
+  recentWindowDays: 30,
+  updateWindowDays: DYNAMIC_UPDATE_WINDOW_DAYS,
+  recentSameVideoWindowDays: 30,
+  minCreatorPositiveViews: 3,
+  positiveCompletionRate: 0.5,
+  minPositiveWatchSeconds: 180,
+  recentCooldownRatio: 0.5,
+  maxHighlightsPerItem: 3,
+  maxItemsPerColumn: 20,
+} as const;
+
+export function getDynamicBillThresholdEvidence(): DynamicBillThresholdEvidence {
+  return {
+    longWindowDays: DYNAMIC_BILL_STRATEGY.longWindowDays,
+    recentWindowDays: DYNAMIC_BILL_STRATEGY.recentWindowDays,
+    updateWindowDays: DYNAMIC_BILL_STRATEGY.updateWindowDays,
+    recentSameVideoWindowDays: DYNAMIC_BILL_STRATEGY.recentSameVideoWindowDays,
+    minCreatorPositiveViews: DYNAMIC_BILL_STRATEGY.minCreatorPositiveViews,
+    positiveCompletionRate: DYNAMIC_BILL_STRATEGY.positiveCompletionRate,
+    minPositiveWatchSeconds: DYNAMIC_BILL_STRATEGY.minPositiveWatchSeconds,
+    recentCooldownRatio: DYNAMIC_BILL_STRATEGY.recentCooldownRatio,
+  };
+}

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -25,7 +25,9 @@ import { getDeviceData } from '../analytics/device';
 import { abortCurrentHistorySync, hasActiveHistorySyncAbortScope } from '../sync/sync-control';
 import { syncFavorites } from '../favorites/sync';
 import { buildSmartFavoriteIndex, getSmartFavoriteOverview, getSmartFavoritesByPath, searchSmartFavorites } from '../favorites/smart';
+import { generateAfkUpdateBillItems } from '../dynamic-bill/rules';
 import { getDynamicOverview, syncDynamicBillUpdates } from '../dynamic-bill/sync';
+import { getDynamicBillItems } from '../storage/dynamic-bill-repo';
 
 const EXPORT_PAGE_LIMIT_MAX = 1000;
 
@@ -227,6 +229,10 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
       return { success: true, data: await getDynamicOverview() as T };
     case 'SYNC_DYNAMIC_UPDATES':
       return { success: true, data: await syncDynamicBillUpdates() as T };
+    case 'GENERATE_DYNAMIC_BILL':
+      return { success: true, data: await generateAfkUpdateBillItems() as T };
+    case 'GET_DYNAMIC_BILL_ITEMS':
+      return { success: true, data: await getDynamicBillItems() as T };
     default:
       return { success: false, error: `Unknown action: ${request.action}` };
   }

--- a/src/background/storage/db.ts
+++ b/src/background/storage/db.ts
@@ -1,7 +1,7 @@
 import Dexie, { type Table } from 'dexie';
 import type { WatchHistoryRecord, PlayerEvent, DailyAggregate } from '../../shared/types/watch-event';
 import type { FavoriteFolder, FavoriteItem, SmartFavoriteIndex } from '../../shared/types/favorite';
-import type { FollowedCreator, FollowedVideoUpdate } from '../../shared/types/dynamic-bill';
+import type { DynamicBillItem, FollowedCreator, FollowedVideoUpdate } from '../../shared/types/dynamic-bill';
 
 export class BiliAnalyticsDB extends Dexie {
   watchHistory!: Table<WatchHistoryRecord, number>;
@@ -12,6 +12,7 @@ export class BiliAnalyticsDB extends Dexie {
   smartFavoriteIndex!: Table<SmartFavoriteIndex, number>;
   followedCreators!: Table<FollowedCreator, number>;
   followedVideoUpdates!: Table<FollowedVideoUpdate, number>;
+  dynamicBillItems!: Table<DynamicBillItem, number>;
 
   constructor() {
     super('BiliAnalyticsDB');
@@ -74,6 +75,27 @@ export class BiliAnalyticsDB extends Dexie {
         '++id, &mid, followedAt, followAgeKnown, isActive, syncedAt, lastSeenAt',
       followedVideoUpdates:
         '++id, &updateKey, dynamicId, bvid, authorMid, dynamicTime, pubtime, syncedAt',
+    });
+
+    this.version(5).stores({
+      watchHistory:
+        '++id, kid, &sessionKey, avid, bvid, [avid+cid+viewAt], authorMid, tagName, viewAt, dt',
+      playerEvents:
+        '++id, [bvid+cid], eventType, timestamp, tabId',
+      dailyAggregates:
+        '++id, &date',
+      favoriteFolders:
+        '++id, &mediaId, title, syncedAt',
+      favoriteItems:
+        '++id, &itemKey, mediaId, avid, bvid, authorMid, tagName, favTime, syncedAt',
+      smartFavoriteIndex:
+        '++id, &itemKey, status, indexedAt, contentHash',
+      followedCreators:
+        '++id, &mid, followedAt, followAgeKnown, isActive, syncedAt, lastSeenAt',
+      followedVideoUpdates:
+        '++id, &updateKey, dynamicId, bvid, authorMid, dynamicTime, pubtime, syncedAt',
+      dynamicBillItems:
+        '++id, &billKey, column, status, creatorMid, updateKey, generatedAt, localRank',
     });
   }
 }

--- a/src/background/storage/dynamic-bill-repo.ts
+++ b/src/background/storage/dynamic-bill-repo.ts
@@ -1,6 +1,9 @@
 import { DYNAMIC_UPDATE_WINDOW_DAYS } from '../../shared/constants';
 import type {
+  DynamicBillColumn,
+  DynamicBillItem,
   DynamicBillOverview,
+  DynamicBillStatus,
   DynamicSyncState,
   FollowedCreator,
   FollowedVideoUpdate,
@@ -78,6 +81,50 @@ export async function getRecentFollowedVideoUpdates(windowDays = DYNAMIC_UPDATE_
     .sortBy('dynamicTime');
 }
 
+export async function getActiveFollowedCreators(): Promise<FollowedCreator[]> {
+  const creators = await db.followedCreators.toArray();
+  return creators.filter(creator => creator.isActive !== false);
+}
+
+export async function replaceDynamicBillItemsForColumn(
+  column: DynamicBillColumn,
+  items: DynamicBillItem[],
+): Promise<DynamicBillItem[]> {
+  const storedItems: DynamicBillItem[] = [];
+
+  await db.transaction('rw', db.dynamicBillItems, async () => {
+    const existing = await db.dynamicBillItems.where('column').equals(column).toArray();
+    const existingByKey = new Map(existing.map(item => [item.billKey, item]));
+    await db.dynamicBillItems.where('column').equals(column).delete();
+
+    const nextItems = items.map(item => mergeExistingDynamicBillState(item, existingByKey.get(item.billKey)));
+    if (nextItems.length > 0) {
+      await db.dynamicBillItems.bulkPut(nextItems);
+      storedItems.push(...nextItems);
+    }
+  });
+
+  return storedItems.sort((a, b) => a.localRank - b.localRank);
+}
+
+export async function getDynamicBillItems(options: {
+  column?: DynamicBillColumn;
+  status?: DynamicBillStatus;
+} = {}): Promise<DynamicBillItem[]> {
+  let items = options.column
+    ? await db.dynamicBillItems.where('column').equals(options.column).toArray()
+    : await db.dynamicBillItems.toArray();
+
+  if (options.status) {
+    items = items.filter(item => item.status === options.status);
+  }
+
+  return items.sort((a, b) => {
+    if (a.status !== b.status) return statusOrder(a.status) - statusOrder(b.status);
+    return a.localRank - b.localRank;
+  });
+}
+
 export async function getDynamicBillOverview(windowDays = DYNAMIC_UPDATE_WINDOW_DAYS): Promise<DynamicBillOverview> {
   const [syncState, creators, recentUpdates] = await Promise.all([
     getDynamicSyncState(),
@@ -127,4 +174,34 @@ function isStaleSyncState(state: DynamicSyncState): boolean {
   return state.status === 'syncing'
     && state.lastStartedAt > 0
     && Date.now() - state.lastStartedAt > DYNAMIC_SYNC_STALE_TIMEOUT_MS;
+}
+
+function mergeExistingDynamicBillState(
+  item: DynamicBillItem,
+  existing?: DynamicBillItem,
+): DynamicBillItem {
+  if (!existing) return item;
+  return {
+    ...item,
+    id: existing.id,
+    status: existing.status,
+    openedAt: existing.openedAt,
+    consumedAt: existing.consumedAt,
+    processedAt: existing.processedAt,
+  };
+}
+
+function statusOrder(status: DynamicBillStatus): number {
+  switch (status) {
+    case 'unopened':
+      return 0;
+    case 'opened':
+      return 1;
+    case 'consumed':
+      return 2;
+    case 'processed':
+      return 3;
+    default:
+      return 4;
+  }
 }

--- a/src/shared/types/dynamic-bill.ts
+++ b/src/shared/types/dynamic-bill.ts
@@ -34,6 +34,9 @@ export interface FollowedVideoUpdate {
   syncedAt: number;
 }
 
+export type DynamicBillColumn = 'afk_update';
+export type DynamicBillStatus = 'unopened' | 'opened' | 'consumed' | 'processed';
+
 export type DynamicSyncStatus = 'idle' | 'syncing' | 'success' | 'not_logged_in' | 'failed';
 export type DynamicSyncStage = 'idle' | 'following' | 'dynamic-feed' | 'video-detail' | 'storage' | 'complete';
 
@@ -76,5 +79,91 @@ export interface DynamicSyncResult {
   filteredOutsideWindowCount: number;
   detailEnrichedCount: number;
   error?: string;
+  overview: DynamicBillOverview;
+}
+
+export interface DynamicBillWindowEvidence {
+  windowDays: number;
+  startedAt: number;
+  endedAt: number;
+  watchedCount: number;
+  positiveWatchCount: number;
+  totalWatchTimeSeconds: number;
+  avgCompletion: number;
+  lastWatchedAt: number;
+}
+
+export interface DynamicBillNewVideoEvidence {
+  updateKey: string;
+  dynamicId: string;
+  bvid: string;
+  avid: number;
+  title: string;
+  cover: string;
+  duration: number;
+  pubtime: number;
+  dynamicTime: number;
+  tagName: string;
+  tags: string[];
+}
+
+export interface DynamicBillFollowEvidence {
+  followedAt?: number;
+  followAgeKnown: boolean;
+  followAgeDays?: number;
+}
+
+export interface DynamicBillThresholdEvidence {
+  longWindowDays: number;
+  recentWindowDays: number;
+  updateWindowDays: number;
+  recentSameVideoWindowDays: number;
+  minCreatorPositiveViews: number;
+  positiveCompletionRate: number;
+  minPositiveWatchSeconds: number;
+  recentCooldownRatio: number;
+}
+
+export interface DynamicBillEvidence {
+  kind: DynamicBillColumn;
+  longWindow: DynamicBillWindowEvidence;
+  recentWindow: DynamicBillWindowEvidence;
+  newVideo: DynamicBillNewVideoEvidence;
+  follow: DynamicBillFollowEvidence;
+  cooldownRatio: number;
+  daysSinceLastWatch: number | null;
+  facts: string[];
+  thresholds: DynamicBillThresholdEvidence;
+}
+
+export interface DynamicBillItem {
+  id?: number;
+  billKey: string;
+  column: DynamicBillColumn;
+  status: DynamicBillStatus;
+  updateKey: string;
+  creatorMid: number;
+  creatorName: string;
+  creatorFace: string;
+  historyBvids: string[];
+  evidence: DynamicBillEvidence;
+  localRank: number;
+  score: number;
+  openedAt?: number;
+  consumedAt?: number;
+  processedAt?: number;
+  generatedAt: number;
+}
+
+export interface DynamicBillGenerateResult {
+  generatedAt: number;
+  itemCount: number;
+  candidatesScanned: number;
+  eligibleCreatorCount: number;
+  excludedNoLongSignalCount: number;
+  excludedRecentActiveCount: number;
+  excludedRecentSameVideoCount: number;
+  items: DynamicBillItem[];
+  thresholds: DynamicBillThresholdEvidence;
   overview: DynamicBillOverview;
 }

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -1,5 +1,5 @@
 import type { QuickStats, DashboardOverview, CategoryDistribution, InterestDrift, DurationBucket, CreatorRanking, NewCreator, BehaviorMetrics, WeeklyTip, BlindBoxItem } from './analytics';
-import type { DynamicBillOverview, DynamicSyncResult } from './dynamic-bill';
+import type { DynamicBillGenerateResult, DynamicBillItem, DynamicBillOverview, DynamicSyncResult } from './dynamic-bill';
 import type { FavoriteSyncResult, SmartFavoriteOverview, SmartFavoriteResult, SmartFavoriteSearchResponse, SmartIndexResult } from './favorite';
 
 // Popup / Dashboard → Service Worker
@@ -24,7 +24,9 @@ export type RequestAction =
   | 'BUILD_SMART_FAVORITE_INDEX'
   | 'SEARCH_SMART_FAVORITES'
   | 'GET_DYNAMIC_BILL_OVERVIEW'
-  | 'SYNC_DYNAMIC_UPDATES';
+  | 'SYNC_DYNAMIC_UPDATES'
+  | 'GENERATE_DYNAMIC_BILL'
+  | 'GET_DYNAMIC_BILL_ITEMS';
 
 // Content Script → Service Worker
 export type ContentAction =
@@ -140,3 +142,5 @@ export type SmartFavoriteSearchMessageResponse = BiliVizResponse<SmartFavoriteSe
 export type SmartFavoritePathResponse = BiliVizResponse<SmartFavoriteResult[]>;
 export type DynamicBillOverviewResponse = BiliVizResponse<DynamicBillOverview>;
 export type DynamicSyncResponse = BiliVizResponse<DynamicSyncResult>;
+export type DynamicBillGenerateResponse = BiliVizResponse<DynamicBillGenerateResult>;
+export type DynamicBillItemsResponse = BiliVizResponse<DynamicBillItem[]>;


### PR DESCRIPTION
## What changed

- Implements the local-only `afk_update` / 久违更新 bill generation rule for Issue #5.
- Adds `dynamicBillItems` storage plus `GENERATE_DYNAMIC_BILL` and `GET_DYNAMIC_BILL_ITEMS` messages.
- Updates the Dashboard dynamic bill page to show real 久违更新 items with local evidence while keeping 换换口味 and 被淹没的关注 disabled for later slices.

## Rule thresholds

- Long window: 180 days.
- Recent cooling window: 30 days.
- New followed-video update window: 7 days.
- Same-new-video exclusion window: 30 days; if the new video bvid appears in recent local history, that update is excluded.
- Positive watch: completion >= 50%, or watch progress >= 180 seconds, or local history marks the video as favorited.
- Minimum long-window signal: at least 3 positive watches for the creator.
- Cooling rule: recent positive watches must be <= `floor(expectedRecentPositive * 0.5)`, where expected recent positives are prorated from the long-window positive count.
- Follow age is not used for eligibility; it only adds a small score boost and appears in facts as auxiliary context.

## Evidence fields

Each item stores local evidence in `DynamicBillEvidence`:

- `longWindow`: days, start/end seconds, watch count, positive watch count, total watch seconds, average completion, last watched time.
- `recentWindow`: same fields for the 30-day cooling window.
- `newVideo`: update key, dynamic id, bvid/avid, title, cover, duration, pubtime, dynamic time, tag data.
- `follow`: followedAt when known, followAgeKnown, optional followAgeDays.
- `facts`: human-readable local facts shown without AI.
- `thresholds`: the concrete thresholds used for auditability.

No AI call is added, and no complete history or complete following list is uploaded.

## Validation

- `npm run typecheck` passed.
- `npm run build` passed. Vite still reports the existing large `chunks/theme` warning.
- `git diff --check` passed; Git printed Windows LF/CRLF working-tree warnings only.
- Browser mock QA against the built Dashboard passed: page rendered, mock 久违更新 item showed long/recent evidence, state labels remained 未打开 / 已打开 / 已消费 / 已处理, `未消费` did not appear, and the 已打开 filter interaction showed the empty state with no current console errors.

## Remaining risks

- Thresholds are fixed and centralized for this slice; adaptive tuning can be revisited after real usage data.
- Creator matching depends on local history having `authorMid`; older incomplete records can under-select candidates.
- Status progression, feedback, unfollow prompts, 换换口味, and 被淹没的关注 are intentionally left out of this PR.

Refs #5.