### PR TITLE
[codex] Implement dynamic bill state flow

### DIFF
--- a/dashboard/modules/dynamic-bill/DynamicBillPage.tsx
+++ b/dashboard/modules/dynamic-bill/DynamicBillPage.tsx
@@ -1,21 +1,24 @@
 import { useEffect, useMemo, useState } from "preact/hooks";
 import type {
   DynamicBillColumn,
+  DynamicBillFilterPreference,
   DynamicBillGenerateResult,
   DynamicBillEvidence,
   DynamicBillItem,
   DynamicBillOverview,
   DynamicBillStatus,
+  DynamicBillStatusFilter,
   DynamicSyncResult,
   DynamicSyncStatus,
 } from "../../../src/shared/types/dynamic-bill";
 import { requestSW } from "../../utils/messaging";
 
 const STATUS_FILTERS: Array<{
-  key: DynamicBillStatus;
+  key: DynamicBillStatusFilter;
   label: string;
   detail: string;
 }> = [
+  { key: "active", label: "待查看", detail: "优先展示未打开和已打开，不包含已消费或已处理" },
   { key: "unopened", label: "未打开", detail: "尚未从动态账单打开新投稿" },
   { key: "opened", label: "已打开", detail: "打开过，但尚未确认有效观看" },
   { key: "consumed", label: "已消费", detail: "由观看历史或播放器事件确认" },
@@ -53,15 +56,16 @@ const BILL_COLUMNS = [
 type BillColumnKey = (typeof BILL_COLUMNS)[number]["key"];
 
 export function DynamicBillPage() {
-  const [status, setStatus] = useState<DynamicBillStatus>("unopened");
+  const [statusFilter, setStatusFilter] = useState<DynamicBillStatusFilter>("active");
   const [overview, setOverview] = useState<DynamicBillOverview | null>(null);
   const [items, setItems] = useState<DynamicBillItem[]>([]);
   const [selectedBillKey, setSelectedBillKey] = useState("");
   const [syncing, setSyncing] = useState(false);
   const [generating, setGenerating] = useState(false);
+  const [processingBillKey, setProcessingBillKey] = useState("");
   const [notice, setNotice] = useState("");
   const activeStatus =
-    STATUS_FILTERS.find((item) => item.key === status) ?? STATUS_FILTERS[0];
+    STATUS_FILTERS.find((item) => item.key === statusFilter) ?? STATUS_FILTERS[0];
   const syncState = overview?.syncState;
   const isSyncing = syncing || syncState?.status === "syncing";
   const overviewNotice = overview
@@ -80,8 +84,8 @@ export function DynamicBillPage() {
     [items],
   );
   const visibleItems = useMemo(
-    () => items.filter((item) => item.status === status),
-    [items, status],
+    () => items.filter((item) => matchesStatusFilter(item, statusFilter)),
+    [items, statusFilter],
   );
   const selectedItem =
     visibleItems.find((item) => item.billKey === selectedBillKey) ??
@@ -90,6 +94,9 @@ export function DynamicBillPage() {
   const statusCounts = useMemo(() => countByStatus(items), [items]);
 
   useEffect(() => {
+    refreshFilterPreference().catch((error) => {
+      setNotice(`读取筛选偏好失败：${describeError(error)}`);
+    });
     refreshOverview().catch((error) => {
       setNotice(`读取动态账单状态失败：${describeError(error)}`);
     });
@@ -98,6 +105,12 @@ export function DynamicBillPage() {
     });
   }, []);
 
+  useEffect(() => {
+    setSelectedBillKey((current) =>
+      chooseSelectedBillKey(current, items, statusFilter),
+    );
+  }, [items, statusFilter]);
+
   async function refreshOverview() {
     const next = await requestSW<DynamicBillOverview>(
       "GET_DYNAMIC_BILL_OVERVIEW",
@@ -105,13 +118,18 @@ export function DynamicBillPage() {
     setOverview(next);
   }
 
+  async function refreshFilterPreference() {
+    const preference = await requestSW<DynamicBillFilterPreference>(
+      "GET_DYNAMIC_BILL_FILTER",
+    );
+    setStatusFilter(preference.status);
+  }
+
   async function refreshBillItems() {
     const next = await requestSW<DynamicBillItem[]>("GET_DYNAMIC_BILL_ITEMS");
     setItems(next);
     setSelectedBillKey((current) =>
-      current && next.some((item) => item.billKey === current)
-        ? current
-        : next[0]?.billKey ?? "",
+      chooseSelectedBillKey(current, next, statusFilter),
     );
   }
 
@@ -122,11 +140,55 @@ export function DynamicBillPage() {
     setOverview(result.overview);
     setItems(result.items);
     setSelectedBillKey((current) =>
-      current && result.items.some((item) => item.billKey === current)
-        ? current
-        : result.items[0]?.billKey ?? "",
+      chooseSelectedBillKey(current, result.items, statusFilter),
     );
     return result;
+  }
+
+  async function handleStatusFilterChange(nextStatus: DynamicBillStatusFilter) {
+    setStatusFilter(nextStatus);
+    setSelectedBillKey((current) =>
+      chooseSelectedBillKey(current, items, nextStatus),
+    );
+    try {
+      await requestSW<DynamicBillFilterPreference>("UPDATE_DYNAMIC_BILL_FILTER", {
+        status: nextStatus,
+      });
+    } catch (error) {
+      setNotice(`保存筛选偏好失败：${describeError(error)}`);
+    }
+  }
+
+  async function handleOpenVideo(item: DynamicBillItem) {
+    setProcessingBillKey(item.billKey);
+    setNotice("");
+    try {
+      await requestSW<DynamicBillItem>("OPEN_DYNAMIC_BILL_VIDEO", {
+        billKey: item.billKey,
+      });
+      await refreshBillItems();
+      setNotice(`已打开《${item.evidence.newVideo.title || item.evidence.newVideo.bvid}》，账单状态推进为已打开。`);
+    } catch (error) {
+      setNotice(`打开新视频失败：${describeError(error)}`);
+    } finally {
+      setProcessingBillKey("");
+    }
+  }
+
+  async function handleMarkProcessed(item: DynamicBillItem) {
+    setProcessingBillKey(item.billKey);
+    setNotice("");
+    try {
+      await requestSW<DynamicBillItem>("MARK_DYNAMIC_BILL_ITEM_PROCESSED", {
+        billKey: item.billKey,
+      });
+      await refreshBillItems();
+      setNotice(`已将「${item.creatorName}」标记为已处理；该动作不等同于已消费。`);
+    } catch (error) {
+      setNotice(`标记已处理失败：${describeError(error)}`);
+    } finally {
+      setProcessingBillKey("");
+    }
   }
 
   async function handleGenerate() {
@@ -240,7 +302,7 @@ export function DynamicBillPage() {
       >
         <strong>{notice || overviewNotice}</strong>
         <span>
-          本切片启用三类本地证据栏目；状态推进和筛选持久化留给 #8，负反馈累计、topic 降低和取关提示留给 #9 闭环。
+          本切片启用三类本地证据栏目；状态只会从未打开向已打开、已消费、已处理推进。负反馈累计、topic 降低和取关提示留给 #9 闭环。
         </span>
       </section>
 
@@ -249,8 +311,10 @@ export function DynamicBillPage() {
           <button
             key={item.key}
             type="button"
-            className={status === item.key ? "is-selected" : ""}
-            onClick={() => setStatus(item.key)}
+            className={statusFilter === item.key ? "is-selected" : ""}
+            aria-pressed={statusFilter === item.key}
+            data-testid={`dynamic-bill-filter-${item.key}`}
+            onClick={() => handleStatusFilterChange(item.key)}
           >
             <span>{item.label}</span>
             <strong>{statusCounts[item.key] ?? 0}</strong>
@@ -284,7 +348,12 @@ export function DynamicBillPage() {
                     <h3>{column.title}</h3>
                     <p>{column.detail}</p>
                   </div>
-                  <span>{columnCount}</span>
+                  <span
+                    title={`${activeStatus.label} ${columnItems.length} / 全部 ${columnCount}`}
+                    data-testid={`dynamic-bill-column-count-${column.key}`}
+                  >
+                    {columnItems.length}/{columnCount}
+                  </span>
                 </div>
                 {columnItems.length > 0 ? (
                   <div className="dynamic-bill-item-list">
@@ -297,6 +366,7 @@ export function DynamicBillPage() {
                             : ""
                         }`}
                         key={item.billKey}
+                        data-testid="dynamic-bill-item-card"
                         onClick={() => setSelectedBillKey(item.billKey)}
                       >
                         <span className="dynamic-bill-card-meta">
@@ -325,7 +395,12 @@ export function DynamicBillPage() {
 
         <aside className="dynamic-bill-detail" aria-label="账单项详情">
           {selectedItem ? (
-            <BillItemDetail item={selectedItem} />
+            <BillItemDetail
+              item={selectedItem}
+              busy={processingBillKey === selectedItem.billKey}
+              onMarkProcessed={handleMarkProcessed}
+              onOpenVideo={handleOpenVideo}
+            />
           ) : (
             <EmptyDetail status={activeStatus} />
           )}
@@ -335,9 +410,20 @@ export function DynamicBillPage() {
   );
 }
 
-function BillItemDetail({ item }: { item: DynamicBillItem }) {
+function BillItemDetail({
+  busy,
+  item,
+  onMarkProcessed,
+  onOpenVideo,
+}: {
+  busy: boolean;
+  item: DynamicBillItem;
+  onMarkProcessed: (item: DynamicBillItem) => void;
+  onOpenVideo: (item: DynamicBillItem) => void;
+}) {
   const evidence = item.evidence;
   const isBuriedFollow = evidence.kind === "buried_follow";
+  const isProcessed = item.status === "processed";
   return (
     <>
       <span className="dynamic-bill-kicker">
@@ -347,6 +433,10 @@ function BillItemDetail({ item }: { item: DynamicBillItem }) {
       <p>
         新投稿：{evidence.newVideo.title || evidence.newVideo.bvid}
       </p>
+      <div className="dynamic-bill-status-copy">
+        <strong>处理状态</strong>
+        <span>{statusFlowCopy(item)}</span>
+      </div>
       <div className="dynamic-bill-status-copy">
         <strong>关注关系证据</strong>
         <span>{followEvidenceCopy(evidence)}</span>
@@ -408,9 +498,23 @@ function BillItemDetail({ item }: { item: DynamicBillItem }) {
         </span>
       </div>
       <div className="dynamic-bill-action-grid">
-        <a href={videoUrl(evidence.newVideo.bvid)} target="_blank" rel="noreferrer">
+        <button
+          type="button"
+          className="is-primary"
+          disabled={busy}
+          data-testid="dynamic-bill-open-video"
+          onClick={() => onOpenVideo(item)}
+        >
           打开新视频
-        </a>
+        </button>
+        <button
+          type="button"
+          disabled={busy || isProcessed}
+          data-testid="dynamic-bill-mark-processed"
+          onClick={() => onMarkProcessed(item)}
+        >
+          {isProcessed ? "已处理" : "标记已处理"}
+        </button>
         <a href={spaceUrl(item.creatorMid)} target="_blank" rel="noreferrer">
           打开 UP 主页
         </a>
@@ -422,7 +526,7 @@ function BillItemDetail({ item }: { item: DynamicBillItem }) {
 function EmptyDetail({
   status,
 }: {
-  status: { key: DynamicBillStatus; label: string; detail: string };
+  status: { key: DynamicBillStatusFilter; label: string; detail: string };
 }) {
   return (
     <>
@@ -631,10 +735,31 @@ function interestKindLabel(kind: "category" | "tag"): string {
   return kind === "category" ? "分区" : "标签";
 }
 
-function countByStatus(items: DynamicBillItem[]): Record<DynamicBillStatus, number> {
+function matchesStatusFilter(item: DynamicBillItem, statusFilter: DynamicBillStatusFilter): boolean {
+  if (statusFilter === "active") {
+    return item.status === "unopened" || item.status === "opened";
+  }
+  return item.status === statusFilter;
+}
+
+function chooseSelectedBillKey(
+  current: string,
+  items: DynamicBillItem[],
+  statusFilter: DynamicBillStatusFilter,
+): string {
+  const visible = items.filter((item) => matchesStatusFilter(item, statusFilter));
+  return current && visible.some((item) => item.billKey === current)
+    ? current
+    : visible[0]?.billKey ?? "";
+}
+
+function countByStatus(items: DynamicBillItem[]): Record<DynamicBillStatusFilter, number> {
+  const unopened = items.filter((item) => item.status === "unopened").length;
+  const opened = items.filter((item) => item.status === "opened").length;
   return {
-    unopened: items.filter((item) => item.status === "unopened").length,
-    opened: items.filter((item) => item.status === "opened").length,
+    active: unopened + opened,
+    unopened,
+    opened,
     consumed: items.filter((item) => item.status === "consumed").length,
     processed: items.filter((item) => item.status === "processed").length,
   };
@@ -661,8 +786,13 @@ function statusLabel(status: DynamicBillStatus): string {
   return STATUS_FILTERS.find((item) => item.key === status)?.label ?? "未打开";
 }
 
-function videoUrl(bvid: string): string {
-  return `https://www.bilibili.com/video/${encodeURIComponent(bvid)}`;
+function statusFlowCopy(item: DynamicBillItem): string {
+  const events = [
+    item.openedAt ? `打开于 ${formatTime(item.openedAt)}` : "尚未从动态账单打开",
+    item.consumedAt ? `消费确认于 ${formatTime(item.consumedAt)}` : "尚未确认有效观看",
+    item.processedAt ? `处理于 ${formatTime(item.processedAt)}` : "尚未手动处理",
+  ];
+  return `${statusLabel(item.status)}：${events.join("；")}。`;
 }
 
 function spaceUrl(mid: number): string {

--- a/dashboard/styles/dashboard.css
+++ b/dashboard/styles/dashboard.css
@@ -715,6 +715,17 @@ button {
   background: rgba(0, 161, 214, 0.16);
 }
 
+.dynamic-bill-action-grid button.is-primary {
+  color: #FFFFFF;
+  border-color: rgba(0, 161, 214, 0.42);
+  background: rgba(0, 161, 214, 0.16);
+}
+
+.dynamic-bill-action-grid button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 .dynamic-bill-fact-list {
   display: grid;
   gap: 7px;

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -1,4 +1,5 @@
 import type { BiliVizRequest, BiliVizContentMessage, BiliVizResponse, PlayerActionPayload, PlayerHeartbeatPayload, SyncNowResult } from '../../shared/types/messages';
+import type { DynamicBillStatusFilter } from '../../shared/types/dynamic-bill';
 import { runInitialBackfill } from '../sync/initial-backfill';
 import {
   saveConfig,
@@ -26,8 +27,16 @@ import { abortCurrentHistorySync, hasActiveHistorySyncAbortScope } from '../sync
 import { syncFavorites } from '../favorites/sync';
 import { buildSmartFavoriteIndex, getSmartFavoriteOverview, getSmartFavoritesByPath, searchSmartFavorites } from '../favorites/smart';
 import { generateDynamicBillItems } from '../dynamic-bill/generator';
+import { DYNAMIC_BILL_STRATEGY } from '../dynamic-bill/strategy';
 import { getDynamicOverview, syncDynamicBillUpdates } from '../dynamic-bill/sync';
-import { getDynamicBillItems } from '../storage/dynamic-bill-repo';
+import {
+  getDynamicBillFilterPreference,
+  getDynamicBillItems,
+  markDynamicBillItemOpened,
+  markDynamicBillItemProcessed,
+  markDynamicBillItemsConsumedByBvid,
+  setDynamicBillFilterPreference,
+} from '../storage/dynamic-bill-repo';
 
 const EXPORT_PAGE_LIMIT_MAX = 1000;
 
@@ -71,6 +80,7 @@ async function handleContentMessage(msg: BiliVizContentMessage): Promise<void> {
         playbackRate: p.playbackRate ?? 1,
         tabId: 0,
       });
+      await markConsumedFromPlayerEvent(p);
       break;
     }
     case 'PLAYER_ACTION': {
@@ -87,6 +97,7 @@ async function handleContentMessage(msg: BiliVizContentMessage): Promise<void> {
         seekTo: p.seekTo,
         tabId: 0,
       });
+      await markConsumedFromPlayerEvent(p);
       break;
     }
     case 'PAGE_NAVIGATION':
@@ -233,9 +244,67 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
       return { success: true, data: await generateDynamicBillItems() as T };
     case 'GET_DYNAMIC_BILL_ITEMS':
       return { success: true, data: await getDynamicBillItems() as T };
+    case 'GET_DYNAMIC_BILL_FILTER':
+      return { success: true, data: await getDynamicBillFilterPreference() as T };
+    case 'UPDATE_DYNAMIC_BILL_FILTER': {
+      const status = normalizeDynamicBillStatusFilter(request.params?.status);
+      return { success: true, data: await setDynamicBillFilterPreference(status) as T };
+    }
+    case 'OPEN_DYNAMIC_BILL_VIDEO': {
+      const billKey = requireStringParam(request.params?.billKey, 'billKey');
+      const item = await markDynamicBillItemOpened(billKey);
+      if (!item) throw new Error('DYNAMIC_BILL_ITEM_NOT_FOUND');
+      await chrome.tabs.create({ url: videoUrl(item.evidence.newVideo.bvid) });
+      return { success: true, data: item as T };
+    }
+    case 'MARK_DYNAMIC_BILL_ITEM_PROCESSED': {
+      const billKey = requireStringParam(request.params?.billKey, 'billKey');
+      const item = await markDynamicBillItemProcessed(billKey);
+      if (!item) throw new Error('DYNAMIC_BILL_ITEM_NOT_FOUND');
+      return { success: true, data: item as T };
+    }
     default:
       return { success: false, error: `Unknown action: ${request.action}` };
   }
+}
+
+async function markConsumedFromPlayerEvent(
+  payload: PlayerHeartbeatPayload | PlayerActionPayload,
+): Promise<void> {
+  if (!payload.bvid || !isEffectivePlayerWatch(payload)) return;
+  await markDynamicBillItemsConsumedByBvid(payload.bvid, Date.now());
+}
+
+function isEffectivePlayerWatch(payload: PlayerHeartbeatPayload | PlayerActionPayload): boolean {
+  if ('action' in payload) return payload.action === 'complete';
+  const duration = Math.max(0, payload.duration);
+  const currentTime = Math.max(0, payload.currentTime);
+  const completion = duration > 0 ? Math.min(currentTime / duration, 1) : 0;
+
+  return completion >= DYNAMIC_BILL_STRATEGY.positiveCompletionRate
+    || currentTime >= DYNAMIC_BILL_STRATEGY.minPositiveWatchSeconds;
+}
+
+function normalizeDynamicBillStatusFilter(value: unknown): DynamicBillStatusFilter {
+  if (
+    value === 'active'
+    || value === 'unopened'
+    || value === 'opened'
+    || value === 'consumed'
+    || value === 'processed'
+  ) {
+    return value;
+  }
+  throw new Error('INVALID_DYNAMIC_BILL_STATUS_FILTER');
+}
+
+function requireStringParam(value: unknown, name: string): string {
+  if (typeof value === 'string' && value.trim()) return value;
+  throw new Error(`MISSING_${name.toUpperCase()}`);
+}
+
+function videoUrl(bvid: string): string {
+  return `https://www.bilibili.com/video/${encodeURIComponent(bvid)}`;
 }
 
 function normalizeNonNegativeInteger(value: unknown, fallback: number): number {

--- a/src/background/storage/dynamic-bill-repo.ts
+++ b/src/background/storage/dynamic-bill-repo.ts
@@ -1,16 +1,21 @@
 import { DYNAMIC_UPDATE_WINDOW_DAYS } from '../../shared/constants';
 import type {
+  DynamicBillFilterPreference,
   DynamicBillColumn,
   DynamicBillItem,
   DynamicBillOverview,
   DynamicBillStatus,
+  DynamicBillStatusFilter,
   DynamicSyncState,
   FollowedCreator,
   FollowedVideoUpdate,
 } from '../../shared/types/dynamic-bill';
+import type { WatchHistoryRecord } from '../../shared/types/watch-event';
+import { DYNAMIC_BILL_STRATEGY } from '../dynamic-bill/strategy';
 import { db } from './db';
 
 const DYNAMIC_SYNC_STATE_KEY = 'dynamicBillSyncState';
+const DYNAMIC_BILL_FILTER_KEY = 'dynamicBillFilterPreference';
 const DYNAMIC_SYNC_STALE_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_SYNC_STATE: DynamicSyncState = {
   status: 'idle',
@@ -18,6 +23,10 @@ const DEFAULT_SYNC_STATE: DynamicSyncState = {
   lastStartedAt: 0,
   lastFinishedAt: 0,
   lastSuccessAt: 0,
+};
+const DEFAULT_FILTER_PREFERENCE: DynamicBillFilterPreference = {
+  status: 'active',
+  updatedAt: 0,
 };
 
 export async function replaceFollowedCreatorSnapshot(creators: FollowedCreator[], syncedAt: number): Promise<number> {
@@ -125,6 +134,75 @@ export async function getDynamicBillItems(options: {
   });
 }
 
+export async function getDynamicBillFilterPreference(): Promise<DynamicBillFilterPreference> {
+  const result = await chrome.storage.local.get(DYNAMIC_BILL_FILTER_KEY);
+  const stored = result[DYNAMIC_BILL_FILTER_KEY] as Partial<DynamicBillFilterPreference> | undefined;
+  if (!stored || !isDynamicBillStatusFilter(stored.status)) {
+    return DEFAULT_FILTER_PREFERENCE;
+  }
+
+  return {
+    status: stored.status,
+    updatedAt: normalizeTimestamp(stored.updatedAt),
+  };
+}
+
+export async function setDynamicBillFilterPreference(
+  status: DynamicBillStatusFilter,
+): Promise<DynamicBillFilterPreference> {
+  const preference: DynamicBillFilterPreference = {
+    status,
+    updatedAt: Date.now(),
+  };
+  await chrome.storage.local.set({ [DYNAMIC_BILL_FILTER_KEY]: preference });
+  return preference;
+}
+
+export async function markDynamicBillItemOpened(billKey: string, openedAt = Date.now()): Promise<DynamicBillItem | null> {
+  const item = await db.dynamicBillItems.where('billKey').equals(billKey).first();
+  if (!item) return null;
+
+  await advanceDynamicBillItemsByBvid(item.evidence.newVideo.bvid, 'opened', openedAt);
+  return (await db.dynamicBillItems.where('billKey').equals(billKey).first()) ?? item;
+}
+
+export async function markDynamicBillItemProcessed(billKey: string, processedAt = Date.now()): Promise<DynamicBillItem | null> {
+  const item = await db.dynamicBillItems.where('billKey').equals(billKey).first();
+  if (!item) return null;
+
+  const patch = buildStatusPatch(item, 'processed', processedAt);
+  if (!patch || item.id === undefined) return item;
+
+  await db.dynamicBillItems.update(item.id, patch);
+  return {
+    ...item,
+    ...patch,
+  };
+}
+
+export async function markDynamicBillItemsConsumedByBvid(bvid: string, consumedAt = Date.now()): Promise<number> {
+  return advanceDynamicBillItemsByBvid(bvid, 'consumed', consumedAt);
+}
+
+export async function markDynamicBillItemsConsumedByHistoryRecords(
+  records: WatchHistoryRecord[],
+  consumedAt = Date.now(),
+): Promise<number> {
+  const bvids = new Set(
+    records
+      .filter(isEffectiveHistoryRecord)
+      .map(record => record.bvid)
+      .filter(Boolean),
+  );
+  if (bvids.size === 0) return 0;
+
+  let updated = 0;
+  for (const bvid of bvids) {
+    updated += await markDynamicBillItemsConsumedByBvid(bvid, consumedAt);
+  }
+  return updated;
+}
+
 export async function getDynamicBillOverview(windowDays = DYNAMIC_UPDATE_WINDOW_DAYS): Promise<DynamicBillOverview> {
   const [syncState, creators, recentUpdates] = await Promise.all([
     getDynamicSyncState(),
@@ -189,6 +267,78 @@ function mergeExistingDynamicBillState(
     consumedAt: existing.consumedAt,
     processedAt: existing.processedAt,
   };
+}
+
+async function advanceDynamicBillItemsByBvid(
+  bvid: string,
+  status: DynamicBillStatus,
+  timestamp: number,
+): Promise<number> {
+  if (!bvid) return 0;
+
+  let updated = 0;
+  await db.transaction('rw', db.dynamicBillItems, async () => {
+    const items = await db.dynamicBillItems.toArray();
+    const nextItems: DynamicBillItem[] = [];
+
+    for (const item of items) {
+      if (item.evidence.newVideo.bvid !== bvid) continue;
+      const patch = buildStatusPatch(item, status, timestamp);
+      if (!patch) continue;
+      nextItems.push({ ...item, ...patch });
+      updated++;
+    }
+
+    if (nextItems.length > 0) {
+      await db.dynamicBillItems.bulkPut(nextItems);
+    }
+  });
+
+  return updated;
+}
+
+function buildStatusPatch(
+  item: DynamicBillItem,
+  targetStatus: DynamicBillStatus,
+  timestamp: number,
+): Partial<DynamicBillItem> | null {
+  if (statusOrder(item.status) > statusOrder(targetStatus)) return null;
+
+  const patch: Partial<DynamicBillItem> = {};
+  if (statusOrder(item.status) < statusOrder(targetStatus)) {
+    patch.status = targetStatus;
+  }
+
+  if (targetStatus === 'opened' && !item.openedAt) {
+    patch.openedAt = timestamp;
+  }
+  if (targetStatus === 'consumed' && !item.consumedAt) {
+    patch.consumedAt = timestamp;
+  }
+  if (targetStatus === 'processed' && !item.processedAt) {
+    patch.processedAt = timestamp;
+  }
+
+  return Object.keys(patch).length > 0 ? patch : null;
+}
+
+function isEffectiveHistoryRecord(record: WatchHistoryRecord): boolean {
+  return record.isFavorite
+    || record.actualCompletion >= DYNAMIC_BILL_STRATEGY.positiveCompletionRate
+    || record.progress >= DYNAMIC_BILL_STRATEGY.minPositiveWatchSeconds;
+}
+
+function isDynamicBillStatusFilter(status: unknown): status is DynamicBillStatusFilter {
+  return status === 'active'
+    || status === 'unopened'
+    || status === 'opened'
+    || status === 'consumed'
+    || status === 'processed';
+}
+
+function normalizeTimestamp(value: unknown): number {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
 }
 
 function statusOrder(status: DynamicBillStatus): number {

--- a/src/background/sync/initial-backfill.ts
+++ b/src/background/sync/initial-backfill.ts
@@ -18,6 +18,7 @@ import { getHistoryBvid, getHistoryDeviceType, toWatchHistoryRecord } from './wa
 import type { HistorySyncMode } from '../../shared/types/messages';
 import { beginHistorySyncAbortScope, endHistorySyncAbortScope } from './sync-control';
 import { abortableDelay } from '../utils/abortable-delay';
+import { markDynamicBillItemsConsumedByHistoryRecords } from '../storage/dynamic-bill-repo';
 
 export interface BackfillResult {
   mode: HistorySyncMode;
@@ -168,6 +169,7 @@ async function runHistorySyncUnlocked(
       await writeProgress(result, startedAt, true);
       const records = newItems.map(item => toWatchHistoryRecord(item, videoInfo.get(getHistoryBvid(item))));
       await bulkInsert(records);
+      await markDynamicBillItemsConsumedByHistoryRecords(records);
       result.insertedCount += records.length;
     }
 

--- a/src/shared/types/dynamic-bill.ts
+++ b/src/shared/types/dynamic-bill.ts
@@ -36,6 +36,7 @@ export interface FollowedVideoUpdate {
 
 export type DynamicBillColumn = 'afk_update' | 'variety' | 'buried_follow';
 export type DynamicBillStatus = 'unopened' | 'opened' | 'consumed' | 'processed';
+export type DynamicBillStatusFilter = 'active' | DynamicBillStatus;
 export type DynamicBillInterestKind = 'category' | 'tag';
 export type DynamicBillFollowMemorySignal = 'long_follow' | 'special_follow' | 'weak_watch';
 
@@ -60,6 +61,11 @@ export interface DynamicBillOverview {
   recentVideoUpdateCount: number;
   lastVideoDynamicTime: number;
   updateWindowDays: number;
+}
+
+export interface DynamicBillFilterPreference {
+  status: DynamicBillStatusFilter;
+  updatedAt: number;
 }
 
 export interface DynamicSyncResult {

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -1,5 +1,5 @@
 import type { QuickStats, DashboardOverview, CategoryDistribution, InterestDrift, DurationBucket, CreatorRanking, NewCreator, BehaviorMetrics, WeeklyTip, BlindBoxItem } from './analytics';
-import type { DynamicBillGenerateResult, DynamicBillItem, DynamicBillOverview, DynamicSyncResult } from './dynamic-bill';
+import type { DynamicBillFilterPreference, DynamicBillGenerateResult, DynamicBillItem, DynamicBillOverview, DynamicSyncResult } from './dynamic-bill';
 import type { FavoriteSyncResult, SmartFavoriteOverview, SmartFavoriteResult, SmartFavoriteSearchResponse, SmartIndexResult } from './favorite';
 
 // Popup / Dashboard → Service Worker
@@ -26,7 +26,11 @@ export type RequestAction =
   | 'GET_DYNAMIC_BILL_OVERVIEW'
   | 'SYNC_DYNAMIC_UPDATES'
   | 'GENERATE_DYNAMIC_BILL'
-  | 'GET_DYNAMIC_BILL_ITEMS';
+  | 'GET_DYNAMIC_BILL_ITEMS'
+  | 'GET_DYNAMIC_BILL_FILTER'
+  | 'UPDATE_DYNAMIC_BILL_FILTER'
+  | 'OPEN_DYNAMIC_BILL_VIDEO'
+  | 'MARK_DYNAMIC_BILL_ITEM_PROCESSED';
 
 // Content Script → Service Worker
 export type ContentAction =
@@ -144,3 +148,5 @@ export type DynamicBillOverviewResponse = BiliVizResponse<DynamicBillOverview>;
 export type DynamicSyncResponse = BiliVizResponse<DynamicSyncResult>;
 export type DynamicBillGenerateResponse = BiliVizResponse<DynamicBillGenerateResult>;
 export type DynamicBillItemsResponse = BiliVizResponse<DynamicBillItem[]>;
+export type DynamicBillItemResponse = BiliVizResponse<DynamicBillItem | null>;
+export type DynamicBillFilterResponse = BiliVizResponse<DynamicBillFilterPreference>;


### PR DESCRIPTION
## Scope

Implements Issue #8 dynamic bill state advancement and persistent status filtering only.

## What changed

- Adds persisted dynamic bill filter preference in `chrome.storage.local` under `dynamicBillFilterPreference`.
- Adds dashboard filters for `active` (`unopened` + `opened`) plus the four explicit states: `unopened`, `opened`, `consumed`, `processed`.
- Wires dashboard 打开新视频 through the service worker so the matching bill item advances from `unopened` to `opened` and records `openedAt` before opening the Bilibili video tab.
- Wires 标记已处理 through the service worker so the selected bill item advances to `processed` and records `processedAt` without setting `consumedAt`.
- Advances matching bill items to `consumed` with `consumedAt` when either:
  - newly synced watch history records satisfy the existing positive-watch rule (`isFavorite`, completion >= threshold, or progress >= threshold), or
  - player events provide a `complete` action or heartbeat that crosses the effective-watch threshold.

## State flow rules

`unopened < opened < consumed < processed`; state helpers only move forward and never downgrade. Manual `processed` is not treated as consumption, so a directly processed unopened item keeps `consumedAt` empty and remains counted as processed, not consumed.

## Persistence

The status filter is stored locally via `chrome.storage.local` as `dynamicBillFilterPreference`. Dynamic bill item state stays in Dexie `dynamicBillItems` and is preserved when regenerating a column through the existing `mergeExistingDynamicBillState` path.

## Validation

- `git diff --check` passed. Windows line-ending warnings only.
- `npm run typecheck` passed.
- `npm run build` passed. Existing Vite large chunk warning remains for `chunks/theme-*.js`.
- Browser mock QA passed against built dashboard with mock `chrome.runtime`:
  - default `active` filter showed all three columns with `1/1` counts and no `未消费` copy for unopened items;
  - opening a new video advanced the selected item to `opened` and recorded `openedAt`;
  - mock effective heartbeat advanced the item to `consumed`; after reload, `consumed` filter and state were retained;
  - manual processed action advanced an item to `processed`; after reload, `processed` filter and state were retained;
  - directly processing an unopened item did not increase consumed count and detail still showed `尚未确认有效观看`.

## Remaining risk

- Browser QA used mocked extension APIs rather than a live installed extension on bilibili.com.
- Player heartbeat consumption still depends on the existing content script heartbeat fidelity; `seek`/`pause` actions are intentionally not enough to mark consumed.

Closes #8