### PR TITLE
[codex] Implement dynamic bill local feedback

### DIFF
--- a/dashboard/modules/dynamic-bill/DynamicBillPage.tsx
+++ b/dashboard/modules/dynamic-bill/DynamicBillPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from "preact/hooks";
 import type {
   DynamicBillColumn,
+  DynamicBillFeedbackResult,
+  DynamicBillFeedbackScope,
   DynamicBillFilterPreference,
   DynamicBillGenerateResult,
   DynamicBillEvidence,
@@ -55,6 +57,12 @@ const BILL_COLUMNS = [
 
 type BillColumnKey = (typeof BILL_COLUMNS)[number]["key"];
 
+interface CreatorReviewPrompt {
+  creatorMid: number;
+  creatorName: string;
+  feedbackCount: number;
+}
+
 export function DynamicBillPage() {
   const [statusFilter, setStatusFilter] = useState<DynamicBillStatusFilter>("active");
   const [overview, setOverview] = useState<DynamicBillOverview | null>(null);
@@ -63,6 +71,8 @@ export function DynamicBillPage() {
   const [syncing, setSyncing] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [processingBillKey, setProcessingBillKey] = useState("");
+  const [creatorReviewPrompt, setCreatorReviewPrompt] =
+    useState<CreatorReviewPrompt | null>(null);
   const [notice, setNotice] = useState("");
   const activeStatus =
     STATUS_FILTERS.find((item) => item.key === statusFilter) ?? STATUS_FILTERS[0];
@@ -191,6 +201,36 @@ export function DynamicBillPage() {
     }
   }
 
+  async function handleAddFeedback(
+    item: DynamicBillItem,
+    scope: DynamicBillFeedbackScope,
+  ) {
+    setProcessingBillKey(item.billKey);
+    setNotice("");
+    try {
+      const result = await requestSW<DynamicBillFeedbackResult>(
+        "ADD_DYNAMIC_BILL_FEEDBACK",
+        {
+          billKey: item.billKey,
+          scope,
+        },
+      );
+      await refreshBillItems();
+      setNotice(describeFeedbackResult(result));
+      if (result.summary.shouldShowCreatorReviewPrompt) {
+        setCreatorReviewPrompt({
+          creatorMid: result.item.creatorMid,
+          creatorName: result.item.creatorName,
+          feedbackCount: result.summary.count,
+        });
+      }
+    } catch (error) {
+      setNotice(`保存少提醒反馈失败：${describeError(error)}`);
+    } finally {
+      setProcessingBillKey("");
+    }
+  }
+
   async function handleGenerate() {
     setGenerating(true);
     setNotice("");
@@ -302,7 +342,7 @@ export function DynamicBillPage() {
       >
         <strong>{notice || overviewNotice}</strong>
         <span>
-          本切片启用三类本地证据栏目；状态只会从未打开向已打开、已消费、已处理推进。负反馈累计、topic 降低和取关提示留给 #9 闭环。
+          本切片启用三类本地证据栏目；状态只会从未打开向已打开、已消费、已处理推进。少提醒反馈只写入本地，后续生成会按 UP 或主题降权，达到阈值后不再写入候选。
         </span>
       </section>
 
@@ -398,6 +438,13 @@ export function DynamicBillPage() {
             <BillItemDetail
               item={selectedItem}
               busy={processingBillKey === selectedItem.billKey}
+              creatorReviewPrompt={
+                creatorReviewPrompt?.creatorMid === selectedItem.creatorMid
+                  ? creatorReviewPrompt
+                  : null
+              }
+              onAddFeedback={handleAddFeedback}
+              onDismissCreatorReviewPrompt={() => setCreatorReviewPrompt(null)}
               onMarkProcessed={handleMarkProcessed}
               onOpenVideo={handleOpenVideo}
             />
@@ -412,12 +459,18 @@ export function DynamicBillPage() {
 
 function BillItemDetail({
   busy,
+  creatorReviewPrompt,
   item,
+  onAddFeedback,
+  onDismissCreatorReviewPrompt,
   onMarkProcessed,
   onOpenVideo,
 }: {
   busy: boolean;
+  creatorReviewPrompt: CreatorReviewPrompt | null;
   item: DynamicBillItem;
+  onAddFeedback: (item: DynamicBillItem, scope: DynamicBillFeedbackScope) => void;
+  onDismissCreatorReviewPrompt: () => void;
   onMarkProcessed: (item: DynamicBillItem) => void;
   onOpenVideo: (item: DynamicBillItem) => void;
 }) {
@@ -497,6 +550,35 @@ function BillItemDetail({
             : "长期窗口中没有可展示的近期以前代表 bvid。"}
         </span>
       </div>
+      {creatorReviewPrompt ? (
+        <div
+          className="dynamic-bill-creator-review"
+          data-testid="dynamic-bill-creator-review-prompt"
+        >
+          <strong>是否考虑取关这个 UP？</strong>
+          <span>
+            你已经 {creatorReviewPrompt.feedbackCount} 次选择少提醒「{creatorReviewPrompt.creatorName}」。
+            可以打开 UP 主页自行检查；Bili-Bill 不会修改你的关注关系，也不会提供插件内取关。
+          </span>
+          <div className="dynamic-bill-feedback-actions">
+            <a
+              href={spaceUrl(creatorReviewPrompt.creatorMid)}
+              target="_blank"
+              rel="noreferrer"
+              data-testid="dynamic-bill-review-open-creator"
+            >
+              打开 UP 主页
+            </a>
+            <button
+              type="button"
+              data-testid="dynamic-bill-review-dismiss"
+              onClick={onDismissCreatorReviewPrompt}
+            >
+              暂不处理
+            </button>
+          </div>
+        </div>
+      ) : null}
       <div className="dynamic-bill-action-grid">
         <button
           type="button"
@@ -515,6 +597,24 @@ function BillItemDetail({
         >
           {isProcessed ? "已处理" : "标记已处理"}
         </button>
+        <button
+          type="button"
+          disabled={busy}
+          data-testid="dynamic-bill-less-creator"
+          onClick={() => onAddFeedback(item, "creator")}
+        >
+          少提醒这个 UP
+        </button>
+        {evidence.interest ? (
+          <button
+            type="button"
+            disabled={busy}
+            data-testid="dynamic-bill-less-topic"
+            onClick={() => onAddFeedback(item, "topic")}
+          >
+            少提醒这个主题
+          </button>
+        ) : null}
         <a href={spaceUrl(item.creatorMid)} target="_blank" rel="noreferrer">
           打开 UP 主页
         </a>
@@ -597,7 +697,22 @@ function describeSyncResult(result: DynamicSyncResult): string {
 }
 
 function describeGenerateResult(result: DynamicBillGenerateResult): string {
-  return `本地账单生成 ${result.itemCount} 项：久违更新 ${result.columnItemCounts.afk_update} 项，换换口味 ${result.columnItemCounts.variety} 项，被淹没的关注 ${result.columnItemCounts.buried_follow} 项；扫描最近投稿 ${result.candidatesScanned} 条，排除近期已看同视频 ${result.excludedRecentSameVideoCount} 条，长期/关注记忆证据不足 ${result.excludedNoLongSignalCount} 个，近期仍活跃 ${result.excludedRecentActiveCount} 个。`;
+  return `本地账单生成 ${result.itemCount} 项：久违更新 ${result.columnItemCounts.afk_update} 项，换换口味 ${result.columnItemCounts.variety} 项，被淹没的关注 ${result.columnItemCounts.buried_follow} 项；扫描最近投稿 ${result.candidatesScanned} 条，排除近期已看同视频 ${result.excludedRecentSameVideoCount} 条，长期/关注记忆证据不足 ${result.excludedNoLongSignalCount} 个，近期仍活跃 ${result.excludedRecentActiveCount} 个，本地少提醒阈值排除 ${result.excludedByFeedbackCount} 个。`;
+}
+
+function describeFeedbackResult(result: DynamicBillFeedbackResult): string {
+  const target = result.summary.scope === "creator" ? "UP" : "主题";
+  const threshold = result.summary.scope === "creator"
+    ? result.summary.thresholds.creatorBlockCount
+    : result.summary.thresholds.topicBlockCount;
+  const nextRule = result.summary.isBlocked
+    ? `已达到 ${threshold} 次阈值，下次生成不会再写入这个${target}的相关候选`
+    : `下次生成会降低这个${target}的排序权重；累计 ${threshold} 次后不再写入候选`;
+  const reviewCopy = result.summary.shouldShowCreatorReviewPrompt
+    ? "；已展示取关思考提示，但不会修改 B 站关注关系"
+    : "";
+
+  return `已在本地记录「${result.summary.label}」少提醒 ${result.summary.count} 次，${nextRule}。这不会把当前账单项标记为已处理${reviewCopy}。`;
 }
 
 function getColumnEmptyCopy(
@@ -680,15 +795,16 @@ function cardFact(item: DynamicBillItem): string {
 function thresholdCopy(evidence: DynamicBillEvidence): string {
   const positiveRule = `正反馈为完成度 ≥ ${formatPercent(evidence.thresholds.positiveCompletionRate)}、观看 ≥ ${formatDuration(evidence.thresholds.minPositiveWatchSeconds)} 或已收藏`;
   const sameVideoRule = `近期同一新视频排除窗口为 ${evidence.thresholds.recentSameVideoWindowDays} 天`;
+  const feedbackRule = `本地少提醒第 ${evidence.thresholds.feedbackDampenCount} 次开始降权，UP 累计 ${evidence.thresholds.feedbackCreatorBlockCount} 次或主题累计 ${evidence.thresholds.feedbackTopicBlockCount} 次后不再写入候选`;
 
   if (evidence.kind === "variety") {
-    return `长期兴趣正反馈不少于 ${evidence.thresholds.minInterestPositiveViews} 次，长期正反馈占比 ≥ ${formatPercent(evidence.thresholds.minInterestLongPositiveShare)}；近期正反馈不高于长期节奏的 ${formatPercent(evidence.thresholds.maxInterestRecentPositiveRatio)}；最近 ${evidence.thresholds.updateWindowDays} 天新投稿必须命中该分区/标签；${positiveRule}；${sameVideoRule}。`;
+    return `长期兴趣正反馈不少于 ${evidence.thresholds.minInterestPositiveViews} 次，长期正反馈占比 ≥ ${formatPercent(evidence.thresholds.minInterestLongPositiveShare)}；近期正反馈不高于长期节奏的 ${formatPercent(evidence.thresholds.maxInterestRecentPositiveRatio)}；最近 ${evidence.thresholds.updateWindowDays} 天新投稿必须命中该分区/标签；${positiveRule}；${sameVideoRule}；${feedbackRule}。`;
   }
   if (evidence.kind === "buried_follow") {
-    return `基础入选必须是已关注 UP、最近 ${evidence.thresholds.updateWindowDays} 天有新视频投稿、近期 ${evidence.thresholds.recentWindowDays} 天观看不超过 ${evidence.thresholds.maxBuriedRecentWatchCount} 次且正反馈不超过 ${evidence.thresholds.maxBuriedRecentPositiveWatchCount} 次；关注记忆信号至少满足：已关注不少于 ${evidence.thresholds.minBuriedFollowAgeDays} 天、特别关注、或近期窗口以前弱观看不少于 ${evidence.thresholds.minBuriedWeakWatchCount} 次之一；${positiveRule}；${sameVideoRule}。`;
+    return `基础入选必须是已关注 UP、最近 ${evidence.thresholds.updateWindowDays} 天有新视频投稿、近期 ${evidence.thresholds.recentWindowDays} 天观看不超过 ${evidence.thresholds.maxBuriedRecentWatchCount} 次且正反馈不超过 ${evidence.thresholds.maxBuriedRecentPositiveWatchCount} 次；关注记忆信号至少满足：已关注不少于 ${evidence.thresholds.minBuriedFollowAgeDays} 天、特别关注、或近期窗口以前弱观看不少于 ${evidence.thresholds.minBuriedWeakWatchCount} 次之一；${positiveRule}；${sameVideoRule}；${feedbackRule}。`;
   }
 
-  return `长期 UP 正反馈不少于 ${evidence.thresholds.minCreatorPositiveViews} 次；近期正反馈不高于长期节奏的 ${formatPercent(evidence.thresholds.recentCooldownRatio)}；${positiveRule}；${sameVideoRule}。`;
+  return `长期 UP 正反馈不少于 ${evidence.thresholds.minCreatorPositiveViews} 次；近期正反馈不高于长期节奏的 ${formatPercent(evidence.thresholds.recentCooldownRatio)}；${positiveRule}；${sameVideoRule}；${feedbackRule}。`;
 }
 
 function longWindowLabel(evidence: DynamicBillEvidence): string {

--- a/dashboard/styles/dashboard.css
+++ b/dashboard/styles/dashboard.css
@@ -687,6 +687,54 @@ button {
   line-height: 1.45;
 }
 
+.dynamic-bill-creator-review {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid rgba(245, 158, 11, 0.38);
+  border-radius: 8px;
+  background: rgba(245, 158, 11, 0.1);
+}
+
+.dynamic-bill-creator-review strong {
+  color: #FBBF24;
+  font-size: 14px;
+}
+
+.dynamic-bill-creator-review span {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.dynamic-bill-feedback-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.dynamic-bill-feedback-actions button,
+.dynamic-bill-feedback-actions a {
+  display: grid;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  padding: 0 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 7px;
+  color: #D5DCE8;
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 12px;
+  font-weight: 750;
+  text-align: center;
+  text-decoration: none;
+}
+
+.dynamic-bill-feedback-actions a {
+  border-color: rgba(0, 161, 214, 0.42);
+  background: rgba(0, 161, 214, 0.16);
+}
+
 .dynamic-bill-action-grid {
   display: grid;
   grid-template-columns: 1fr;
@@ -849,6 +897,7 @@ button {
   }
 
   .dynamic-bill-scope-actions,
+  .dynamic-bill-feedback-actions,
   .dynamic-bill-evidence-grid {
     grid-template-columns: 1fr;
   }

--- a/src/background/dynamic-bill/buried-follow.ts
+++ b/src/background/dynamic-bill/buried-follow.ts
@@ -10,10 +10,12 @@ import type { WatchHistoryRecord } from '../../shared/types/watch-event';
 import { getRecordsSince } from '../storage/watch-history-repo';
 import {
   getActiveFollowedCreators,
+  getDynamicBillFeedbackProfile,
   getDynamicBillOverview,
   getRecentFollowedVideoUpdates,
   replaceDynamicBillItemsForColumn,
 } from '../storage/dynamic-bill-repo';
+import { applyDynamicBillFeedbackScore, evaluateDynamicBillFeedback } from './feedback';
 import { DYNAMIC_BILL_STRATEGY, getDynamicBillThresholdEvidence } from './strategy';
 
 const SECONDS_PER_DAY = 86_400;
@@ -35,7 +37,10 @@ interface Candidate {
   historicalWeakWatchCount: number;
   historyBvids: string[];
   score: number;
+  feedbackFacts: string[];
 }
+
+type CandidateInput = Omit<Candidate, 'score' | 'feedbackFacts'>;
 
 export async function generateBuriedFollowBillItems(): Promise<DynamicBillGenerateResult> {
   const generatedAt = Date.now();
@@ -45,10 +50,11 @@ export async function generateBuriedFollowBillItems(): Promise<DynamicBillGenera
   const recentCutoff = nowSeconds - DYNAMIC_BILL_STRATEGY.recentWindowDays * SECONDS_PER_DAY;
   const recentSameVideoCutoff = nowSeconds - DYNAMIC_BILL_STRATEGY.recentSameVideoWindowDays * SECONDS_PER_DAY;
 
-  const [creators, updates, longRecords] = await Promise.all([
+  const [creators, updates, longRecords, feedbackProfile] = await Promise.all([
     getActiveFollowedCreators(),
     getRecentFollowedVideoUpdates(DYNAMIC_BILL_STRATEGY.updateWindowDays),
     getRecordsSince(longCutoff),
+    getDynamicBillFeedbackProfile(),
   ]);
 
   const activeCreatorsByMid = new Map(creators.map(creator => [creator.mid, creator]));
@@ -78,6 +84,7 @@ export async function generateBuriedFollowBillItems(): Promise<DynamicBillGenera
   const candidates: Candidate[] = [];
   let excludedNoLongSignalCount = 0;
   let excludedRecentActiveCount = 0;
+  let excludedByFeedbackCount = 0;
 
   for (const [creatorMid, update] of newestUnwatchedUpdateByCreator) {
     const creator = activeCreatorsByMid.get(creatorMid);
@@ -120,8 +127,7 @@ export async function generateBuriedFollowBillItems(): Promise<DynamicBillGenera
       ? recentStats.watchedCount / DYNAMIC_BILL_STRATEGY.maxBuriedRecentWatchCount
       : 0;
     const historyBvids = selectHistoryHighlights(creatorRecords, update.bvid, recentCutoff);
-
-    const candidate: Omit<Candidate, 'score'> = {
+    const candidateInput: CandidateInput = {
       creator,
       update,
       longStats,
@@ -133,10 +139,21 @@ export async function generateBuriedFollowBillItems(): Promise<DynamicBillGenera
       historicalWeakWatchCount,
       historyBvids,
     };
+    const feedback = evaluateDynamicBillFeedback(feedbackProfile, {
+      creatorMid,
+    });
+    if (feedback.blocked) {
+      excludedByFeedbackCount++;
+      continue;
+    }
 
     candidates.push({
-      ...candidate,
-      score: scoreCandidate(candidate, nowSeconds),
+      ...candidateInput,
+      feedbackFacts: feedback.facts,
+      score: applyDynamicBillFeedbackScore(
+        scoreCandidate(candidateInput, nowSeconds),
+        feedback,
+      ),
     });
   }
 
@@ -156,6 +173,7 @@ export async function generateBuriedFollowBillItems(): Promise<DynamicBillGenera
     excludedNoLongSignalCount,
     excludedRecentActiveCount,
     excludedRecentSameVideoCount,
+    excludedByFeedbackCount,
     columnItemCounts: {
       afk_update: 0,
       variety: 0,
@@ -271,7 +289,7 @@ function selectHistoryHighlights(
     .slice(0, DYNAMIC_BILL_STRATEGY.maxHighlightsPerItem);
 }
 
-function scoreCandidate(candidate: Omit<Candidate, 'score'>, nowSeconds: number): number {
+function scoreCandidate(candidate: CandidateInput, nowSeconds: number): number {
   const updateAgeDays = Math.max(0, (nowSeconds - candidate.update.dynamicTime) / SECONDS_PER_DAY);
   const followAgeStrength = candidate.followAgeDays !== undefined
     ? Math.min(candidate.followAgeDays / 365, 4) * 5
@@ -354,6 +372,8 @@ function buildFacts(candidate: Candidate): string[] {
   } else {
     facts.push('本地长期窗口未发现该 UP 的观看记录；本项由关注关系记忆信号支撑，而不是强历史观看正反馈。');
   }
+
+  facts.push(...candidate.feedbackFacts);
 
   return facts;
 }

--- a/src/background/dynamic-bill/feedback.ts
+++ b/src/background/dynamic-bill/feedback.ts
@@ -1,0 +1,55 @@
+import type { DynamicBillFeedbackProfile } from '../storage/dynamic-bill-repo';
+import { DYNAMIC_BILL_STRATEGY } from './strategy';
+
+export interface DynamicBillFeedbackEvaluation {
+  blocked: boolean;
+  scoreMultiplier: number;
+  creatorFeedbackCount: number;
+  topicFeedbackCount: number;
+  facts: string[];
+}
+
+export function evaluateDynamicBillFeedback(
+  profile: DynamicBillFeedbackProfile,
+  target: {
+    creatorMid: number;
+    topicKey?: string;
+    topicLabel?: string;
+  },
+): DynamicBillFeedbackEvaluation {
+  const creatorFeedbackCount = profile.creatorCountsByMid.get(target.creatorMid) ?? 0;
+  const topicFeedbackCount = target.topicKey
+    ? profile.topicCountsByKey.get(target.topicKey) ?? 0
+    : 0;
+  const creatorBlocked = creatorFeedbackCount >= DYNAMIC_BILL_STRATEGY.feedbackCreatorBlockCount;
+  const topicBlocked = topicFeedbackCount >= DYNAMIC_BILL_STRATEGY.feedbackTopicBlockCount;
+  const isDampened = creatorFeedbackCount >= DYNAMIC_BILL_STRATEGY.feedbackDampenCount
+    || topicFeedbackCount >= DYNAMIC_BILL_STRATEGY.feedbackDampenCount;
+  const facts: string[] = [];
+
+  if (creatorFeedbackCount > 0) {
+    facts.push(
+      `本地少提醒记录：这个 UP 已累计 ${creatorFeedbackCount} 次；未达屏蔽阈值时本次生成会降低排序权重。`,
+    );
+  }
+  if (topicFeedbackCount > 0) {
+    facts.push(
+      `本地少提醒记录：${target.topicLabel ?? '这个主题'}已累计 ${topicFeedbackCount} 次；未达屏蔽阈值时本次生成会降低排序权重。`,
+    );
+  }
+
+  return {
+    blocked: creatorBlocked || topicBlocked,
+    scoreMultiplier: isDampened ? DYNAMIC_BILL_STRATEGY.feedbackScoreMultiplier : 1,
+    creatorFeedbackCount,
+    topicFeedbackCount,
+    facts,
+  };
+}
+
+export function applyDynamicBillFeedbackScore(
+  score: number,
+  feedback: DynamicBillFeedbackEvaluation,
+): number {
+  return Math.round(score * feedback.scoreMultiplier * 100) / 100;
+}

--- a/src/background/dynamic-bill/generator.ts
+++ b/src/background/dynamic-bill/generator.ts
@@ -40,6 +40,10 @@ export async function generateDynamicBillItems(): Promise<DynamicBillGenerateRes
       afkResult.excludedRecentSameVideoCount
       + varietyResult.excludedRecentSameVideoCount
       + buriedFollowResult.excludedRecentSameVideoCount,
+    excludedByFeedbackCount:
+      afkResult.excludedByFeedbackCount
+      + varietyResult.excludedByFeedbackCount
+      + buriedFollowResult.excludedByFeedbackCount,
     columnItemCounts: {
       afk_update: afkResult.columnItemCounts.afk_update,
       variety: varietyResult.columnItemCounts.variety,

--- a/src/background/dynamic-bill/rules.ts
+++ b/src/background/dynamic-bill/rules.ts
@@ -9,10 +9,12 @@ import type { WatchHistoryRecord } from '../../shared/types/watch-event';
 import { getRecordsSince } from '../storage/watch-history-repo';
 import {
   getActiveFollowedCreators,
+  getDynamicBillFeedbackProfile,
   getDynamicBillOverview,
   getRecentFollowedVideoUpdates,
   replaceDynamicBillItemsForColumn,
 } from '../storage/dynamic-bill-repo';
+import { applyDynamicBillFeedbackScore, evaluateDynamicBillFeedback } from './feedback';
 import { DYNAMIC_BILL_STRATEGY, getDynamicBillThresholdEvidence } from './strategy';
 
 const SECONDS_PER_DAY = 86_400;
@@ -31,7 +33,10 @@ interface Candidate {
   daysSinceLastWatch: number | null;
   score: number;
   historyBvids: string[];
+  feedbackFacts: string[];
 }
+
+type CandidateInput = Omit<Candidate, 'score' | 'feedbackFacts'>;
 
 export async function generateAfkUpdateBillItems(): Promise<DynamicBillGenerateResult> {
   const generatedAt = Date.now();
@@ -41,10 +46,11 @@ export async function generateAfkUpdateBillItems(): Promise<DynamicBillGenerateR
   const recentCutoff = nowSeconds - DYNAMIC_BILL_STRATEGY.recentWindowDays * SECONDS_PER_DAY;
   const recentSameVideoCutoff = nowSeconds - DYNAMIC_BILL_STRATEGY.recentSameVideoWindowDays * SECONDS_PER_DAY;
 
-  const [creators, updates, longRecords] = await Promise.all([
+  const [creators, updates, longRecords, feedbackProfile] = await Promise.all([
     getActiveFollowedCreators(),
     getRecentFollowedVideoUpdates(DYNAMIC_BILL_STRATEGY.updateWindowDays),
     getRecordsSince(longCutoff),
+    getDynamicBillFeedbackProfile(),
   ]);
 
   const activeCreatorsByMid = new Map(creators.map(creator => [creator.mid, creator]));
@@ -74,6 +80,7 @@ export async function generateAfkUpdateBillItems(): Promise<DynamicBillGenerateR
   const candidates: Candidate[] = [];
   let excludedNoLongSignalCount = 0;
   let excludedRecentActiveCount = 0;
+  let excludedByFeedbackCount = 0;
 
   for (const [creatorMid, update] of newestUnwatchedUpdateByCreator) {
     const creator = activeCreatorsByMid.get(creatorMid);
@@ -112,8 +119,7 @@ export async function generateAfkUpdateBillItems(): Promise<DynamicBillGenerateR
       ? recentStats.positiveWatchCount / expectedRecentPositive
       : 0;
     const historyBvids = selectHistoryHighlights(creatorRecords, update.bvid, recentCutoff);
-
-    candidates.push({
+    const candidateInput: CandidateInput = {
       creator,
       update,
       longStats,
@@ -121,15 +127,22 @@ export async function generateAfkUpdateBillItems(): Promise<DynamicBillGenerateR
       cooldownRatio,
       daysSinceLastWatch,
       historyBvids,
-      score: scoreCandidate({
-        creator,
-        update,
-        longStats,
-        recentStats,
-        cooldownRatio,
-        daysSinceLastWatch,
-        historyBvids,
-      }, nowSeconds),
+    };
+    const feedback = evaluateDynamicBillFeedback(feedbackProfile, {
+      creatorMid,
+    });
+    if (feedback.blocked) {
+      excludedByFeedbackCount++;
+      continue;
+    }
+
+    candidates.push({
+      ...candidateInput,
+      feedbackFacts: feedback.facts,
+      score: applyDynamicBillFeedbackScore(
+        scoreCandidate(candidateInput, nowSeconds),
+        feedback,
+      ),
     });
   }
 
@@ -149,6 +162,7 @@ export async function generateAfkUpdateBillItems(): Promise<DynamicBillGenerateR
     excludedNoLongSignalCount,
     excludedRecentActiveCount,
     excludedRecentSameVideoCount,
+    excludedByFeedbackCount,
     columnItemCounts: {
       afk_update: storedItems.length,
       variety: 0,
@@ -246,7 +260,7 @@ function selectHistoryHighlights(
     .slice(0, DYNAMIC_BILL_STRATEGY.maxHighlightsPerItem);
 }
 
-function scoreCandidate(candidate: Omit<Candidate, 'score'>, nowSeconds: number): number {
+function scoreCandidate(candidate: CandidateInput, nowSeconds: number): number {
   const followAgeDays = getFollowAgeDays(candidate.creator, nowSeconds) ?? 0;
   const updateAgeDays = Math.max(0, (nowSeconds - candidate.update.dynamicTime) / SECONDS_PER_DAY);
   const watchStrength = candidate.longStats.positiveWatchCount * 10
@@ -328,6 +342,8 @@ function buildFacts(candidate: Candidate, followAgeDays?: number): string[] {
   } else {
     facts.push('关注时间未知；入选不依赖关注时长。');
   }
+
+  facts.push(...candidate.feedbackFacts);
 
   return facts;
 }

--- a/src/background/dynamic-bill/strategy.ts
+++ b/src/background/dynamic-bill/strategy.ts
@@ -17,6 +17,11 @@ export const DYNAMIC_BILL_STRATEGY = {
   minBuriedWeakWatchCount: 1,
   maxBuriedRecentWatchCount: 1,
   maxBuriedRecentPositiveWatchCount: 0,
+  feedbackDampenCount: 1,
+  feedbackCreatorBlockCount: 3,
+  feedbackTopicBlockCount: 2,
+  feedbackCreatorReviewPromptCount: 2,
+  feedbackScoreMultiplier: 0.35,
   maxHighlightsPerItem: 3,
   maxItemsPerColumn: 20,
 } as const;
@@ -38,5 +43,10 @@ export function getDynamicBillThresholdEvidence(): DynamicBillThresholdEvidence 
     minBuriedWeakWatchCount: DYNAMIC_BILL_STRATEGY.minBuriedWeakWatchCount,
     maxBuriedRecentWatchCount: DYNAMIC_BILL_STRATEGY.maxBuriedRecentWatchCount,
     maxBuriedRecentPositiveWatchCount: DYNAMIC_BILL_STRATEGY.maxBuriedRecentPositiveWatchCount,
+    feedbackDampenCount: DYNAMIC_BILL_STRATEGY.feedbackDampenCount,
+    feedbackCreatorBlockCount: DYNAMIC_BILL_STRATEGY.feedbackCreatorBlockCount,
+    feedbackTopicBlockCount: DYNAMIC_BILL_STRATEGY.feedbackTopicBlockCount,
+    feedbackCreatorReviewPromptCount: DYNAMIC_BILL_STRATEGY.feedbackCreatorReviewPromptCount,
+    feedbackScoreMultiplier: DYNAMIC_BILL_STRATEGY.feedbackScoreMultiplier,
   };
 }

--- a/src/background/dynamic-bill/variety.ts
+++ b/src/background/dynamic-bill/variety.ts
@@ -10,10 +10,12 @@ import type { WatchHistoryRecord } from '../../shared/types/watch-event';
 import { getRecordsSince } from '../storage/watch-history-repo';
 import {
   getActiveFollowedCreators,
+  getDynamicBillFeedbackProfile,
   getDynamicBillOverview,
   getRecentFollowedVideoUpdates,
   replaceDynamicBillItemsForColumn,
 } from '../storage/dynamic-bill-repo';
+import { applyDynamicBillFeedbackScore, evaluateDynamicBillFeedback } from './feedback';
 import { DYNAMIC_BILL_STRATEGY, getDynamicBillThresholdEvidence } from './strategy';
 
 const SECONDS_PER_DAY = 86_400;
@@ -57,7 +59,10 @@ interface VarietyCandidate {
   daysSinceLastWatch: number | null;
   historyBvids: string[];
   score: number;
+  feedbackFacts: string[];
 }
+
+type VarietyCandidateInput = Omit<VarietyCandidate, 'score' | 'feedbackFacts'>;
 
 export async function generateVarietyBillItems(): Promise<DynamicBillGenerateResult> {
   const generatedAt = Date.now();
@@ -67,10 +72,11 @@ export async function generateVarietyBillItems(): Promise<DynamicBillGenerateRes
   const recentCutoff = nowSeconds - DYNAMIC_BILL_STRATEGY.recentWindowDays * SECONDS_PER_DAY;
   const recentSameVideoCutoff = nowSeconds - DYNAMIC_BILL_STRATEGY.recentSameVideoWindowDays * SECONDS_PER_DAY;
 
-  const [creators, updates, longRecords] = await Promise.all([
+  const [creators, updates, longRecords, feedbackProfile] = await Promise.all([
     getActiveFollowedCreators(),
     getRecentFollowedVideoUpdates(DYNAMIC_BILL_STRATEGY.updateWindowDays),
     getRecordsSince(longCutoff),
+    getDynamicBillFeedbackProfile(),
   ]);
 
   const activeCreatorsByMid = new Map(creators.map(creator => [creator.mid, creator]));
@@ -108,6 +114,7 @@ export async function generateVarietyBillItems(): Promise<DynamicBillGenerateRes
 
   const candidates: VarietyCandidate[] = [];
   let excludedNoMatchingInterestUpdateCount = 0;
+  let excludedByFeedbackCount = 0;
 
   for (const update of unwatchedUpdates) {
     const creator = activeCreatorsByMid.get(update.authorMid);
@@ -131,8 +138,7 @@ export async function generateVarietyBillItems(): Promise<DynamicBillGenerateRes
       .filter(signal => signal.key === interest.key)
       .map(signal => signal.label);
     const historyBvids = selectHistoryHighlights(interest.longStats.records, update.bvid, recentCutoff);
-
-    const candidate: Omit<VarietyCandidate, 'score'> = {
+    const candidateInput: VarietyCandidateInput = {
       creator,
       update,
       interest,
@@ -140,10 +146,23 @@ export async function generateVarietyBillItems(): Promise<DynamicBillGenerateRes
       daysSinceLastWatch,
       historyBvids,
     };
+    const feedback = evaluateDynamicBillFeedback(feedbackProfile, {
+      creatorMid: creator.mid,
+      topicKey: interest.key,
+      topicLabel: `${formatInterestKind(interest.kind)}「${interest.label}」`,
+    });
+    if (feedback.blocked) {
+      excludedByFeedbackCount++;
+      continue;
+    }
 
     candidates.push({
-      ...candidate,
-      score: scoreVarietyCandidate(candidate, nowSeconds),
+      ...candidateInput,
+      feedbackFacts: feedback.facts,
+      score: applyDynamicBillFeedbackScore(
+        scoreVarietyCandidate(candidateInput, nowSeconds),
+        feedback,
+      ),
     });
   }
 
@@ -164,6 +183,7 @@ export async function generateVarietyBillItems(): Promise<DynamicBillGenerateRes
       interestSelection.excludedNoLongSignalCount + excludedNoMatchingInterestUpdateCount,
     excludedRecentActiveCount: interestSelection.excludedRecentActiveCount,
     excludedRecentSameVideoCount,
+    excludedByFeedbackCount,
     columnItemCounts: {
       afk_update: 0,
       variety: storedItems.length,
@@ -362,7 +382,7 @@ function scoreInterest(interest: EligibleInterest): number {
 }
 
 function scoreVarietyCandidate(
-  candidate: Omit<VarietyCandidate, 'score'>,
+  candidate: VarietyCandidateInput,
   nowSeconds: number,
 ): number {
   const followAgeDays = getFollowAgeDays(candidate.creator, nowSeconds) ?? 0;
@@ -459,6 +479,8 @@ function buildFacts(candidate: VarietyCandidate, followAgeDays?: number): string
   } else {
     facts.push('关注时间未知；入选不依赖关注时长。');
   }
+
+  facts.push(...candidate.feedbackFacts);
 
   return facts;
 }

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -1,5 +1,5 @@
 import type { BiliVizRequest, BiliVizContentMessage, BiliVizResponse, PlayerActionPayload, PlayerHeartbeatPayload, SyncNowResult } from '../../shared/types/messages';
-import type { DynamicBillStatusFilter } from '../../shared/types/dynamic-bill';
+import type { DynamicBillFeedbackScope, DynamicBillStatusFilter } from '../../shared/types/dynamic-bill';
 import { runInitialBackfill } from '../sync/initial-backfill';
 import {
   saveConfig,
@@ -32,6 +32,7 @@ import { getDynamicOverview, syncDynamicBillUpdates } from '../dynamic-bill/sync
 import {
   getDynamicBillFilterPreference,
   getDynamicBillItems,
+  addDynamicBillFeedback,
   markDynamicBillItemOpened,
   markDynamicBillItemProcessed,
   markDynamicBillItemsConsumedByBvid,
@@ -250,6 +251,11 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
       const status = normalizeDynamicBillStatusFilter(request.params?.status);
       return { success: true, data: await setDynamicBillFilterPreference(status) as T };
     }
+    case 'ADD_DYNAMIC_BILL_FEEDBACK': {
+      const billKey = requireStringParam(request.params?.billKey, 'billKey');
+      const scope = normalizeDynamicBillFeedbackScope(request.params?.scope);
+      return { success: true, data: await addDynamicBillFeedback(billKey, scope) as T };
+    }
     case 'OPEN_DYNAMIC_BILL_VIDEO': {
       const billKey = requireStringParam(request.params?.billKey, 'billKey');
       const item = await markDynamicBillItemOpened(billKey);
@@ -296,6 +302,11 @@ function normalizeDynamicBillStatusFilter(value: unknown): DynamicBillStatusFilt
     return value;
   }
   throw new Error('INVALID_DYNAMIC_BILL_STATUS_FILTER');
+}
+
+function normalizeDynamicBillFeedbackScope(value: unknown): DynamicBillFeedbackScope {
+  if (value === 'creator' || value === 'topic') return value;
+  throw new Error('INVALID_DYNAMIC_BILL_FEEDBACK_SCOPE');
 }
 
 function requireStringParam(value: unknown, name: string): string {

--- a/src/background/storage/db.ts
+++ b/src/background/storage/db.ts
@@ -1,7 +1,7 @@
 import Dexie, { type Table } from 'dexie';
 import type { WatchHistoryRecord, PlayerEvent, DailyAggregate } from '../../shared/types/watch-event';
 import type { FavoriteFolder, FavoriteItem, SmartFavoriteIndex } from '../../shared/types/favorite';
-import type { DynamicBillItem, FollowedCreator, FollowedVideoUpdate } from '../../shared/types/dynamic-bill';
+import type { DynamicBillFeedbackRecord, DynamicBillItem, FollowedCreator, FollowedVideoUpdate } from '../../shared/types/dynamic-bill';
 
 export class BiliAnalyticsDB extends Dexie {
   watchHistory!: Table<WatchHistoryRecord, number>;
@@ -13,6 +13,7 @@ export class BiliAnalyticsDB extends Dexie {
   followedCreators!: Table<FollowedCreator, number>;
   followedVideoUpdates!: Table<FollowedVideoUpdate, number>;
   dynamicBillItems!: Table<DynamicBillItem, number>;
+  dynamicBillFeedback!: Table<DynamicBillFeedbackRecord, number>;
 
   constructor() {
     super('BiliAnalyticsDB');
@@ -96,6 +97,29 @@ export class BiliAnalyticsDB extends Dexie {
         '++id, &updateKey, dynamicId, bvid, authorMid, dynamicTime, pubtime, syncedAt',
       dynamicBillItems:
         '++id, &billKey, column, status, creatorMid, updateKey, generatedAt, localRank',
+    });
+
+    this.version(6).stores({
+      watchHistory:
+        '++id, kid, &sessionKey, avid, bvid, [avid+cid+viewAt], authorMid, tagName, viewAt, dt',
+      playerEvents:
+        '++id, [bvid+cid], eventType, timestamp, tabId',
+      dailyAggregates:
+        '++id, &date',
+      favoriteFolders:
+        '++id, &mediaId, title, syncedAt',
+      favoriteItems:
+        '++id, &itemKey, mediaId, avid, bvid, authorMid, tagName, favTime, syncedAt',
+      smartFavoriteIndex:
+        '++id, &itemKey, status, indexedAt, contentHash',
+      followedCreators:
+        '++id, &mid, followedAt, followAgeKnown, isActive, syncedAt, lastSeenAt',
+      followedVideoUpdates:
+        '++id, &updateKey, dynamicId, bvid, authorMid, dynamicTime, pubtime, syncedAt',
+      dynamicBillItems:
+        '++id, &billKey, column, status, creatorMid, updateKey, generatedAt, localRank',
+      dynamicBillFeedback:
+        '++id, [scope+key], scope, key, creatorMid, billKey, column, createdAt',
     });
   }
 }

--- a/src/background/storage/dynamic-bill-repo.ts
+++ b/src/background/storage/dynamic-bill-repo.ts
@@ -1,5 +1,10 @@
 import { DYNAMIC_UPDATE_WINDOW_DAYS } from '../../shared/constants';
 import type {
+  DynamicBillFeedbackRecord,
+  DynamicBillFeedbackResult,
+  DynamicBillFeedbackScope,
+  DynamicBillFeedbackSummary,
+  DynamicBillFeedbackThresholds,
   DynamicBillFilterPreference,
   DynamicBillColumn,
   DynamicBillItem,
@@ -28,6 +33,11 @@ const DEFAULT_FILTER_PREFERENCE: DynamicBillFilterPreference = {
   status: 'active',
   updatedAt: 0,
 };
+
+export interface DynamicBillFeedbackProfile {
+  creatorCountsByMid: Map<number, number>;
+  topicCountsByKey: Map<string, number>;
+}
 
 export async function replaceFollowedCreatorSnapshot(creators: FollowedCreator[], syncedAt: number): Promise<number> {
   const activeMids = new Set(creators.map(creator => creator.mid));
@@ -156,6 +166,52 @@ export async function setDynamicBillFilterPreference(
   };
   await chrome.storage.local.set({ [DYNAMIC_BILL_FILTER_KEY]: preference });
   return preference;
+}
+
+export async function addDynamicBillFeedback(
+  billKey: string,
+  scope: DynamicBillFeedbackScope,
+  createdAt = Date.now(),
+): Promise<DynamicBillFeedbackResult> {
+  const item = await db.dynamicBillItems.where('billKey').equals(billKey).first();
+  if (!item) throw new Error('DYNAMIC_BILL_ITEM_NOT_FOUND');
+
+  const feedback = buildDynamicBillFeedbackRecord(item, scope, createdAt);
+  const id = await db.dynamicBillFeedback.add(feedback);
+  const count = await db.dynamicBillFeedback
+    .where('[scope+key]')
+    .equals([feedback.scope, feedback.key])
+    .count();
+
+  return {
+    feedback: { ...feedback, id },
+    summary: buildDynamicBillFeedbackSummary(
+      feedback.scope,
+      feedback.key,
+      feedback.label,
+      count,
+    ),
+    item,
+  };
+}
+
+export async function getDynamicBillFeedbackProfile(): Promise<DynamicBillFeedbackProfile> {
+  const records = await db.dynamicBillFeedback.toArray();
+  const creatorCountsByMid = new Map<number, number>();
+  const topicCountsByKey = new Map<string, number>();
+
+  for (const record of records) {
+    if (record.scope === 'creator') {
+      const creatorMid = normalizeCreatorMid(record.creatorMid, record.key);
+      if (creatorMid === null) continue;
+      creatorCountsByMid.set(creatorMid, (creatorCountsByMid.get(creatorMid) ?? 0) + 1);
+    }
+    if (record.scope === 'topic' && record.key) {
+      topicCountsByKey.set(record.key, (topicCountsByKey.get(record.key) ?? 0) + 1);
+    }
+  }
+
+  return { creatorCountsByMid, topicCountsByKey };
 }
 
 export async function markDynamicBillItemOpened(billKey: string, openedAt = Date.now()): Promise<DynamicBillItem | null> {
@@ -326,6 +382,87 @@ function isEffectiveHistoryRecord(record: WatchHistoryRecord): boolean {
   return record.isFavorite
     || record.actualCompletion >= DYNAMIC_BILL_STRATEGY.positiveCompletionRate
     || record.progress >= DYNAMIC_BILL_STRATEGY.minPositiveWatchSeconds;
+}
+
+function buildDynamicBillFeedbackRecord(
+  item: DynamicBillItem,
+  scope: DynamicBillFeedbackScope,
+  createdAt: number,
+): DynamicBillFeedbackRecord {
+  if (scope === 'creator') {
+    return {
+      scope,
+      key: String(item.creatorMid),
+      label: item.creatorName || String(item.creatorMid),
+      billKey: item.billKey,
+      column: item.column,
+      creatorMid: item.creatorMid,
+      creatorName: item.creatorName,
+      createdAt,
+    };
+  }
+
+  if (scope === 'topic') {
+    const interest = item.evidence.interest;
+    if (!interest) throw new Error('DYNAMIC_BILL_TOPIC_FEEDBACK_UNAVAILABLE');
+    return {
+      scope,
+      key: interest.key,
+      label: `${interestKindLabel(interest.kind)}：${interest.label}`,
+      billKey: item.billKey,
+      column: item.column,
+      creatorMid: item.creatorMid,
+      creatorName: item.creatorName,
+      topicKind: interest.kind,
+      topicLabel: interest.label,
+      createdAt,
+    };
+  }
+
+  throw new Error('INVALID_DYNAMIC_BILL_FEEDBACK_SCOPE');
+}
+
+function buildDynamicBillFeedbackSummary(
+  scope: DynamicBillFeedbackScope,
+  key: string,
+  label: string,
+  count: number,
+): DynamicBillFeedbackSummary {
+  const thresholds = getDynamicBillFeedbackThresholds();
+  const blockCount = scope === 'creator'
+    ? thresholds.creatorBlockCount
+    : thresholds.topicBlockCount;
+
+  return {
+    scope,
+    key,
+    label,
+    count,
+    isDampened: count >= thresholds.dampenCount,
+    isBlocked: count >= blockCount,
+    shouldShowCreatorReviewPrompt:
+      scope === 'creator' && count >= thresholds.creatorReviewPromptCount,
+    thresholds,
+  };
+}
+
+function getDynamicBillFeedbackThresholds(): DynamicBillFeedbackThresholds {
+  return {
+    dampenCount: DYNAMIC_BILL_STRATEGY.feedbackDampenCount,
+    creatorBlockCount: DYNAMIC_BILL_STRATEGY.feedbackCreatorBlockCount,
+    topicBlockCount: DYNAMIC_BILL_STRATEGY.feedbackTopicBlockCount,
+    creatorReviewPromptCount: DYNAMIC_BILL_STRATEGY.feedbackCreatorReviewPromptCount,
+    scoreMultiplier: DYNAMIC_BILL_STRATEGY.feedbackScoreMultiplier,
+  };
+}
+
+function normalizeCreatorMid(creatorMid: unknown, key: string): number | null {
+  const raw = Number.isFinite(Number(creatorMid)) ? Number(creatorMid) : Number(key);
+  return Number.isFinite(raw) && raw > 0 ? raw : null;
+}
+
+function interestKindLabel(kind: string): string {
+  return kind === 'category' ? '分区' : '标签';
 }
 
 function isDynamicBillStatusFilter(status: unknown): status is DynamicBillStatusFilter {

--- a/src/shared/types/dynamic-bill.ts
+++ b/src/shared/types/dynamic-bill.ts
@@ -39,6 +39,7 @@ export type DynamicBillStatus = 'unopened' | 'opened' | 'consumed' | 'processed'
 export type DynamicBillStatusFilter = 'active' | DynamicBillStatus;
 export type DynamicBillInterestKind = 'category' | 'tag';
 export type DynamicBillFollowMemorySignal = 'long_follow' | 'special_follow' | 'weak_watch';
+export type DynamicBillFeedbackScope = 'creator' | 'topic';
 
 export type DynamicSyncStatus = 'idle' | 'syncing' | 'success' | 'not_logged_in' | 'failed';
 export type DynamicSyncStage = 'idle' | 'following' | 'dynamic-feed' | 'video-detail' | 'storage' | 'complete';
@@ -66,6 +67,45 @@ export interface DynamicBillOverview {
 export interface DynamicBillFilterPreference {
   status: DynamicBillStatusFilter;
   updatedAt: number;
+}
+
+export interface DynamicBillFeedbackRecord {
+  id?: number;
+  scope: DynamicBillFeedbackScope;
+  key: string;
+  label: string;
+  billKey: string;
+  column: DynamicBillColumn;
+  creatorMid: number;
+  creatorName: string;
+  topicKind?: DynamicBillInterestKind;
+  topicLabel?: string;
+  createdAt: number;
+}
+
+export interface DynamicBillFeedbackThresholds {
+  dampenCount: number;
+  creatorBlockCount: number;
+  topicBlockCount: number;
+  creatorReviewPromptCount: number;
+  scoreMultiplier: number;
+}
+
+export interface DynamicBillFeedbackSummary {
+  scope: DynamicBillFeedbackScope;
+  key: string;
+  label: string;
+  count: number;
+  isDampened: boolean;
+  isBlocked: boolean;
+  shouldShowCreatorReviewPrompt: boolean;
+  thresholds: DynamicBillFeedbackThresholds;
+}
+
+export interface DynamicBillFeedbackResult {
+  feedback: DynamicBillFeedbackRecord;
+  summary: DynamicBillFeedbackSummary;
+  item: DynamicBillItem;
 }
 
 export interface DynamicSyncResult {
@@ -139,6 +179,11 @@ export interface DynamicBillThresholdEvidence {
   minBuriedWeakWatchCount: number;
   maxBuriedRecentWatchCount: number;
   maxBuriedRecentPositiveWatchCount: number;
+  feedbackDampenCount: number;
+  feedbackCreatorBlockCount: number;
+  feedbackTopicBlockCount: number;
+  feedbackCreatorReviewPromptCount: number;
+  feedbackScoreMultiplier: number;
 }
 
 export interface DynamicBillInterestEvidence {
@@ -191,6 +236,7 @@ export interface DynamicBillGenerateResult {
   excludedNoLongSignalCount: number;
   excludedRecentActiveCount: number;
   excludedRecentSameVideoCount: number;
+  excludedByFeedbackCount: number;
   columnItemCounts: Record<DynamicBillColumn, number>;
   columnEligibleCounts: Record<DynamicBillColumn, number>;
   items: DynamicBillItem[];

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -1,5 +1,5 @@
 import type { QuickStats, DashboardOverview, CategoryDistribution, InterestDrift, DurationBucket, CreatorRanking, NewCreator, BehaviorMetrics, WeeklyTip, BlindBoxItem } from './analytics';
-import type { DynamicBillFilterPreference, DynamicBillGenerateResult, DynamicBillItem, DynamicBillOverview, DynamicSyncResult } from './dynamic-bill';
+import type { DynamicBillFeedbackResult, DynamicBillFilterPreference, DynamicBillGenerateResult, DynamicBillItem, DynamicBillOverview, DynamicSyncResult } from './dynamic-bill';
 import type { FavoriteSyncResult, SmartFavoriteOverview, SmartFavoriteResult, SmartFavoriteSearchResponse, SmartIndexResult } from './favorite';
 
 // Popup / Dashboard → Service Worker
@@ -29,6 +29,7 @@ export type RequestAction =
   | 'GET_DYNAMIC_BILL_ITEMS'
   | 'GET_DYNAMIC_BILL_FILTER'
   | 'UPDATE_DYNAMIC_BILL_FILTER'
+  | 'ADD_DYNAMIC_BILL_FEEDBACK'
   | 'OPEN_DYNAMIC_BILL_VIDEO'
   | 'MARK_DYNAMIC_BILL_ITEM_PROCESSED';
 
@@ -150,3 +151,4 @@ export type DynamicBillGenerateResponse = BiliVizResponse<DynamicBillGenerateRes
 export type DynamicBillItemsResponse = BiliVizResponse<DynamicBillItem[]>;
 export type DynamicBillItemResponse = BiliVizResponse<DynamicBillItem | null>;
 export type DynamicBillFilterResponse = BiliVizResponse<DynamicBillFilterPreference>;
+export type DynamicBillFeedbackResponse = BiliVizResponse<DynamicBillFeedbackResult>;


### PR DESCRIPTION
﻿## Summary

Implements the local feedback loop for Bili-Bill dynamic bills.

- Adds local creator/topic feedback storage and the `ADD_DYNAMIC_BILL_FEEDBACK` message path.
- Adds Dashboard actions: “少提醒这个 UP” and “少提醒这个主题”. Feedback is independent from `processed` and does not advance `unopened/opened/consumed/processed`.
- Applies local feedback in subsequent `GENERATE_DYNAMIC_BILL` runs for `afk_update`, `variety`, and `buried_follow`.
- Shows a low-pressure “是否考虑取关这个 UP？” prompt after repeated creator feedback, with only “打开 UP 主页” and “暂不处理”. No Bilibili follow relation API is called.

Closes #9

## Feedback thresholds

- First feedback (`feedbackDampenCount = 1`) lowers future matching candidate score by `feedbackScoreMultiplier = 0.35`.
- Creator feedback blocks matching UP candidates at `feedbackCreatorBlockCount = 3`.
- Topic feedback blocks matching topic candidates at `feedbackTopicBlockCount = 2`.
- Creator review prompt appears at `feedbackCreatorReviewPromptCount = 2`.

## Storage

- New Dexie v6 table: `dynamicBillFeedback`.
- Indexed as `++id, [scope+key], scope, key, creatorMid, billKey, column, createdAt`.
- Feedback records are append-only local events. They are not uploaded and are not written back to Bilibili.

## Generation rules

- `afk_update` and `buried_follow` evaluate creator feedback by `creatorMid`.
- `variety` evaluates creator feedback by `creatorMid` and topic feedback by `evidence.interest.key`.
- Below block threshold, matching candidates remain eligible but are score-dampened before ranking.
- At block threshold, matching candidates are skipped and counted in `excludedByFeedbackCount`.
- Existing item four-state merge semantics are preserved through `replaceDynamicBillItemsForColumn`.

## Validation

- `git diff --check`
- `npm run typecheck`
- `npm run build`
- Browser mock QA with Playwright fallback because the Browser plugin was not available in this session:
  - page identity / not blank / no framework overlay
  - “少提醒这个 UP” does not change item status
  - creator feedback lowers rank after regeneration
  - repeated creator feedback shows the review prompt
  - creator feedback blocks at threshold
  - “少提醒这个主题” lowers `variety` rank using `evidence.interest.key`
  - topic feedback blocks at threshold
  - no relation/modify/unfollow-style Bilibili write action was called
  - no relevant console errors

## Remaining risk

- Feedback has no retention/undo UI yet; records are append-only local events.
- Browser QA used deterministic mocked dynamic-bill data, not a live Bilibili account sync.
- Existing Vite build still emits the pre-existing large chunk warning for `chunks/theme-*`.
