### PR TITLE
Implement dynamic bill AI explanations

### DIFF
--- a/dashboard/modules/dynamic-bill/DynamicBillPage.tsx
+++ b/dashboard/modules/dynamic-bill/DynamicBillPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from "preact/hooks";
 import type {
   DynamicBillColumn,
+  DynamicBillExplanation,
+  DynamicBillExplanationResult,
   DynamicBillFeedbackResult,
   DynamicBillFeedbackScope,
   DynamicBillFilterPreference,
@@ -13,6 +15,7 @@ import type {
   DynamicSyncResult,
   DynamicSyncStatus,
 } from "../../../src/shared/types/dynamic-bill";
+import type { UserConfig } from "../../../src/shared/types/config";
 import { requestSW } from "../../utils/messaging";
 
 const STATUS_FILTERS: Array<{
@@ -67,9 +70,11 @@ export function DynamicBillPage() {
   const [statusFilter, setStatusFilter] = useState<DynamicBillStatusFilter>("active");
   const [overview, setOverview] = useState<DynamicBillOverview | null>(null);
   const [items, setItems] = useState<DynamicBillItem[]>([]);
+  const [userConfig, setUserConfig] = useState<UserConfig | null>(null);
   const [selectedBillKey, setSelectedBillKey] = useState("");
   const [syncing, setSyncing] = useState(false);
   const [generating, setGenerating] = useState(false);
+  const [explaining, setExplaining] = useState(false);
   const [processingBillKey, setProcessingBillKey] = useState("");
   const [creatorReviewPrompt, setCreatorReviewPrompt] =
     useState<CreatorReviewPrompt | null>(null);
@@ -78,6 +83,13 @@ export function DynamicBillPage() {
     STATUS_FILTERS.find((item) => item.key === statusFilter) ?? STATUS_FILTERS[0];
   const syncState = overview?.syncState;
   const isSyncing = syncing || syncState?.status === "syncing";
+  const isAiEnabled = userConfig?.dynamicBill.aiExplanationsEnabled === true;
+  const isAiConfigured = Boolean(userConfig?.ai.apiKey.trim());
+  const aiAvailability = {
+    enabled: isAiEnabled,
+    configured: isAiConfigured,
+    model: userConfig?.ai.chatModel ?? "",
+  };
   const overviewNotice = overview
     ? describeOverview(overview)
     : "正在读取动态账单同步状态。";
@@ -104,6 +116,9 @@ export function DynamicBillPage() {
   const statusCounts = useMemo(() => countByStatus(items), [items]);
 
   useEffect(() => {
+    refreshConfig().catch((error) => {
+      setNotice(`读取 AI 配置失败：${describeError(error)}`);
+    });
     refreshFilterPreference().catch((error) => {
       setNotice(`读取筛选偏好失败：${describeError(error)}`);
     });
@@ -126,6 +141,10 @@ export function DynamicBillPage() {
       "GET_DYNAMIC_BILL_OVERVIEW",
     );
     setOverview(next);
+  }
+
+  async function refreshConfig() {
+    setUserConfig(await requestSW<UserConfig>("GET_CONFIG"));
   }
 
   async function refreshFilterPreference() {
@@ -244,6 +263,77 @@ export function DynamicBillPage() {
     }
   }
 
+  async function handleToggleAiExplanations() {
+    const current = userConfig ?? await requestSW<UserConfig>("GET_CONFIG");
+    const nextEnabled = !current.dynamicBill.aiExplanationsEnabled;
+    setNotice("");
+    try {
+      await requestSW("UPDATE_CONFIG", {
+        dynamicBill: {
+          aiExplanationsEnabled: nextEnabled,
+        },
+      });
+      await refreshConfig();
+      setNotice(nextEnabled
+        ? "已启用动态账单 AI 解释；生成时只会发送已入选账单项的必要视频元数据和紧凑证据事实。"
+        : "已关闭动态账单 AI 解释；页面继续显示本地证据 fallback。");
+    } catch (error) {
+      setNotice(`更新 AI 解释开关失败：${describeError(error)}`);
+    }
+  }
+
+  async function handleBuildExplanations() {
+    setExplaining(true);
+    setNotice("");
+    try {
+      const total: DynamicBillExplanationResult = {
+        status: "idle",
+        processed: 0,
+        generated: 0,
+        failed: 0,
+        skipped: 0,
+        fallback: 0,
+        pending: 0,
+        items,
+      };
+      let guard = Math.ceil(Math.max(items.length, 1) / 6) + 2;
+      let includeFailedInNextBatch = true;
+      do {
+        const batch = await requestSW<DynamicBillExplanationResult>(
+          "BUILD_DYNAMIC_BILL_EXPLANATIONS",
+          {
+            maxItems: 6,
+            includeFailed: includeFailedInNextBatch,
+          },
+        );
+        includeFailedInNextBatch = false;
+        total.status = batch.status;
+        total.processed += batch.processed;
+        total.generated += batch.generated;
+        total.failed += batch.failed;
+        total.skipped += batch.skipped;
+        total.fallback += batch.fallback;
+        total.pending = batch.pending;
+        total.items = batch.items;
+        setItems(batch.items);
+        setNotice(describeExplanationResult(total));
+        if (
+          batch.status === "disabled"
+          || batch.status === "not_configured"
+          || batch.processed === 0
+        ) {
+          break;
+        }
+      } while (total.pending > 0 && guard-- > 0);
+      await refreshBillItems();
+    } catch (error) {
+      setNotice(`生成 AI 解释失败：${describeError(error)}。页面仍展示本地证据 fallback。`);
+      await refreshBillItems().catch(() => {});
+    } finally {
+      setExplaining(false);
+    }
+  }
+
   async function handleSync() {
     setSyncing(true);
     setNotice("");
@@ -281,19 +371,19 @@ export function DynamicBillPage() {
           <span className="dynamic-bill-kicker">消费前 / 已关注视频投稿</span>
           <h2>动态账单</h2>
           <p>
-            久违更新、换换口味和被淹没的关注用本地观看历史、关注快照和最近投稿池生成，不接 AI，也不上传完整历史或完整关注列表。
+            久违更新、换换口味和被淹没的关注由本地规则入选和排序；AI 只生成解释展示，未启用、未配置或失败时继续显示本地证据 fallback。
           </p>
         </div>
         <div className="dynamic-bill-scope">
-          <strong>本地证据范围</strong>
+          <strong>解释数据范围</strong>
           <span>
-            同步已关注 UP 最近 7 天视频投稿；生成时按长期正反馈、长期兴趣落差或关注记忆信号分别入栏，并排除近期已看过的同一新视频。
+            AI 只接收已入选账单项的新视频标题/简介、UP 名、分区/标签、发布时间、时长和紧凑证据事实；不发送完整历史、完整关注列表、Cookie、用户 mid、个人资料或反馈记录。
           </span>
           <div className="dynamic-bill-scope-actions">
             <button
               type="button"
               className="dynamic-bill-sync-button"
-              disabled={isSyncing || generating}
+              disabled={isSyncing || generating || explaining}
               onClick={handleSync}
             >
               {isSyncing ? "同步中..." : "同步并刷新"}
@@ -301,10 +391,26 @@ export function DynamicBillPage() {
             <button
               type="button"
               className="dynamic-bill-sync-button is-secondary"
-              disabled={isSyncing || generating}
+              disabled={isSyncing || generating || explaining}
               onClick={handleGenerate}
             >
               {generating ? "生成中..." : "生成本地账单"}
+            </button>
+            <button
+              type="button"
+              className="dynamic-bill-sync-button is-secondary"
+              disabled={isSyncing || generating || explaining || items.length === 0}
+              onClick={handleBuildExplanations}
+            >
+              {explaining ? "解释生成中..." : "生成 AI 解释"}
+            </button>
+            <button
+              type="button"
+              className="dynamic-bill-sync-button is-ghost"
+              disabled={isSyncing || generating || explaining}
+              onClick={handleToggleAiExplanations}
+            >
+              {isAiEnabled ? "关闭 AI 解释" : "启用 AI 解释"}
             </button>
           </div>
         </div>
@@ -342,7 +448,7 @@ export function DynamicBillPage() {
       >
         <strong>{notice || overviewNotice}</strong>
         <span>
-          本切片启用三类本地证据栏目；状态只会从未打开向已打开、已消费、已处理推进。少提醒反馈只写入本地，后续生成会按 UP 或主题降权，达到阈值后不再写入候选。
+          本切片启用三类本地证据栏目；状态只会从未打开向已打开、已消费、已处理推进。AI 置信度仅展示，不参与入选、排序、状态推进或少提醒规则。
         </span>
       </section>
 
@@ -447,6 +553,7 @@ export function DynamicBillPage() {
               onDismissCreatorReviewPrompt={() => setCreatorReviewPrompt(null)}
               onMarkProcessed={handleMarkProcessed}
               onOpenVideo={handleOpenVideo}
+              aiAvailability={aiAvailability}
             />
           ) : (
             <EmptyDetail status={activeStatus} />
@@ -458,6 +565,7 @@ export function DynamicBillPage() {
 }
 
 function BillItemDetail({
+  aiAvailability,
   busy,
   creatorReviewPrompt,
   item,
@@ -466,6 +574,11 @@ function BillItemDetail({
   onMarkProcessed,
   onOpenVideo,
 }: {
+  aiAvailability: {
+    enabled: boolean;
+    configured: boolean;
+    model: string;
+  };
   busy: boolean;
   creatorReviewPrompt: CreatorReviewPrompt | null;
   item: DynamicBillItem;
@@ -486,6 +599,7 @@ function BillItemDetail({
       <p>
         新投稿：{evidence.newVideo.title || evidence.newVideo.bvid}
       </p>
+      <ExplanationPanel item={item} aiAvailability={aiAvailability} />
       <div className="dynamic-bill-status-copy">
         <strong>处理状态</strong>
         <span>{statusFlowCopy(item)}</span>
@@ -623,6 +737,73 @@ function BillItemDetail({
   );
 }
 
+function ExplanationPanel({
+  aiAvailability,
+  item,
+}: {
+  aiAvailability: {
+    enabled: boolean;
+    configured: boolean;
+    model: string;
+  };
+  item: DynamicBillItem;
+}) {
+  const explanation = item.explanation;
+  const hasAiExplanation = explanation?.status === "generated";
+  const summary = hasAiExplanation
+    ? explanation.summary
+    : localFallbackSummary(item);
+  const reason = hasAiExplanation
+    ? explanation.reason
+    : localFallbackReason(item);
+  const viewingAngle = hasAiExplanation
+    ? explanation.viewingAngle
+    : localFallbackViewingAngle(item);
+  const keywords = hasAiExplanation
+    ? explanation.keywords
+    : localFallbackKeywords(item);
+
+  return (
+    <div
+      className={`dynamic-bill-ai-panel ${hasAiExplanation ? "is-ai" : "is-fallback"}`}
+      data-testid={`dynamic-bill-explanation-${hasAiExplanation ? "ai" : "fallback"}`}
+    >
+      <div className="dynamic-bill-ai-head">
+        <div>
+          <strong>{hasAiExplanation ? "AI 解释" : "本地证据 fallback"}</strong>
+          <span>{explanationStateCopy(explanation, aiAvailability)}</span>
+        </div>
+        {hasAiExplanation ? (
+          <em title="confidence 只展示，不参与入选、排序或后续规则">
+            置信度 {Math.round(explanation.confidence * 100)}%
+          </em>
+        ) : null}
+      </div>
+      <div className="dynamic-bill-ai-grid">
+        <section>
+          <span>摘要</span>
+          <p>{summary}</p>
+        </section>
+        <section>
+          <span>为什么出现</span>
+          <p>{reason}</p>
+        </section>
+        <section>
+          <span>观看角度</span>
+          <p>{viewingAngle}</p>
+        </section>
+      </div>
+      {keywords.length > 0 ? (
+        <div className="dynamic-bill-keywords" aria-label="解释关键词">
+          {keywords.map((keyword) => (
+            <span key={keyword}>{keyword}</span>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function EmptyDetail({
   status,
 }: {
@@ -698,6 +879,17 @@ function describeSyncResult(result: DynamicSyncResult): string {
 
 function describeGenerateResult(result: DynamicBillGenerateResult): string {
   return `本地账单生成 ${result.itemCount} 项：久违更新 ${result.columnItemCounts.afk_update} 项，换换口味 ${result.columnItemCounts.variety} 项，被淹没的关注 ${result.columnItemCounts.buried_follow} 项；扫描最近投稿 ${result.candidatesScanned} 条，排除近期已看同视频 ${result.excludedRecentSameVideoCount} 条，长期/关注记忆证据不足 ${result.excludedNoLongSignalCount} 个，近期仍活跃 ${result.excludedRecentActiveCount} 个，本地少提醒阈值排除 ${result.excludedByFeedbackCount} 个。`;
+}
+
+function describeExplanationResult(result: DynamicBillExplanationResult): string {
+  if (result.status === "disabled") {
+    return `AI 解释未启用，已为 ${result.fallback} 个账单项展示本地证据 fallback。`;
+  }
+  if (result.status === "not_configured") {
+    return `AI 未配置 API Key，已为 ${result.fallback} 个账单项展示本地证据 fallback。`;
+  }
+  const pending = result.pending > 0 ? `，剩余 ${result.pending} 个待处理` : "";
+  return `AI 解释处理 ${result.processed} 项：成功 ${result.generated} 项，失败 ${result.failed} 项，跳过 ${result.skipped} 项${pending}；失败项仍展示本地证据 fallback。`;
 }
 
 function describeFeedbackResult(result: DynamicBillFeedbackResult): string {
@@ -790,6 +982,73 @@ function cardFact(item: DynamicBillItem): string {
     return `${interestKindLabel(interest.kind)}「${interest.label}」 · 长期占比 ${formatPercent(interest.longPositiveShare)} · 下降 ${formatPercent(interest.positiveDropRatio)}`;
   }
   return `长期正反馈 ${item.evidence.longWindow.positiveWatchCount} 次 · 近期正反馈 ${item.evidence.recentWindow.positiveWatchCount} 次`;
+}
+
+function explanationStateCopy(
+  explanation: DynamicBillExplanation | undefined,
+  aiAvailability: {
+    enabled: boolean;
+    configured: boolean;
+    model: string;
+  },
+): string {
+  if (explanation?.status === "generated") {
+    return `由 ${explanation.model || aiAvailability.model || "AI"} 生成；只用于展示解释，不参与入选、排序或后续规则。`;
+  }
+  if (explanation?.status === "failed") {
+    return `AI 生成失败：${explanation.error ?? "未知错误"}；以下使用本地规则事实解释。`;
+  }
+  if (explanation?.status === "not_configured" || (aiAvailability.enabled && !aiAvailability.configured)) {
+    return "AI 未配置 API Key；以下使用本地规则事实解释。";
+  }
+  if (explanation?.status === "disabled" || !aiAvailability.enabled) {
+    return "AI 解释未启用；以下使用本地规则事实解释。";
+  }
+  return "尚未生成 AI 解释；以下使用本地规则事实解释。";
+}
+
+function localFallbackSummary(item: DynamicBillItem): string {
+  return `来自已关注 UP「${item.creatorName}」的新投稿《${item.evidence.newVideo.title || item.evidence.newVideo.bvid}》。`;
+}
+
+function localFallbackReason(item: DynamicBillItem): string {
+  const facts = localExplanationFacts(item).slice(0, 2).join(" ");
+  return `这个视频出现是因为它已由「${columnTitle(item.column)}」本地规则入选：${facts || localColumnReason(item)}。`;
+}
+
+function localFallbackViewingAngle(item: DynamicBillItem): string {
+  if (item.column === "variety" && item.evidence.interest) {
+    return `把它当作回到「${item.evidence.interest.label}」这个长期兴趣的一次口味切换。`;
+  }
+  if (item.column === "buried_follow") {
+    return "把它当作一次低压力回访，判断这个长期关注是否仍值得保留注意力。";
+  }
+  return "先看它是否能补回一条近期冷却的历史兴趣线。";
+}
+
+function localFallbackKeywords(item: DynamicBillItem): string[] {
+  return Array.from(new Set([
+    columnTitle(item.column),
+    item.evidence.newVideo.tagName,
+    ...(item.evidence.interest ? [item.evidence.interest.label] : []),
+    ...item.evidence.newVideo.tags,
+  ].map((keyword) => keyword.trim()).filter(Boolean))).slice(0, 8);
+}
+
+function localExplanationFacts(item: DynamicBillItem): string[] {
+  return item.evidence.facts
+    .filter((fact) => !fact.includes("少提醒") && !fact.includes("反馈"))
+    .slice(0, 3);
+}
+
+function localColumnReason(item: DynamicBillItem): string {
+  if (item.column === "variety" && item.evidence.interest) {
+    return `长期兴趣「${item.evidence.interest.label}」近期下降，但最近有已关注 UP 新投稿命中。`;
+  }
+  if (item.column === "buried_follow") {
+    return "关注关系仍在，本地近期观看缺席或近乎缺席，且最近有新投稿。";
+  }
+  return "长期窗口有正反馈、近期冷却，且最近有新投稿。";
 }
 
 function thresholdCopy(evidence: DynamicBillEvidence): string {

--- a/dashboard/styles/dashboard.css
+++ b/dashboard/styles/dashboard.css
@@ -340,7 +340,7 @@ button {
 
 .dynamic-bill-scope-actions {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(108px, 1fr));
   gap: 7px;
   margin-top: 4px;
 }
@@ -352,6 +352,11 @@ button {
 .dynamic-bill-sync-button.is-secondary {
   border-color: rgba(0, 161, 214, 0.44);
   background: rgba(0, 161, 214, 0.18);
+}
+
+.dynamic-bill-sync-button.is-ghost {
+  border-color: rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .dynamic-bill-sync-button:disabled {
@@ -685,6 +690,102 @@ button {
   color: var(--text-secondary);
   font-size: 12px;
   line-height: 1.45;
+}
+
+.dynamic-bill-ai-panel {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.dynamic-bill-ai-panel.is-ai {
+  border-color: rgba(0, 161, 214, 0.38);
+  background: rgba(0, 161, 214, 0.08);
+}
+
+.dynamic-bill-ai-panel.is-fallback {
+  border-color: rgba(245, 158, 11, 0.35);
+  background: rgba(245, 158, 11, 0.08);
+}
+
+.dynamic-bill-ai-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.dynamic-bill-ai-head div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.dynamic-bill-ai-head strong {
+  color: #FFFFFF;
+  font-size: 13px;
+}
+
+.dynamic-bill-ai-head span {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.dynamic-bill-ai-head em {
+  flex: none;
+  min-height: 22px;
+  padding: 4px 7px;
+  border-radius: 999px;
+  color: #8FDDF6;
+  background: rgba(0, 161, 214, 0.16);
+  font-size: 11px;
+  font-style: normal;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.dynamic-bill-ai-grid {
+  display: grid;
+  gap: 8px;
+}
+
+.dynamic-bill-ai-grid section {
+  display: grid;
+  gap: 3px;
+}
+
+.dynamic-bill-ai-grid span {
+  color: #8FDDF6;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.dynamic-bill-ai-grid p {
+  margin: 0;
+  color: #D5DCE8;
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.dynamic-bill-keywords {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.dynamic-bill-keywords span {
+  min-height: 22px;
+  padding: 4px 7px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  color: #A8B4C6;
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 11px;
+  font-weight: 750;
 }
 
 .dynamic-bill-creator-review {

--- a/src/background/dynamic-bill/ai.ts
+++ b/src/background/dynamic-bill/ai.ts
@@ -1,0 +1,469 @@
+import type {
+  DynamicBillColumn,
+  DynamicBillExplanation,
+  DynamicBillExplanationResult,
+  DynamicBillExplanationRunStatus,
+  DynamicBillExplanationStatus,
+  DynamicBillItem,
+} from '../../shared/types/dynamic-bill';
+import type { AiConfig } from '../../shared/types/config';
+import { chatJson } from '../ai/openai-compatible';
+import { loadConfig } from '../storage/config-store';
+import { db } from '../storage/db';
+import {
+  getDynamicBillItems,
+  putDynamicBillExplanation,
+} from '../storage/dynamic-bill-repo';
+
+interface BuildDynamicBillExplanationOptions {
+  maxItems?: number;
+  includeFailed?: boolean;
+}
+
+interface AiExplanationResponse {
+  summary?: unknown;
+  reason?: unknown;
+  viewingAngle?: unknown;
+  keywords?: unknown;
+  confidence?: unknown;
+}
+
+interface DynamicBillExplanationPayload {
+  column: string;
+  video: {
+    title: string;
+    intro: string;
+    authorName: string;
+    tagName: string;
+    tags: string[];
+    durationSeconds: number;
+    publishedAt: string;
+  };
+  localEvidence: {
+    facts: string[];
+    longWindow: {
+      days: number;
+      watchedCount: number;
+      positiveWatchCount: number;
+      avgCompletion: number;
+    };
+    recentWindow: {
+      days: number;
+      watchedCount: number;
+      positiveWatchCount: number;
+      avgCompletion: number;
+    };
+    follow: {
+      known: boolean;
+      ageDays?: number;
+      special?: boolean;
+    };
+    interest?: {
+      kind: string;
+      label: string;
+      longPositiveShare: number;
+      recentPositiveShare: number;
+      positiveDropRatio: number;
+    };
+  };
+}
+
+const DEFAULT_EXPLANATION_BATCH_SIZE = 6;
+const MAX_EXPLANATION_BATCH_SIZE = 12;
+const MAX_FACTS_IN_PROMPT = 7;
+
+export async function buildDynamicBillExplanations(
+  options: BuildDynamicBillExplanationOptions = {},
+): Promise<DynamicBillExplanationResult> {
+  const config = await loadConfig();
+  const items = await getDynamicBillItems();
+  const maxItems = Math.max(
+    1,
+    Math.min(
+      Math.floor(options.maxItems ?? DEFAULT_EXPLANATION_BATCH_SIZE),
+      MAX_EXPLANATION_BATCH_SIZE,
+    ),
+  );
+  const includeFailed = options.includeFailed !== false;
+
+  if (items.length === 0) {
+    return emptyResult('idle', items);
+  }
+
+  if (!config.dynamicBill.aiExplanationsEnabled) {
+    const fallback = await writeFallbackExplanations(
+      items,
+      'disabled',
+      config.ai.chatModel,
+      'DYNAMIC_BILL_AI_DISABLED',
+    );
+    return {
+      status: 'disabled',
+      processed: fallback,
+      generated: 0,
+      failed: 0,
+      skipped: 0,
+      fallback,
+      pending: 0,
+      items: await getDynamicBillItems(),
+    };
+  }
+
+  if (!config.ai.apiKey.trim()) {
+    const fallback = await writeFallbackExplanations(
+      items,
+      'not_configured',
+      config.ai.chatModel,
+      'AI_API_KEY_MISSING',
+    );
+    return {
+      status: 'not_configured',
+      processed: fallback,
+      generated: 0,
+      failed: 0,
+      skipped: 0,
+      fallback,
+      pending: 0,
+      items: await getDynamicBillItems(),
+    };
+  }
+
+  let processed = 0;
+  let generated = 0;
+  let failed = 0;
+  let skipped = 0;
+  let processable = 0;
+
+  for (const item of items) {
+    const payload = await buildDynamicBillExplanationPayload(item);
+    const contentHash = hashText(JSON.stringify(payload));
+    if (!shouldProcessItem(item, contentHash, config.ai.chatModel, includeFailed)) {
+      skipped++;
+      continue;
+    }
+
+    processable++;
+    if (processed >= maxItems) continue;
+
+    try {
+      const ai = await createAiExplanation(payload, config.ai);
+      await putDynamicBillExplanation(normalizeAiExplanation(
+        item,
+        ai,
+        config.ai.chatModel,
+        contentHash,
+      ));
+      generated++;
+    } catch (error) {
+      await putDynamicBillExplanation(buildFallbackExplanation(
+        item,
+        'failed',
+        config.ai.chatModel,
+        contentHash,
+        errorMessage(error),
+      ));
+      failed++;
+    }
+    processed++;
+  }
+
+  return {
+    status: runStatus(generated, failed, processed),
+    processed,
+    generated,
+    failed,
+    skipped,
+    fallback: failed,
+    pending: Math.max(0, processable - processed),
+    items: await getDynamicBillItems(),
+  };
+}
+
+export async function buildDynamicBillExplanationPayload(
+  item: DynamicBillItem,
+): Promise<DynamicBillExplanationPayload> {
+  const update = await db.followedVideoUpdates
+    .where('updateKey')
+    .equals(item.updateKey)
+    .first();
+  const evidence = item.evidence;
+
+  return {
+    column: columnTitle(item.column),
+    video: {
+      title: limitText(evidence.newVideo.title || update?.title || '未命名视频', 120),
+      intro: limitText(update?.intro || '', 360),
+      authorName: limitText(item.creatorName || update?.authorName || '未知 UP', 80),
+      tagName: limitText(evidence.newVideo.tagName || update?.tagName || '未知分区', 40),
+      tags: normalizeTextArray(evidence.newVideo.tags.length ? evidence.newVideo.tags : update?.tags).slice(0, 8),
+      durationSeconds: Math.max(0, Math.floor(evidence.newVideo.duration || update?.duration || 0)),
+      publishedAt: evidence.newVideo.pubtime > 0
+        ? new Date(evidence.newVideo.pubtime * 1000).toISOString()
+        : '',
+    },
+    localEvidence: {
+      facts: compactFacts(evidence.facts),
+      longWindow: {
+        days: evidence.longWindow.windowDays,
+        watchedCount: evidence.longWindow.watchedCount,
+        positiveWatchCount: evidence.longWindow.positiveWatchCount,
+        avgCompletion: roundRatio(evidence.longWindow.avgCompletion),
+      },
+      recentWindow: {
+        days: evidence.recentWindow.windowDays,
+        watchedCount: evidence.recentWindow.watchedCount,
+        positiveWatchCount: evidence.recentWindow.positiveWatchCount,
+        avgCompletion: roundRatio(evidence.recentWindow.avgCompletion),
+      },
+      follow: {
+        known: evidence.follow.followAgeKnown,
+        ageDays: evidence.follow.followAgeDays,
+        special: evidence.follow.special,
+      },
+      ...(evidence.interest ? {
+        interest: {
+          kind: evidence.interest.kind === 'category' ? '分区' : '标签',
+          label: evidence.interest.label,
+          longPositiveShare: evidence.interest.longPositiveShare,
+          recentPositiveShare: evidence.interest.recentPositiveShare,
+          positiveDropRatio: evidence.interest.positiveDropRatio,
+        },
+      } : {}),
+    },
+  };
+}
+
+async function createAiExplanation(
+  payload: DynamicBillExplanationPayload,
+  config: AiConfig,
+): Promise<AiExplanationResponse> {
+  return chatJson<AiExplanationResponse>(config, [
+    {
+      role: 'system',
+      content: [
+        '你是 Bili-Bill 动态账单解释助手。请只输出 JSON。',
+        '本地规则已经决定账单项入选和排序；你只生成摘要与解释，不得新增或改写入选规则。',
+        'reason 必须服从 localEvidence.facts，不要与本地事实冲突，不要声称用户一定喜欢或必须观看。',
+        'confidence 只表示你对摘要/解释质量的自评，范围 0 到 1。',
+        'JSON 字段：summary: string，reason: string，viewingAngle: string，keywords: string[]，confidence: number。',
+      ].join('\n'),
+    },
+    {
+      role: 'user',
+      content: JSON.stringify(payload),
+    },
+  ]);
+}
+
+function shouldProcessItem(
+  item: DynamicBillItem,
+  contentHash: string,
+  model: string,
+  includeFailed: boolean,
+): boolean {
+  const explanation = item.explanation;
+  if (!explanation) return true;
+
+  const sameContent = explanation.contentHash === contentHash;
+  const sameModel = explanation.model === model;
+  if (explanation.status === 'generated' && sameContent && sameModel) return false;
+  if (explanation.status === 'failed' && sameContent && sameModel && !includeFailed) return false;
+
+  return true;
+}
+
+async function writeFallbackExplanations(
+  items: DynamicBillItem[],
+  status: Extract<DynamicBillExplanationStatus, 'disabled' | 'not_configured'>,
+  model: string,
+  error: string,
+): Promise<number> {
+  let written = 0;
+  for (const item of items) {
+    const payload = await buildDynamicBillExplanationPayload(item);
+    const contentHash = hashText(JSON.stringify(payload));
+    const explanation = item.explanation;
+    if (
+      explanation?.status === status
+      && explanation.contentHash === contentHash
+      && explanation.model === model
+    ) {
+      continue;
+    }
+    await putDynamicBillExplanation(buildFallbackExplanation(
+      item,
+      status,
+      model,
+      contentHash,
+      error,
+    ));
+    written++;
+  }
+  return written;
+}
+
+function normalizeAiExplanation(
+  item: DynamicBillItem,
+  ai: AiExplanationResponse,
+  model: string,
+  contentHash: string,
+): DynamicBillExplanation {
+  return {
+    billKey: item.billKey,
+    status: 'generated',
+    summary: normalizeText(ai.summary, fallbackSummary(item), 120),
+    reason: normalizeText(ai.reason, fallbackReason(item), 220),
+    viewingAngle: normalizeText(ai.viewingAngle, fallbackViewingAngle(item), 160),
+    keywords: normalizeTextArray(ai.keywords).slice(0, 8),
+    confidence: normalizeConfidence(ai.confidence),
+    model,
+    generatedAt: Date.now(),
+    contentHash,
+  };
+}
+
+function buildFallbackExplanation(
+  item: DynamicBillItem,
+  status: DynamicBillExplanationStatus,
+  model: string,
+  contentHash: string,
+  error: string,
+): DynamicBillExplanation {
+  return {
+    billKey: item.billKey,
+    status,
+    summary: fallbackSummary(item),
+    reason: fallbackReason(item),
+    viewingAngle: fallbackViewingAngle(item),
+    keywords: fallbackKeywords(item),
+    confidence: 0,
+    model,
+    generatedAt: Date.now(),
+    contentHash,
+    error,
+  };
+}
+
+function fallbackSummary(item: DynamicBillItem): string {
+  return `来自已关注 UP「${item.creatorName}」的新投稿《${item.evidence.newVideo.title || item.evidence.newVideo.bvid}》。`;
+}
+
+function fallbackReason(item: DynamicBillItem): string {
+  const facts = compactFacts(item.evidence.facts).slice(0, 2).join(' ');
+  return `这个视频出现是因为它已经被「${columnTitle(item.column)}」本地规则入选：${facts || cardReason(item)}。`;
+}
+
+function fallbackViewingAngle(item: DynamicBillItem): string {
+  if (item.column === 'variety' && item.evidence.interest) {
+    return `把它当作回到「${item.evidence.interest.label}」这个长期兴趣的一次口味切换。`;
+  }
+  if (item.column === 'buried_follow') {
+    return '把它当作一次低压力回访，判断这个长期关注是否仍值得保留注意力。';
+  }
+  return '先看它是否能补回一条近期冷却的历史兴趣线。';
+}
+
+function fallbackKeywords(item: DynamicBillItem): string[] {
+  return Array.from(new Set([
+    columnTitle(item.column),
+    item.evidence.newVideo.tagName,
+    ...(item.evidence.interest ? [item.evidence.interest.label] : []),
+    ...item.evidence.newVideo.tags,
+  ].map(keyword => keyword.trim()).filter(Boolean))).slice(0, 8);
+}
+
+function cardReason(item: DynamicBillItem): string {
+  if (item.column === 'variety' && item.evidence.interest) {
+    return `长期兴趣「${item.evidence.interest.label}」近期下降，但最近有已关注 UP 新投稿命中。`;
+  }
+  if (item.column === 'buried_follow') {
+    return '关注关系仍在，本地近期观看缺席或近乎缺席，且最近有新投稿。';
+  }
+  return '长期窗口有正反馈、近期冷却，且最近有新投稿。';
+}
+
+function compactFacts(facts: string[]): string[] {
+  return facts
+    .filter(fact => !fact.includes('少提醒') && !fact.includes('反馈'))
+    .map(fact => limitText(fact, 180))
+    .slice(0, MAX_FACTS_IN_PROMPT);
+}
+
+function columnTitle(column: DynamicBillColumn): string {
+  switch (column) {
+    case 'afk_update':
+      return '久违更新';
+    case 'variety':
+      return '换换口味';
+    case 'buried_follow':
+      return '被淹没的关注';
+    default:
+      return column;
+  }
+}
+
+function runStatus(
+  generated: number,
+  failed: number,
+  processed: number,
+): DynamicBillExplanationRunStatus {
+  if (generated > 0 && failed === 0) return 'generated';
+  if (failed > 0 && generated === 0) return 'failed';
+  if (generated > 0) return 'generated';
+  return processed > 0 ? 'failed' : 'idle';
+}
+
+function emptyResult(
+  status: DynamicBillExplanationRunStatus,
+  items: DynamicBillItem[],
+): DynamicBillExplanationResult {
+  return {
+    status,
+    processed: 0,
+    generated: 0,
+    failed: 0,
+    skipped: 0,
+    fallback: 0,
+    pending: 0,
+    items,
+  };
+}
+
+function normalizeText(value: unknown, fallback: string, maxLength: number): string {
+  return limitText(typeof value === 'string' && value.trim() ? value.trim() : fallback, maxLength);
+}
+
+function normalizeTextArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map(item => typeof item === 'string' ? limitText(item.trim(), 24) : '')
+    .filter(Boolean);
+}
+
+function normalizeConfidence(value: unknown): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 0.5;
+  return roundRatio(Math.max(0, Math.min(1, numeric)));
+}
+
+function limitText(value: string, maxLength: number): string {
+  const trimmed = value.trim();
+  return trimmed.length > maxLength ? `${trimmed.slice(0, maxLength - 1)}…` : trimmed;
+}
+
+function roundRatio(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function hashText(text: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16);
+}

--- a/src/background/dynamic-bill/buried-follow.ts
+++ b/src/background/dynamic-bill/buried-follow.ts
@@ -364,7 +364,7 @@ function buildFacts(candidate: Candidate): string[] {
     `近期缺席证据：最近 ${recent.windowDays} 天观看 ${recent.watchedCount} 次、正反馈 ${recent.positiveWatchCount} 次；规则要求观看不超过 ${DYNAMIC_BILL_STRATEGY.maxBuriedRecentWatchCount} 次且正反馈为 ${DYNAMIC_BILL_STRATEGY.maxBuriedRecentPositiveWatchCount} 次。`,
     `新投稿证据：最近 ${DYNAMIC_BILL_STRATEGY.updateWindowDays} 天，已关注 UP「${candidate.creator.name || candidate.update.authorName}」发布《${candidate.update.title || candidate.update.bvid}》。`,
     `本地最近 ${DYNAMIC_BILL_STRATEGY.recentSameVideoWindowDays} 天未发现同一新视频 ${candidate.update.bvid} 的观看记录。`,
-    '入选只使用本地关注快照、观看历史聚合和最近投稿元数据，不接 AI，也不上传完整历史或完整关注列表。',
+    '入选只使用本地关注快照、观看历史聚合和最近投稿元数据；AI 不参与入选，也不上传完整历史或完整关注列表。',
   ];
 
   if (candidate.daysSinceLastWatch !== null) {

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -26,6 +26,7 @@ import { getDeviceData } from '../analytics/device';
 import { abortCurrentHistorySync, hasActiveHistorySyncAbortScope } from '../sync/sync-control';
 import { syncFavorites } from '../favorites/sync';
 import { buildSmartFavoriteIndex, getSmartFavoriteOverview, getSmartFavoritesByPath, searchSmartFavorites } from '../favorites/smart';
+import { buildDynamicBillExplanations } from '../dynamic-bill/ai';
 import { generateDynamicBillItems } from '../dynamic-bill/generator';
 import { DYNAMIC_BILL_STRATEGY } from '../dynamic-bill/strategy';
 import { getDynamicOverview, syncDynamicBillUpdates } from '../dynamic-bill/sync';
@@ -243,6 +244,14 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
       return { success: true, data: await syncDynamicBillUpdates() as T };
     case 'GENERATE_DYNAMIC_BILL':
       return { success: true, data: await generateDynamicBillItems() as T };
+    case 'BUILD_DYNAMIC_BILL_EXPLANATIONS': {
+      const maxItems = normalizePositiveInteger(request.params?.maxItems, 6);
+      const includeFailed = request.params?.includeFailed !== false;
+      return {
+        success: true,
+        data: await buildDynamicBillExplanations({ maxItems, includeFailed }) as T,
+      };
+    }
     case 'GET_DYNAMIC_BILL_ITEMS':
       return { success: true, data: await getDynamicBillItems() as T };
     case 'GET_DYNAMIC_BILL_FILTER':
@@ -322,4 +331,10 @@ function normalizeNonNegativeInteger(value: unknown, fallback: number): number {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return fallback;
   return Math.max(0, Math.floor(numeric));
+}
+
+function normalizePositiveInteger(value: unknown, fallback: number): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return fallback;
+  return Math.max(1, Math.floor(numeric));
 }

--- a/src/background/storage/config-store.ts
+++ b/src/background/storage/config-store.ts
@@ -16,6 +16,10 @@ export async function loadConfig(): Promise<UserConfig> {
         ...DEFAULT_CONFIG.ai,
         ...(result[CONFIG_KEY].ai ?? {}),
       },
+      dynamicBill: {
+        ...DEFAULT_CONFIG.dynamicBill,
+        ...(result[CONFIG_KEY].dynamicBill ?? {}),
+      },
     };
   }
   return DEFAULT_CONFIG;
@@ -29,6 +33,10 @@ export async function saveConfig(config: Partial<UserConfig>): Promise<void> {
     ai: {
       ...current.ai,
       ...(config.ai ?? {}),
+    },
+    dynamicBill: {
+      ...current.dynamicBill,
+      ...(config.dynamicBill ?? {}),
     },
   };
   await chrome.storage.local.set({ [CONFIG_KEY]: updated });

--- a/src/background/storage/db.ts
+++ b/src/background/storage/db.ts
@@ -1,7 +1,13 @@
 import Dexie, { type Table } from 'dexie';
 import type { WatchHistoryRecord, PlayerEvent, DailyAggregate } from '../../shared/types/watch-event';
 import type { FavoriteFolder, FavoriteItem, SmartFavoriteIndex } from '../../shared/types/favorite';
-import type { DynamicBillFeedbackRecord, DynamicBillItem, FollowedCreator, FollowedVideoUpdate } from '../../shared/types/dynamic-bill';
+import type {
+  DynamicBillExplanation,
+  DynamicBillFeedbackRecord,
+  DynamicBillItem,
+  FollowedCreator,
+  FollowedVideoUpdate,
+} from '../../shared/types/dynamic-bill';
 
 export class BiliAnalyticsDB extends Dexie {
   watchHistory!: Table<WatchHistoryRecord, number>;
@@ -13,6 +19,7 @@ export class BiliAnalyticsDB extends Dexie {
   followedCreators!: Table<FollowedCreator, number>;
   followedVideoUpdates!: Table<FollowedVideoUpdate, number>;
   dynamicBillItems!: Table<DynamicBillItem, number>;
+  dynamicBillExplanations!: Table<DynamicBillExplanation, number>;
   dynamicBillFeedback!: Table<DynamicBillFeedbackRecord, number>;
 
   constructor() {
@@ -120,6 +127,31 @@ export class BiliAnalyticsDB extends Dexie {
         '++id, &billKey, column, status, creatorMid, updateKey, generatedAt, localRank',
       dynamicBillFeedback:
         '++id, [scope+key], scope, key, creatorMid, billKey, column, createdAt',
+    });
+
+    this.version(7).stores({
+      watchHistory:
+        '++id, kid, &sessionKey, avid, bvid, [avid+cid+viewAt], authorMid, tagName, viewAt, dt',
+      playerEvents:
+        '++id, [bvid+cid], eventType, timestamp, tabId',
+      dailyAggregates:
+        '++id, &date',
+      favoriteFolders:
+        '++id, &mediaId, title, syncedAt',
+      favoriteItems:
+        '++id, &itemKey, mediaId, avid, bvid, authorMid, tagName, favTime, syncedAt',
+      smartFavoriteIndex:
+        '++id, &itemKey, status, indexedAt, contentHash',
+      followedCreators:
+        '++id, &mid, followedAt, followAgeKnown, isActive, syncedAt, lastSeenAt',
+      followedVideoUpdates:
+        '++id, &updateKey, dynamicId, bvid, authorMid, dynamicTime, pubtime, syncedAt',
+      dynamicBillItems:
+        '++id, &billKey, column, status, creatorMid, updateKey, generatedAt, localRank',
+      dynamicBillFeedback:
+        '++id, [scope+key], scope, key, creatorMid, billKey, column, createdAt',
+      dynamicBillExplanations:
+        '++id, &billKey, status, generatedAt, model, contentHash',
     });
   }
 }

--- a/src/background/storage/dynamic-bill-repo.ts
+++ b/src/background/storage/dynamic-bill-repo.ts
@@ -1,5 +1,6 @@
 import { DYNAMIC_UPDATE_WINDOW_DAYS } from '../../shared/constants';
 import type {
+  DynamicBillExplanation,
   DynamicBillFeedbackRecord,
   DynamicBillFeedbackResult,
   DynamicBillFeedbackScope,
@@ -138,10 +139,43 @@ export async function getDynamicBillItems(options: {
     items = items.filter(item => item.status === options.status);
   }
 
-  return items.sort((a, b) => {
+  const explanations = await getDynamicBillExplanationMap(items.map(item => item.billKey));
+
+  return items.map(item => ({
+    ...item,
+    explanation: explanations.get(item.billKey),
+  })).sort((a, b) => {
     if (a.status !== b.status) return statusOrder(a.status) - statusOrder(b.status);
     return a.localRank - b.localRank;
   });
+}
+
+export async function getDynamicBillExplanationMap(
+  billKeys: string[],
+): Promise<Map<string, DynamicBillExplanation>> {
+  const uniqueKeys = Array.from(new Set(billKeys.filter(Boolean)));
+  if (uniqueKeys.length === 0) return new Map();
+
+  const explanations = await db.dynamicBillExplanations
+    .where('billKey')
+    .anyOf(uniqueKeys)
+    .toArray();
+  return new Map(explanations.map(explanation => [explanation.billKey, explanation]));
+}
+
+export async function putDynamicBillExplanation(
+  explanation: DynamicBillExplanation,
+): Promise<DynamicBillExplanation> {
+  const existing = await db.dynamicBillExplanations
+    .where('billKey')
+    .equals(explanation.billKey)
+    .first();
+  const next: DynamicBillExplanation = {
+    ...explanation,
+    id: existing?.id,
+  };
+  await db.dynamicBillExplanations.put(next);
+  return next;
 }
 
 export async function getDynamicBillFilterPreference(): Promise<DynamicBillFilterPreference> {

--- a/src/shared/types/config.ts
+++ b/src/shared/types/config.ts
@@ -7,12 +7,17 @@ export interface UserConfig {
   showSidebar: boolean;
   theme: 'dark' | 'light';
   ai: AiConfig;
+  dynamicBill: DynamicBillConfig;
 }
 
 export interface AiConfig {
   baseURL: string;
   apiKey: string;
   chatModel: string;
+}
+
+export interface DynamicBillConfig {
+  aiExplanationsEnabled: boolean;
 }
 
 export const DEFAULT_CONFIG: UserConfig = {
@@ -27,5 +32,8 @@ export const DEFAULT_CONFIG: UserConfig = {
     baseURL: 'https://api.deepseek.com',
     apiKey: '',
     chatModel: 'deepseek-v4-flash',
+  },
+  dynamicBill: {
+    aiExplanationsEnabled: false,
   },
 };

--- a/src/shared/types/dynamic-bill.ts
+++ b/src/shared/types/dynamic-bill.ts
@@ -40,6 +40,8 @@ export type DynamicBillStatusFilter = 'active' | DynamicBillStatus;
 export type DynamicBillInterestKind = 'category' | 'tag';
 export type DynamicBillFollowMemorySignal = 'long_follow' | 'special_follow' | 'weak_watch';
 export type DynamicBillFeedbackScope = 'creator' | 'topic';
+export type DynamicBillExplanationStatus = 'generated' | 'failed' | 'not_configured' | 'disabled';
+export type DynamicBillExplanationRunStatus = 'idle' | DynamicBillExplanationStatus;
 
 export type DynamicSyncStatus = 'idle' | 'syncing' | 'success' | 'not_logged_in' | 'failed';
 export type DynamicSyncStage = 'idle' | 'following' | 'dynamic-feed' | 'video-detail' | 'storage' | 'complete';
@@ -106,6 +108,32 @@ export interface DynamicBillFeedbackResult {
   feedback: DynamicBillFeedbackRecord;
   summary: DynamicBillFeedbackSummary;
   item: DynamicBillItem;
+}
+
+export interface DynamicBillExplanation {
+  id?: number;
+  billKey: string;
+  status: DynamicBillExplanationStatus;
+  summary: string;
+  reason: string;
+  viewingAngle: string;
+  keywords: string[];
+  confidence: number;
+  model: string;
+  generatedAt: number;
+  contentHash: string;
+  error?: string;
+}
+
+export interface DynamicBillExplanationResult {
+  status: DynamicBillExplanationRunStatus;
+  processed: number;
+  generated: number;
+  failed: number;
+  skipped: number;
+  fallback: number;
+  pending: number;
+  items: DynamicBillItem[];
 }
 
 export interface DynamicSyncResult {
@@ -226,6 +254,7 @@ export interface DynamicBillItem {
   consumedAt?: number;
   processedAt?: number;
   generatedAt: number;
+  explanation?: DynamicBillExplanation;
 }
 
 export interface DynamicBillGenerateResult {

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -1,5 +1,13 @@
 import type { QuickStats, DashboardOverview, CategoryDistribution, InterestDrift, DurationBucket, CreatorRanking, NewCreator, BehaviorMetrics, WeeklyTip, BlindBoxItem } from './analytics';
-import type { DynamicBillFeedbackResult, DynamicBillFilterPreference, DynamicBillGenerateResult, DynamicBillItem, DynamicBillOverview, DynamicSyncResult } from './dynamic-bill';
+import type {
+  DynamicBillExplanationResult,
+  DynamicBillFeedbackResult,
+  DynamicBillFilterPreference,
+  DynamicBillGenerateResult,
+  DynamicBillItem,
+  DynamicBillOverview,
+  DynamicSyncResult,
+} from './dynamic-bill';
 import type { FavoriteSyncResult, SmartFavoriteOverview, SmartFavoriteResult, SmartFavoriteSearchResponse, SmartIndexResult } from './favorite';
 
 // Popup / Dashboard → Service Worker
@@ -26,6 +34,7 @@ export type RequestAction =
   | 'GET_DYNAMIC_BILL_OVERVIEW'
   | 'SYNC_DYNAMIC_UPDATES'
   | 'GENERATE_DYNAMIC_BILL'
+  | 'BUILD_DYNAMIC_BILL_EXPLANATIONS'
   | 'GET_DYNAMIC_BILL_ITEMS'
   | 'GET_DYNAMIC_BILL_FILTER'
   | 'UPDATE_DYNAMIC_BILL_FILTER'
@@ -148,6 +157,7 @@ export type SmartFavoritePathResponse = BiliVizResponse<SmartFavoriteResult[]>;
 export type DynamicBillOverviewResponse = BiliVizResponse<DynamicBillOverview>;
 export type DynamicSyncResponse = BiliVizResponse<DynamicSyncResult>;
 export type DynamicBillGenerateResponse = BiliVizResponse<DynamicBillGenerateResult>;
+export type DynamicBillExplanationResponse = BiliVizResponse<DynamicBillExplanationResult>;
 export type DynamicBillItemsResponse = BiliVizResponse<DynamicBillItem[]>;
 export type DynamicBillItemResponse = BiliVizResponse<DynamicBillItem | null>;
 export type DynamicBillFilterResponse = BiliVizResponse<DynamicBillFilterPreference>;


### PR DESCRIPTION
﻿## Summary
- Add AI explanation generation for already-selected dynamic bill items only.
- AI output fields are `summary` / `reason` / `viewingAngle` / `keywords` / `confidence`.
- Add local evidence fallback display for AI disabled, AI not configured, and AI failed states.
- Fix the build batching flow so the first batch may retry failed explanations, while later batches in the same click pass `includeFailed: false` and avoid repeating the same failed batch.

## Product Boundaries
- `confidence` is display-only and does not participate in selection, sorting, state advancement, or later rules.
- Explanation payloads only contain necessary video metadata and compact local evidence facts for the already-selected bill item.
- Payloads do not include full watch history, full following list, Cookie, user `mid`, personal profile, or feedback records.
- No full `dynamicBillFeedback` records are uploaded.
- No Bilibili follow relationship writeback is added.
- This PR does not change dynamic bill selection, sorting, status advancement, or feedback downrank/blocking rules.

## Validation
- `git diff --check`
- `npm run typecheck`
- `npm run build`
- Playwright mock QA covers AI success, AI failure, and AI not configured states. The AI failure mock uses more than one batch and verifies the second batch sends `includeFailed: false`.
