### PR TITLE
[codex] Implement buried follow dynamic bill

### DIFF
--- a/dashboard/modules/dynamic-bill/DynamicBillPage.tsx
+++ b/dashboard/modules/dynamic-bill/DynamicBillPage.tsx
@@ -44,9 +44,9 @@ const BILL_COLUMNS = [
   {
     key: "buried_follow",
     title: "被淹没的关注",
-    detail: "后续切片接入；本 PR 不生成该栏目。",
+    detail: "有关注关系、近期观看缺席或近乎缺席，最近 7 天有新投稿的 UP。",
     accent: "mint",
-    enabled: false,
+    enabled: true,
   },
 ] as const;
 
@@ -73,6 +73,10 @@ export function DynamicBillPage() {
   );
   const varietyItems = useMemo(
     () => items.filter((item) => item.column === "variety"),
+    [items],
+  );
+  const buriedFollowItems = useMemo(
+    () => items.filter((item) => item.column === "buried_follow"),
     [items],
   );
   const visibleItems = useMemo(
@@ -175,13 +179,13 @@ export function DynamicBillPage() {
           <span className="dynamic-bill-kicker">消费前 / 已关注视频投稿</span>
           <h2>动态账单</h2>
           <p>
-            久违更新和换换口味用本地观看历史、关注快照和最近投稿池生成，不接 AI，也不上传完整历史或完整关注列表。
+            久违更新、换换口味和被淹没的关注用本地观看历史、关注快照和最近投稿池生成，不接 AI，也不上传完整历史或完整关注列表。
           </p>
         </div>
         <div className="dynamic-bill-scope">
           <strong>本地证据范围</strong>
           <span>
-            同步已关注 UP 最近 7 天视频投稿；生成时要求长期正反馈或长期兴趣、近期冷却或下降，并排除近期已看过的同一新视频。
+            同步已关注 UP 最近 7 天视频投稿；生成时按长期正反馈、长期兴趣落差或关注记忆信号分别入栏，并排除近期已看过的同一新视频。
           </span>
           <div className="dynamic-bill-scope-actions">
             <button
@@ -226,7 +230,7 @@ export function DynamicBillPage() {
         <StatusMetric
           label="本地账单"
           value={String(items.length)}
-          detail={`久违更新 ${afkItems.length} / 换换口味 ${varietyItems.length}`}
+          detail={`久违更新 ${afkItems.length} / 换换口味 ${varietyItems.length} / 被淹没的关注 ${buriedFollowItems.length}`}
         />
       </section>
 
@@ -236,7 +240,7 @@ export function DynamicBillPage() {
       >
         <strong>{notice || overviewNotice}</strong>
         <span>
-          本切片启用久违更新和换换口味；被淹没的关注、状态推进、反馈和取关提示均未接入。topic 降低或屏蔽留给 #9 闭环。
+          本切片启用三类本地证据栏目；状态推进和筛选持久化留给 #8，负反馈累计、topic 降低和取关提示留给 #9 闭环。
         </span>
       </section>
 
@@ -333,6 +337,7 @@ export function DynamicBillPage() {
 
 function BillItemDetail({ item }: { item: DynamicBillItem }) {
   const evidence = item.evidence;
+  const isBuriedFollow = evidence.kind === "buried_follow";
   return (
     <>
       <span className="dynamic-bill-kicker">
@@ -342,6 +347,17 @@ function BillItemDetail({ item }: { item: DynamicBillItem }) {
       <p>
         新投稿：{evidence.newVideo.title || evidence.newVideo.bvid}
       </p>
+      <div className="dynamic-bill-status-copy">
+        <strong>关注关系证据</strong>
+        <span>{followEvidenceCopy(evidence)}</span>
+      </div>
+      <div className="dynamic-bill-status-copy">
+        <strong>新投稿证据</strong>
+        <span>
+          最近 {evidence.thresholds.updateWindowDays} 天投稿《{evidence.newVideo.title || evidence.newVideo.bvid}》，
+          bvid {evidence.newVideo.bvid}；同一新视频排除窗口为 {evidence.thresholds.recentSameVideoWindowDays} 天。
+        </span>
+      </div>
       {evidence.interest ? (
         <div className="dynamic-bill-status-copy">
           <strong>
@@ -356,14 +372,22 @@ function BillItemDetail({ item }: { item: DynamicBillItem }) {
       ) : null}
       <div className="dynamic-bill-evidence-grid">
         <EvidenceStat
-          label={`${evidence.interest ? "长期兴趣" : "长期"} ${evidence.longWindow.windowDays} 天`}
-          value={`${evidence.longWindow.positiveWatchCount} 次正反馈`}
-          detail={`${evidence.longWindow.watchedCount} 次观看 · 平均完成度 ${formatPercent(evidence.longWindow.avgCompletion)}`}
+          label={`${longWindowLabel(evidence)} ${evidence.longWindow.windowDays} 天`}
+          value={isBuriedFollow
+            ? `${evidence.longWindow.watchedCount} 次本地观看`
+            : `${evidence.longWindow.positiveWatchCount} 次正反馈`}
+          detail={isBuriedFollow
+            ? `${evidence.longWindow.positiveWatchCount} 次正反馈 · 平均完成度 ${formatPercent(evidence.longWindow.avgCompletion)}`
+            : `${evidence.longWindow.watchedCount} 次观看 · 平均完成度 ${formatPercent(evidence.longWindow.avgCompletion)}`}
         />
         <EvidenceStat
-          label={`${evidence.interest ? "近期兴趣" : "近期"} ${evidence.recentWindow.windowDays} 天`}
-          value={`${evidence.recentWindow.positiveWatchCount} 次正反馈`}
-          detail={`${evidence.recentWindow.watchedCount} 次观看 · 冷却比 ${formatPercent(evidence.cooldownRatio)}`}
+          label={`${recentWindowLabel(evidence)} ${evidence.recentWindow.windowDays} 天`}
+          value={isBuriedFollow
+            ? `${evidence.recentWindow.watchedCount} 次观看`
+            : `${evidence.recentWindow.positiveWatchCount} 次正反馈`}
+          detail={isBuriedFollow
+            ? `${evidence.recentWindow.positiveWatchCount} 次正反馈 · 缺席或近乎缺席`
+            : `${evidence.recentWindow.watchedCount} 次观看 · 冷却比 ${formatPercent(evidence.cooldownRatio)}`}
         />
       </div>
       <div className="dynamic-bill-status-copy">
@@ -469,7 +493,7 @@ function describeSyncResult(result: DynamicSyncResult): string {
 }
 
 function describeGenerateResult(result: DynamicBillGenerateResult): string {
-  return `本地账单生成 ${result.itemCount} 项：久违更新 ${result.columnItemCounts.afk_update} 项，换换口味 ${result.columnItemCounts.variety} 项；扫描最近投稿 ${result.candidatesScanned} 条，排除近期已看同视频 ${result.excludedRecentSameVideoCount} 条，长期证据不足 ${result.excludedNoLongSignalCount} 个，近期仍活跃 ${result.excludedRecentActiveCount} 个。`;
+  return `本地账单生成 ${result.itemCount} 项：久违更新 ${result.columnItemCounts.afk_update} 项，换换口味 ${result.columnItemCounts.variety} 项，被淹没的关注 ${result.columnItemCounts.buried_follow} 项；扫描最近投稿 ${result.candidatesScanned} 条，排除近期已看同视频 ${result.excludedRecentSameVideoCount} 条，长期/关注记忆证据不足 ${result.excludedNoLongSignalCount} 个，近期仍活跃 ${result.excludedRecentActiveCount} 个。`;
 }
 
 function getColumnEmptyCopy(
@@ -518,6 +542,12 @@ function getColumnEmptyCopy(
       detail: "可能是长期分区/标签强度不足、近期没有明显下降，或最近新投稿没有命中下降兴趣。",
     };
   }
+  if (column.key === "buried_follow") {
+    return {
+      title: `暂无${statusLabel}被淹没的关注`,
+      detail: "可能是缺少长期关注、特别关注或近期窗口以前弱观看等关注记忆信号，或该 UP 最近 30 天仍在观看。",
+    };
+  }
   return {
     title: `暂无${statusLabel}久违更新`,
     detail: "可能是长期正反馈不足、近期仍在观看，或同一新视频已在近期观看历史中出现。",
@@ -525,7 +555,7 @@ function getColumnEmptyCopy(
 }
 
 function isDynamicBillColumn(key: BillColumnKey): key is DynamicBillColumn {
-  return key === "afk_update" || key === "variety";
+  return key === "afk_update" || key === "variety" || key === "buried_follow";
 }
 
 function columnTitle(column: DynamicBillColumn): string {
@@ -533,6 +563,9 @@ function columnTitle(column: DynamicBillColumn): string {
 }
 
 function cardFact(item: DynamicBillItem): string {
+  if (item.column === "buried_follow") {
+    return `${followShortCopy(item.evidence)} · 近期观看 ${item.evidence.recentWindow.watchedCount} 次`;
+  }
   const interest = item.evidence.interest;
   if (interest) {
     return `${interestKindLabel(interest.kind)}「${interest.label}」 · 长期占比 ${formatPercent(interest.longPositiveShare)} · 下降 ${formatPercent(interest.positiveDropRatio)}`;
@@ -547,8 +580,51 @@ function thresholdCopy(evidence: DynamicBillEvidence): string {
   if (evidence.kind === "variety") {
     return `长期兴趣正反馈不少于 ${evidence.thresholds.minInterestPositiveViews} 次，长期正反馈占比 ≥ ${formatPercent(evidence.thresholds.minInterestLongPositiveShare)}；近期正反馈不高于长期节奏的 ${formatPercent(evidence.thresholds.maxInterestRecentPositiveRatio)}；最近 ${evidence.thresholds.updateWindowDays} 天新投稿必须命中该分区/标签；${positiveRule}；${sameVideoRule}。`;
   }
+  if (evidence.kind === "buried_follow") {
+    return `基础入选必须是已关注 UP、最近 ${evidence.thresholds.updateWindowDays} 天有新视频投稿、近期 ${evidence.thresholds.recentWindowDays} 天观看不超过 ${evidence.thresholds.maxBuriedRecentWatchCount} 次且正反馈不超过 ${evidence.thresholds.maxBuriedRecentPositiveWatchCount} 次；关注记忆信号至少满足：已关注不少于 ${evidence.thresholds.minBuriedFollowAgeDays} 天、特别关注、或近期窗口以前弱观看不少于 ${evidence.thresholds.minBuriedWeakWatchCount} 次之一；${positiveRule}；${sameVideoRule}。`;
+  }
 
   return `长期 UP 正反馈不少于 ${evidence.thresholds.minCreatorPositiveViews} 次；近期正反馈不高于长期节奏的 ${formatPercent(evidence.thresholds.recentCooldownRatio)}；${positiveRule}；${sameVideoRule}。`;
+}
+
+function longWindowLabel(evidence: DynamicBillEvidence): string {
+  if (evidence.kind === "buried_follow") return "长期观看";
+  return evidence.interest ? "长期兴趣" : "长期";
+}
+
+function recentWindowLabel(evidence: DynamicBillEvidence): string {
+  if (evidence.kind === "buried_follow") return "近期缺席";
+  return evidence.interest ? "近期兴趣" : "近期";
+}
+
+function followEvidenceCopy(evidence: DynamicBillEvidence): string {
+  const special = evidence.follow.special ? "；特别关注" : "";
+  const memorySignals = evidence.follow.memorySignals?.length
+    ? `；关注记忆信号：${followMemorySignalsCopy(evidence.follow.memorySignals)}`
+    : "";
+  return `${followShortCopy(evidence)}${special}${memorySignals}。`;
+}
+
+function followShortCopy(evidence: DynamicBillEvidence): string {
+  if (evidence.follow.followAgeDays !== undefined) {
+    return `已关注约 ${evidence.follow.followAgeDays} 天`;
+  }
+  return "已关注，关注时长未知";
+}
+
+function followMemorySignalsCopy(signals: NonNullable<DynamicBillEvidence["follow"]["memorySignals"]>): string {
+  return signals.map((signal) => {
+    switch (signal) {
+      case "long_follow":
+        return "长期关注";
+      case "special_follow":
+        return "特别关注";
+      case "weak_watch":
+        return "历史弱观看";
+      default:
+        return signal;
+    }
+  }).join("、");
 }
 
 function interestKindLabel(kind: "category" | "tag"): string {

--- a/src/background/dynamic-bill/buried-follow.ts
+++ b/src/background/dynamic-bill/buried-follow.ts
@@ -1,4 +1,5 @@
 import type {
+  DynamicBillFollowMemorySignal,
   DynamicBillGenerateResult,
   DynamicBillItem,
   DynamicBillWindowEvidence,
@@ -16,7 +17,7 @@ import {
 import { DYNAMIC_BILL_STRATEGY, getDynamicBillThresholdEvidence } from './strategy';
 
 const SECONDS_PER_DAY = 86_400;
-const AFK_UPDATE_COLUMN = 'afk_update';
+const BURIED_FOLLOW_COLUMN = 'buried_follow';
 
 interface CreatorWindowStats extends DynamicBillWindowEvidence {
   records: WatchHistoryRecord[];
@@ -29,11 +30,14 @@ interface Candidate {
   recentStats: CreatorWindowStats;
   cooldownRatio: number;
   daysSinceLastWatch: number | null;
-  score: number;
+  followAgeDays?: number;
+  memorySignals: DynamicBillFollowMemorySignal[];
+  historicalWeakWatchCount: number;
   historyBvids: string[];
+  score: number;
 }
 
-export async function generateAfkUpdateBillItems(): Promise<DynamicBillGenerateResult> {
+export async function generateBuriedFollowBillItems(): Promise<DynamicBillGenerateResult> {
   const generatedAt = Date.now();
   const nowSeconds = Math.floor(generatedAt / 1000);
   const thresholds = getDynamicBillThresholdEvidence();
@@ -86,50 +90,53 @@ export async function generateAfkUpdateBillItems(): Promise<DynamicBillGenerateR
       longCutoff,
       nowSeconds,
     );
-    if (longStats.positiveWatchCount < DYNAMIC_BILL_STRATEGY.minCreatorPositiveViews) {
-      excludedNoLongSignalCount++;
-      continue;
-    }
-
     const recentStats = buildWindowStats(
       creatorRecords.filter(record => record.viewAt >= recentCutoff),
       DYNAMIC_BILL_STRATEGY.recentWindowDays,
       recentCutoff,
       nowSeconds,
     );
-    const expectedRecentPositive = longStats.positiveWatchCount
-      * (DYNAMIC_BILL_STRATEGY.recentWindowDays / DYNAMIC_BILL_STRATEGY.longWindowDays);
-    const recentPositiveLimit = Math.floor(expectedRecentPositive * DYNAMIC_BILL_STRATEGY.recentCooldownRatio);
-    if (recentStats.positiveWatchCount > recentPositiveLimit) {
+
+    if (
+      recentStats.watchedCount > DYNAMIC_BILL_STRATEGY.maxBuriedRecentWatchCount
+      || recentStats.positiveWatchCount > DYNAMIC_BILL_STRATEGY.maxBuriedRecentPositiveWatchCount
+    ) {
       excludedRecentActiveCount++;
+      continue;
+    }
+
+    const followAgeDays = getFollowAgeDays(creator, nowSeconds);
+    const historicalWeakWatchCount = creatorRecords.filter(record => record.viewAt < recentCutoff).length;
+    const memorySignals = buildMemorySignals(creator, followAgeDays, historicalWeakWatchCount);
+    if (memorySignals.length === 0) {
+      excludedNoLongSignalCount++;
       continue;
     }
 
     const daysSinceLastWatch = longStats.lastWatchedAt > 0
       ? Math.floor((nowSeconds - longStats.lastWatchedAt) / SECONDS_PER_DAY)
       : null;
-    const cooldownRatio = expectedRecentPositive > 0
-      ? recentStats.positiveWatchCount / expectedRecentPositive
+    const cooldownRatio = DYNAMIC_BILL_STRATEGY.maxBuriedRecentWatchCount > 0
+      ? recentStats.watchedCount / DYNAMIC_BILL_STRATEGY.maxBuriedRecentWatchCount
       : 0;
     const historyBvids = selectHistoryHighlights(creatorRecords, update.bvid, recentCutoff);
 
-    candidates.push({
+    const candidate: Omit<Candidate, 'score'> = {
       creator,
       update,
       longStats,
       recentStats,
       cooldownRatio,
       daysSinceLastWatch,
+      followAgeDays,
+      memorySignals,
+      historicalWeakWatchCount,
       historyBvids,
-      score: scoreCandidate({
-        creator,
-        update,
-        longStats,
-        recentStats,
-        cooldownRatio,
-        daysSinceLastWatch,
-        historyBvids,
-      }, nowSeconds),
+    };
+
+    candidates.push({
+      ...candidate,
+      score: scoreCandidate(candidate, nowSeconds),
     });
   }
 
@@ -138,7 +145,7 @@ export async function generateAfkUpdateBillItems(): Promise<DynamicBillGenerateR
     .slice(0, DYNAMIC_BILL_STRATEGY.maxItemsPerColumn)
     .map((candidate, index) => toBillItem(candidate, index + 1, generatedAt));
 
-  const storedItems = await replaceDynamicBillItemsForColumn(AFK_UPDATE_COLUMN, items);
+  const storedItems = await replaceDynamicBillItemsForColumn(BURIED_FOLLOW_COLUMN, items);
   const overview = await getDynamicBillOverview(DYNAMIC_BILL_STRATEGY.updateWindowDays);
 
   return {
@@ -150,14 +157,14 @@ export async function generateAfkUpdateBillItems(): Promise<DynamicBillGenerateR
     excludedRecentActiveCount,
     excludedRecentSameVideoCount,
     columnItemCounts: {
-      afk_update: storedItems.length,
+      afk_update: 0,
       variety: 0,
-      buried_follow: 0,
+      buried_follow: storedItems.length,
     },
     columnEligibleCounts: {
-      afk_update: candidates.length,
+      afk_update: 0,
       variety: 0,
-      buried_follow: 0,
+      buried_follow: candidates.length,
     },
     items: storedItems,
     thresholds,
@@ -201,6 +208,24 @@ function buildWindowStats(
     lastWatchedAt,
     records,
   };
+}
+
+function buildMemorySignals(
+  creator: FollowedCreator,
+  followAgeDays: number | undefined,
+  historicalWeakWatchCount: number,
+): DynamicBillFollowMemorySignal[] {
+  const signals: DynamicBillFollowMemorySignal[] = [];
+  if (followAgeDays !== undefined && followAgeDays >= DYNAMIC_BILL_STRATEGY.minBuriedFollowAgeDays) {
+    signals.push('long_follow');
+  }
+  if (creator.special) {
+    signals.push('special_follow');
+  }
+  if (historicalWeakWatchCount >= DYNAMIC_BILL_STRATEGY.minBuriedWeakWatchCount) {
+    signals.push('weak_watch');
+  }
+  return signals;
 }
 
 function isPositiveWatch(record: WatchHistoryRecord): boolean {
@@ -247,30 +272,28 @@ function selectHistoryHighlights(
 }
 
 function scoreCandidate(candidate: Omit<Candidate, 'score'>, nowSeconds: number): number {
-  const followAgeDays = getFollowAgeDays(candidate.creator, nowSeconds) ?? 0;
   const updateAgeDays = Math.max(0, (nowSeconds - candidate.update.dynamicTime) / SECONDS_PER_DAY);
-  const watchStrength = candidate.longStats.positiveWatchCount * 10
-    + Math.min(candidate.longStats.totalWatchTimeSeconds / 3600, 12)
-    + candidate.longStats.avgCompletion * 8;
-  const cooldownStrength = (1 - Math.min(candidate.cooldownRatio, 1)) * 18
-    + Math.min(candidate.daysSinceLastWatch ?? DYNAMIC_BILL_STRATEGY.longWindowDays, 90) / 6;
-  const followAgeBoost = Math.min(followAgeDays / 365, 1) * 4;
+  const followAgeStrength = candidate.followAgeDays !== undefined
+    ? Math.min(candidate.followAgeDays / 365, 4) * 5
+    : 0;
+  const specialBoost = candidate.creator.special ? 10 : 0;
+  const weakHistoryBoost = Math.min(candidate.historicalWeakWatchCount, 3) * 3
+    + Math.min(candidate.longStats.totalWatchTimeSeconds / 3600, 3);
+  const absenceBoost = candidate.recentStats.watchedCount === 0 ? 8 : 3;
   const freshnessBoost = Math.max(0, DYNAMIC_BILL_STRATEGY.updateWindowDays - updateAgeDays)
     / DYNAMIC_BILL_STRATEGY.updateWindowDays
-    * 3;
+    * 5;
 
-  return Math.round((watchStrength + cooldownStrength + followAgeBoost + freshnessBoost) * 100) / 100;
+  return Math.round((followAgeStrength + specialBoost + weakHistoryBoost + absenceBoost + freshnessBoost) * 100) / 100;
 }
 
 function toBillItem(candidate: Candidate, localRank: number, generatedAt: number): DynamicBillItem {
-  const nowSeconds = Math.floor(generatedAt / 1000);
-  const followAgeDays = getFollowAgeDays(candidate.creator, nowSeconds);
   const thresholds = getDynamicBillThresholdEvidence();
-  const facts = buildFacts(candidate, followAgeDays);
+  const facts = buildFacts(candidate);
 
   return {
-    billKey: `${AFK_UPDATE_COLUMN}:${candidate.update.updateKey}`,
-    column: AFK_UPDATE_COLUMN,
+    billKey: `${BURIED_FOLLOW_COLUMN}:${candidate.update.updateKey}`,
+    column: BURIED_FOLLOW_COLUMN,
     status: 'unopened',
     updateKey: candidate.update.updateKey,
     creatorMid: candidate.creator.mid,
@@ -281,7 +304,7 @@ function toBillItem(candidate: Candidate, localRank: number, generatedAt: number
     score: candidate.score,
     generatedAt,
     evidence: {
-      kind: AFK_UPDATE_COLUMN,
+      kind: BURIED_FOLLOW_COLUMN,
       longWindow: stripRecords(candidate.longStats),
       recentWindow: stripRecords(candidate.recentStats),
       newVideo: {
@@ -300,9 +323,11 @@ function toBillItem(candidate: Candidate, localRank: number, generatedAt: number
       follow: {
         followedAt: candidate.creator.followedAt,
         followAgeKnown: candidate.creator.followAgeKnown,
-        followAgeDays,
+        followAgeDays: candidate.followAgeDays,
+        special: candidate.creator.special,
+        memorySignals: candidate.memorySignals,
       },
-      cooldownRatio: Math.round(candidate.cooldownRatio * 100) / 100,
+      cooldownRatio: roundRatio(candidate.cooldownRatio),
       daysSinceLastWatch: candidate.daysSinceLastWatch,
       facts,
       thresholds,
@@ -310,26 +335,42 @@ function toBillItem(candidate: Candidate, localRank: number, generatedAt: number
   };
 }
 
-function buildFacts(candidate: Candidate, followAgeDays?: number): string[] {
-  const long = candidate.longStats;
+function buildFacts(candidate: Candidate): string[] {
   const recent = candidate.recentStats;
+  const followFact = candidate.followAgeDays !== undefined
+    ? `关注关系证据：已关注约 ${candidate.followAgeDays} 天${candidate.creator.special ? '，且为特别关注' : ''}。`
+    : `关注关系证据：已关注，关注时长未知${candidate.creator.special ? '，且为特别关注' : ''}。`;
   const facts = [
-    `长期 ${long.windowDays} 天内观看 ${long.watchedCount} 次，正反馈 ${long.positiveWatchCount} 次，平均完成度 ${formatPercent(long.avgCompletion)}。`,
-    `近期 ${recent.windowDays} 天内观看 ${recent.watchedCount} 次，正反馈 ${recent.positiveWatchCount} 次，冷却比 ${formatPercent(candidate.cooldownRatio)}。`,
-    `最近 ${DYNAMIC_BILL_STRATEGY.updateWindowDays} 天有新投稿《${candidate.update.title || candidate.update.bvid}》。`,
+    followFact,
+    `关注记忆信号：${formatMemorySignals(candidate.memorySignals)}；入选至少需要长期关注、特别关注或近期窗口以前 ${DYNAMIC_BILL_STRATEGY.minBuriedWeakWatchCount} 次弱观看之一。`,
+    `近期缺席证据：最近 ${recent.windowDays} 天观看 ${recent.watchedCount} 次、正反馈 ${recent.positiveWatchCount} 次；规则要求观看不超过 ${DYNAMIC_BILL_STRATEGY.maxBuriedRecentWatchCount} 次且正反馈为 ${DYNAMIC_BILL_STRATEGY.maxBuriedRecentPositiveWatchCount} 次。`,
+    `新投稿证据：最近 ${DYNAMIC_BILL_STRATEGY.updateWindowDays} 天，已关注 UP「${candidate.creator.name || candidate.update.authorName}」发布《${candidate.update.title || candidate.update.bvid}》。`,
     `本地最近 ${DYNAMIC_BILL_STRATEGY.recentSameVideoWindowDays} 天未发现同一新视频 ${candidate.update.bvid} 的观看记录。`,
+    '入选只使用本地关注快照、观看历史聚合和最近投稿元数据，不接 AI，也不上传完整历史或完整关注列表。',
   ];
 
   if (candidate.daysSinceLastWatch !== null) {
-    facts.push(`距上次观看该 UP 已约 ${candidate.daysSinceLastWatch} 天。`);
-  }
-  if (followAgeDays !== undefined) {
-    facts.push(`已关注约 ${followAgeDays} 天；该信息只参与排序加权，不单独决定入选。`);
+    facts.push(`距上次观看该 UP 已约 ${candidate.daysSinceLastWatch} 天；本栏目不要求达到久违更新的强历史正反馈阈值。`);
   } else {
-    facts.push('关注时间未知；入选不依赖关注时长。');
+    facts.push('本地长期窗口未发现该 UP 的观看记录；本项由关注关系记忆信号支撑，而不是强历史观看正反馈。');
   }
 
   return facts;
+}
+
+function formatMemorySignals(signals: DynamicBillFollowMemorySignal[]): string {
+  return signals.map(signal => {
+    switch (signal) {
+      case 'long_follow':
+        return `已关注不少于 ${DYNAMIC_BILL_STRATEGY.minBuriedFollowAgeDays} 天`;
+      case 'special_follow':
+        return '特别关注';
+      case 'weak_watch':
+        return '近期窗口以前有本地弱观看';
+      default:
+        return signal;
+    }
+  }).join('、');
 }
 
 function stripRecords(stats: CreatorWindowStats): DynamicBillWindowEvidence {
@@ -342,8 +383,8 @@ function getFollowAgeDays(creator: FollowedCreator, nowSeconds: number): number 
   return Math.max(0, Math.floor((nowSeconds - creator.followedAt) / SECONDS_PER_DAY));
 }
 
-function formatPercent(value: number): string {
-  return `${Math.round(value * 100)}%`;
+function roundRatio(value: number): number {
+  return Math.round(value * 100) / 100;
 }
 
 function clamp01(value: number): number {

--- a/src/background/dynamic-bill/generator.ts
+++ b/src/background/dynamic-bill/generator.ts
@@ -1,5 +1,6 @@
 import type { DynamicBillGenerateResult } from '../../shared/types/dynamic-bill';
 import { getDynamicBillOverview, getDynamicBillItems } from '../storage/dynamic-bill-repo';
+import { generateBuriedFollowBillItems } from './buried-follow';
 import { generateAfkUpdateBillItems } from './rules';
 import { DYNAMIC_BILL_STRATEGY, getDynamicBillThresholdEvidence } from './strategy';
 import { generateVarietyBillItems } from './variety';
@@ -7,28 +8,47 @@ import { generateVarietyBillItems } from './variety';
 export async function generateDynamicBillItems(): Promise<DynamicBillGenerateResult> {
   const afkResult = await generateAfkUpdateBillItems();
   const varietyResult = await generateVarietyBillItems();
+  const buriedFollowResult = await generateBuriedFollowBillItems();
   const items = await getDynamicBillItems();
   const overview = await getDynamicBillOverview(DYNAMIC_BILL_STRATEGY.updateWindowDays);
-  const generatedAt = Math.max(afkResult.generatedAt, varietyResult.generatedAt);
+  const generatedAt = Math.max(
+    afkResult.generatedAt,
+    varietyResult.generatedAt,
+    buriedFollowResult.generatedAt,
+  );
 
   return {
     generatedAt,
     itemCount: items.length,
-    candidatesScanned: afkResult.candidatesScanned + varietyResult.candidatesScanned,
-    eligibleCreatorCount: afkResult.eligibleCreatorCount + varietyResult.eligibleCreatorCount,
+    candidatesScanned:
+      afkResult.candidatesScanned
+      + varietyResult.candidatesScanned
+      + buriedFollowResult.candidatesScanned,
+    eligibleCreatorCount:
+      afkResult.eligibleCreatorCount
+      + varietyResult.eligibleCreatorCount
+      + buriedFollowResult.eligibleCreatorCount,
     excludedNoLongSignalCount:
-      afkResult.excludedNoLongSignalCount + varietyResult.excludedNoLongSignalCount,
+      afkResult.excludedNoLongSignalCount
+      + varietyResult.excludedNoLongSignalCount
+      + buriedFollowResult.excludedNoLongSignalCount,
     excludedRecentActiveCount:
-      afkResult.excludedRecentActiveCount + varietyResult.excludedRecentActiveCount,
+      afkResult.excludedRecentActiveCount
+      + varietyResult.excludedRecentActiveCount
+      + buriedFollowResult.excludedRecentActiveCount,
     excludedRecentSameVideoCount:
-      afkResult.excludedRecentSameVideoCount + varietyResult.excludedRecentSameVideoCount,
+      afkResult.excludedRecentSameVideoCount
+      + varietyResult.excludedRecentSameVideoCount
+      + buriedFollowResult.excludedRecentSameVideoCount,
     columnItemCounts: {
       afk_update: afkResult.columnItemCounts.afk_update,
       variety: varietyResult.columnItemCounts.variety,
+      buried_follow: buriedFollowResult.columnItemCounts.buried_follow,
     },
     columnEligibleCounts: {
       afk_update: afkResult.columnEligibleCounts.afk_update,
       variety: varietyResult.columnEligibleCounts.variety,
+      buried_follow: buriedFollowResult.columnEligibleCounts.buried_follow,
     },
     items,
     thresholds: getDynamicBillThresholdEvidence(),

--- a/src/background/dynamic-bill/strategy.ts
+++ b/src/background/dynamic-bill/strategy.ts
@@ -13,6 +13,10 @@ export const DYNAMIC_BILL_STRATEGY = {
   positiveCompletionRate: 0.5,
   minPositiveWatchSeconds: 180,
   recentCooldownRatio: 0.5,
+  minBuriedFollowAgeDays: 180,
+  minBuriedWeakWatchCount: 1,
+  maxBuriedRecentWatchCount: 1,
+  maxBuriedRecentPositiveWatchCount: 0,
   maxHighlightsPerItem: 3,
   maxItemsPerColumn: 20,
 } as const;
@@ -30,5 +34,9 @@ export function getDynamicBillThresholdEvidence(): DynamicBillThresholdEvidence 
     positiveCompletionRate: DYNAMIC_BILL_STRATEGY.positiveCompletionRate,
     minPositiveWatchSeconds: DYNAMIC_BILL_STRATEGY.minPositiveWatchSeconds,
     recentCooldownRatio: DYNAMIC_BILL_STRATEGY.recentCooldownRatio,
+    minBuriedFollowAgeDays: DYNAMIC_BILL_STRATEGY.minBuriedFollowAgeDays,
+    minBuriedWeakWatchCount: DYNAMIC_BILL_STRATEGY.minBuriedWeakWatchCount,
+    maxBuriedRecentWatchCount: DYNAMIC_BILL_STRATEGY.maxBuriedRecentWatchCount,
+    maxBuriedRecentPositiveWatchCount: DYNAMIC_BILL_STRATEGY.maxBuriedRecentPositiveWatchCount,
   };
 }

--- a/src/background/dynamic-bill/variety.ts
+++ b/src/background/dynamic-bill/variety.ts
@@ -167,10 +167,12 @@ export async function generateVarietyBillItems(): Promise<DynamicBillGenerateRes
     columnItemCounts: {
       afk_update: 0,
       variety: storedItems.length,
+      buried_follow: 0,
     },
     columnEligibleCounts: {
       afk_update: 0,
       variety: candidates.length,
+      buried_follow: 0,
     },
     items: storedItems,
     thresholds,

--- a/src/shared/types/dynamic-bill.ts
+++ b/src/shared/types/dynamic-bill.ts
@@ -34,9 +34,10 @@ export interface FollowedVideoUpdate {
   syncedAt: number;
 }
 
-export type DynamicBillColumn = 'afk_update' | 'variety';
+export type DynamicBillColumn = 'afk_update' | 'variety' | 'buried_follow';
 export type DynamicBillStatus = 'unopened' | 'opened' | 'consumed' | 'processed';
 export type DynamicBillInterestKind = 'category' | 'tag';
+export type DynamicBillFollowMemorySignal = 'long_follow' | 'special_follow' | 'weak_watch';
 
 export type DynamicSyncStatus = 'idle' | 'syncing' | 'success' | 'not_logged_in' | 'failed';
 export type DynamicSyncStage = 'idle' | 'following' | 'dynamic-feed' | 'video-detail' | 'storage' | 'complete';
@@ -112,6 +113,8 @@ export interface DynamicBillFollowEvidence {
   followedAt?: number;
   followAgeKnown: boolean;
   followAgeDays?: number;
+  special?: boolean;
+  memorySignals?: DynamicBillFollowMemorySignal[];
 }
 
 export interface DynamicBillThresholdEvidence {
@@ -126,6 +129,10 @@ export interface DynamicBillThresholdEvidence {
   positiveCompletionRate: number;
   minPositiveWatchSeconds: number;
   recentCooldownRatio: number;
+  minBuriedFollowAgeDays: number;
+  minBuriedWeakWatchCount: number;
+  maxBuriedRecentWatchCount: number;
+  maxBuriedRecentPositiveWatchCount: number;
 }
 
 export interface DynamicBillInterestEvidence {


### PR DESCRIPTION
Closes #7

## What changed

- Adds the `buried_follow` dynamic bill column from the current `codex/bili-bill-vnext` base.
- Wires `buried_follow` into the shared `GENERATE_DYNAMIC_BILL` generator and existing `dynamicBillItems` storage flow.
- Reuses `DynamicBillItem`, local evidence facts, and the Dashboard board/detail layout.
- Enables three coexisting Dashboard columns: 久违更新 / 换换口味 / 被淹没的关注.

## Local rules and thresholds

`buried_follow` selects only followed creators with a recent followed-video update. A candidate must satisfy all of these local rules:

- Active followed UP snapshot exists.
- Recent video submission exists in `updateWindowDays = 7`.
- Same new video is absent from local watch history within `recentSameVideoWindowDays = 30`.
- Recent absence or near-absence: within `recentWindowDays = 30`, watched count must be `<= 1` and positive watch count must be `0`.
- At least one follow-memory signal is required: known follow age `>= 180` days, special follow, or at least `1` weak local watch before the recent window.

This intentionally does not require the strong historical positive-watch signal used by 久违更新. Positive-watch thresholds remain local: completion `>= 50%`, watch progress `>= 180s`, or favorited.

## Evidence fields

Each generated item stores and displays:

- `evidence.follow`: `followedAt`, `followAgeKnown`, optional `followAgeDays`, `special`, and `memorySignals`.
- `evidence.recentWindow`: recent watched/positive counts for the absence rule.
- `evidence.newVideo`: update key, dynamic id, bvid/avid, title, cover, duration, pubtime/dynamic time, category/tags.
- `evidence.thresholds`: includes the new buried-follow thresholds.
- `evidence.facts`: explicit follow relationship evidence, recent absence evidence, new submission evidence, same-video exclusion, and privacy boundary copy.

When follow age is unavailable, the Dashboard displays `已关注，关注时长未知` and does not synthesize a fake duration.

## Scope kept out

- No #8 state advancement or persisted filter work.
- No multi-negative-feedback accumulation.
- No unfollow prompt or Bilibili relationship writeback; repeated negative feedback and unfollow prompt remain for #9.
- No AI call, no AI payload, and no upload of full watch history or full follow list.

## Validation

- `git diff --check` passed.
- `npm run typecheck` passed.
- `npm run build` passed. Vite still reports the existing large chunk warning for `chunks/theme-*.js`.
- Browser mock QA passed at `http://127.0.0.1:4178/dashboard/index.html#dynamic-bill`:
  - three columns coexisted with mock counts `1 / 1 / 2`;
  - only the four expected status labels appeared: 未打开 / 已打开 / 已消费 / 已处理;
  - `buried_follow` known follow-age detail showed `已关注约 1200 天`;
  - `buried_follow` unknown follow-age detail showed `已关注，关注时长未知`;
  - recent absence, new submission, and rule-threshold evidence were visible in detail;
  - Browser console warn/error logs were empty.

## Clean PR check

- Branch base is current `origin/codex/bili-bill-vnext` at `7cb493a221fb2e66df457c12bc08643d7b3c4246`.
- `origin/codex/bili-bill-vnext..HEAD` contains one commit: `a8dc601 Implement buried follow dynamic bill`.
- Diff is limited to #7 files: buried-follow generator, shared generator counts, type/threshold extension, and Dashboard three-column/evidence copy.

## Remaining risk

- Real account data may need threshold tuning for enough but not noisy `buried_follow` results.
- Follow age still depends on the Bilibili `mtime` candidate field; the unknown-age fallback remains necessary.
- Browser QA used local mock data for buried-follow edge cases, not a fresh real-account generation pass.