### PR TITLE
[codex] Fix Smart Favorites sync completeness audit

### DIFF
--- a/dashboard/modules/favorites/SmartFavoritesPage.tsx
+++ b/dashboard/modules/favorites/SmartFavoritesPage.tsx
@@ -77,8 +77,8 @@ export function SmartFavoritesPage() {
     try {
       const result = await requestSW<FavoriteSyncResult>('SYNC_FAVORITES');
       if (result.status === 'blocked') {
-        setError(result.blockedReason ?? 'Favorite sync incomplete; previous snapshot was kept.');
-        setNotice(`Sync blocked: reported ${result.reportedItems}, fetched ${result.items}, filtered ${result.filteredItems}. Previous video snapshot kept.`);
+        setError(result.blockedReason ?? 'Favorite sync incomplete; available data was kept.');
+        setNotice(`Sync incomplete: kept/updated ${result.insertedOrUpdated} usable videos, deleted nothing. Reported ${result.reportedItems}, fetched ${result.items}, filtered ${result.filteredItems}; see audit below.`);
       } else {
         setNotice(`Sync complete: ${result.folders} folders, ${result.items} videos, ${result.filteredItems} filtered resources.`);
       }

--- a/dashboard/modules/favorites/SmartFavoritesPage.tsx
+++ b/dashboard/modules/favorites/SmartFavoritesPage.tsx
@@ -3,6 +3,7 @@ import { requestSW } from '../../utils/messaging';
 import { BILI_BLUE, BILI_PINK } from '../../../src/shared/constants';
 import type { AiConfig, UserConfig } from '../../../src/shared/types/config';
 import type {
+  FavoriteFolderSyncDiagnostic,
   FavoriteSyncResult,
   SmartFavoriteOverview,
   SmartFavoriteResult,
@@ -75,7 +76,12 @@ export function SmartFavoritesPage() {
     setError(null);
     try {
       const result = await requestSW<FavoriteSyncResult>('SYNC_FAVORITES');
-      setNotice(`已同步 ${result.folders} 个收藏夹，${result.items} 个视频`);
+      if (result.status === 'blocked') {
+        setError(result.blockedReason ?? 'Favorite sync incomplete; previous snapshot was kept.');
+        setNotice(`Sync blocked: reported ${result.reportedItems}, fetched ${result.items}, filtered ${result.filteredItems}. Previous video snapshot kept.`);
+      } else {
+        setNotice(`Sync complete: ${result.folders} folders, ${result.items} videos, ${result.filteredItems} filtered resources.`);
+      }
       setOverview(await requestSW<SmartFavoriteOverview>('GET_SMART_FAVORITES'));
     } catch (e) {
       setError((e as Error).message);
@@ -197,6 +203,7 @@ export function SmartFavoritesPage() {
           <Metric label="索引失败" value={overview?.failedItems ?? 0} />
           <Metric label="待索引" value={overview?.pendingItems ?? 0} />
         </div>
+        <SyncDiagnostics diagnostics={overview?.lastSyncDiagnostics ?? []} />
         <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
           <ActionButton label={busy === 'sync' ? '同步中...' : '同步收藏夹'} onClick={syncFavorites} disabled={!!busy} />
           <ActionButton label={busy === 'index' ? '生成中...' : '生成智能索引'} onClick={buildIndex} disabled={!!busy || !overview?.totalItems} />
@@ -356,6 +363,78 @@ function Metric({ label, value }: { label: string; value: number }) {
 
 function Status({ color, text }: { color: string; text: string }) {
   return <div style={{ ...CARD, color, fontSize: '13px' }}>{text}</div>;
+}
+
+function SyncDiagnostics({ diagnostics }: { diagnostics: FavoriteFolderSyncDiagnostic[] }) {
+  if (diagnostics.length === 0) return null;
+
+  const totals = diagnostics.reduce((sum, diagnostic) => ({
+    reported: sum.reported + diagnostic.reportedMediaCount,
+    stored: sum.stored + diagnostic.storedVideoItems,
+    filtered: sum.filtered + diagnostic.filteredItems,
+    delta: sum.delta + diagnostic.unexplainedDelta,
+    errors: sum.errors + diagnostic.errors.length,
+  }), { reported: 0, stored: 0, filtered: 0, delta: 0, errors: 0 });
+
+  return (
+    <div style={{ marginBottom: '12px', overflowX: 'auto' }}>
+      <div style={{ color: '#FFFFFF', fontSize: '13px', fontWeight: 600, marginBottom: '6px' }}>
+        Sync audit: reported {totals.reported}, stored {totals.stored}, filtered {totals.filtered}, delta {totals.delta}, errors {totals.errors}
+      </div>
+      <div style={{ minWidth: '720px', display: 'grid', gridTemplateColumns: '1.5fr repeat(6, 72px) 1.8fr', gap: '1px', background: '#333355', border: '1px solid #333355', borderRadius: '6px', overflow: 'hidden' }}>
+        {['Folder', 'Reported', 'Pages', 'Raw', 'Stored', 'Filtered', 'Delta', 'Errors'].map(label => (
+          <AuditCell key={label} header text={label} />
+        ))}
+        {diagnostics.map(diagnostic => (
+          <SyncDiagnosticRow key={diagnostic.mediaId} diagnostic={diagnostic} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SyncDiagnosticRow({ diagnostic }: { diagnostic: FavoriteFolderSyncDiagnostic }) {
+  return (
+    <>
+      <AuditCell text={`${diagnostic.title || 'Untitled'} #${diagnostic.mediaId}`} />
+      <AuditCell text={String(diagnostic.reportedMediaCount)} tone={diagnostic.unexplainedDelta > 0 ? 'warn' : undefined} />
+      <AuditCell text={String(diagnostic.pagesFetched)} />
+      <AuditCell text={String(diagnostic.rawResourcesSeen)} />
+      <AuditCell text={String(diagnostic.storedVideoItems)} />
+      <AuditCell text={String(diagnostic.filteredItems)} />
+      <AuditCell text={String(diagnostic.unexplainedDelta)} tone={diagnostic.unexplainedDelta > 0 ? 'warn' : undefined} />
+      <AuditCell text={diagnostic.errors.join('; ') || '-'} tone={diagnostic.errors.length > 0 ? 'error' : undefined} />
+    </>
+  );
+}
+
+function AuditCell({
+  text,
+  header,
+  tone,
+}: {
+  text: string;
+  header?: boolean;
+  tone?: 'warn' | 'error';
+}) {
+  return (
+    <div
+      title={text}
+      style={{
+        background: header ? '#252545' : '#1A1A2E',
+        color: tone === 'error' ? '#FF6B6B' : tone === 'warn' ? '#FFB347' : header ? '#FFFFFF' : '#A0A0B0',
+        fontSize: '11px',
+        fontWeight: header ? 600 : 400,
+        minWidth: 0,
+        overflow: 'hidden',
+        padding: '7px 8px',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {text}
+    </div>
+  );
 }
 
 function TextInput({

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite build --watch --mode development",
     "build": "tsc --noEmit && vite build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:favorites": "node --test tests/favorite-sync-audit.test.ts"
   },
   "dependencies": {
     "preact": "^10.24.0",

--- a/src/background/api/favorites.ts
+++ b/src/background/api/favorites.ts
@@ -1,5 +1,10 @@
 import { FAVORITE_FOLDERS_ENDPOINT, FAVORITE_PAGE_SIZE, FAVORITE_RESOURCES_ENDPOINT, NAV_ENDPOINT } from '../../shared/constants';
-import type { FavoriteFolder, FavoriteItem } from '../../shared/types/favorite';
+import type { FavoriteFolder } from '../../shared/types/favorite';
+import {
+  fetchFavoriteItemsWithPageFetcher,
+  type FavoriteItemsFetchResult,
+  type FavoriteResourcesData,
+} from '../favorites/favorite-fetch-loop';
 import { biliGet } from './client';
 
 interface NavData {
@@ -22,34 +27,6 @@ interface FavoriteFolderApiItem {
 interface FavoriteFoldersData {
   count?: number;
   list?: FavoriteFolderApiItem[];
-}
-
-interface FavoriteResourceApiItem {
-  id?: number;
-  avid?: number;
-  bvid?: string;
-  title?: string;
-  cover?: string;
-  intro?: string;
-  duration?: number;
-  pubtime?: number;
-  fav_time?: number;
-  ctime?: number;
-  type?: number;
-  upper?: {
-    mid?: number;
-    name?: string;
-  };
-  attr?: number;
-}
-
-interface FavoriteResourcesData {
-  info?: {
-    id?: number;
-    title?: string;
-  };
-  medias?: FavoriteResourceApiItem[];
-  has_more?: boolean;
 }
 
 export async function fetchCurrentUserMid(signal?: AbortSignal): Promise<number> {
@@ -79,12 +56,10 @@ export async function fetchFavoriteItems(
   folder: FavoriteFolder,
   signal?: AbortSignal,
   maxPages = 500,
-): Promise<FavoriteItem[]> {
-  const result: FavoriteItem[] = [];
-  const syncedAt = Date.now();
-
-  for (let pn = 1; pn <= maxPages; pn++) {
-    const data = await biliGet<FavoriteResourcesData>(
+): Promise<FavoriteItemsFetchResult> {
+  return fetchFavoriteItemsWithPageFetcher(
+    folder,
+    (pn, pageSignal) => biliGet<FavoriteResourcesData>(
       FAVORITE_RESOURCES_ENDPOINT,
       {
         media_id: String(folder.mediaId),
@@ -98,21 +73,12 @@ export async function fetchFavoriteItems(
       },
       3,
       false,
-      signal,
-    );
-
-    const medias = data.medias ?? [];
-    if (medias.length === 0) break;
-
-    for (const media of medias) {
-      const item = toFavoriteItem(media, folder, syncedAt);
-      if (item) result.push(item);
-    }
-
-    if (data.has_more === false || medias.length < FAVORITE_PAGE_SIZE) break;
-  }
-
-  return result;
+      pageSignal,
+    ),
+    signal,
+    maxPages,
+    FAVORITE_PAGE_SIZE,
+  );
 }
 
 function toFavoriteFolder(item: FavoriteFolderApiItem, syncedAt: number): FavoriteFolder | null {
@@ -126,32 +92,6 @@ function toFavoriteFolder(item: FavoriteFolderApiItem, syncedAt: number): Favori
     mediaCount: Number(item.media_count ?? 0),
     createdAt: Number(item.ctime ?? 0),
     updatedAt: Number(item.mtime ?? 0),
-    syncedAt,
-  };
-}
-
-function toFavoriteItem(item: FavoriteResourceApiItem, folder: FavoriteFolder, syncedAt: number): FavoriteItem | null {
-  const avid = Number(item.id ?? item.avid ?? 0);
-  const bvid = item.bvid ?? '';
-  if (!avid && !bvid) return null;
-
-  const itemKey = `${folder.mediaId}:${bvid || avid}`;
-  return {
-    itemKey,
-    mediaId: folder.mediaId,
-    folderTitle: folder.title,
-    avid,
-    bvid,
-    title: item.title ?? '',
-    intro: item.intro ?? '',
-    authorName: item.upper?.name ?? '',
-    authorMid: Number(item.upper?.mid ?? 0),
-    tagName: '',
-    tags: [],
-    cover: item.cover ?? '',
-    duration: Number(item.duration ?? 0),
-    pubtime: Number(item.pubtime ?? 0),
-    favTime: Number(item.fav_time ?? item.ctime ?? 0),
     syncedAt,
   };
 }

--- a/src/background/favorites/favorite-fetch-loop.ts
+++ b/src/background/favorites/favorite-fetch-loop.ts
@@ -1,0 +1,160 @@
+import type { FavoriteFolder, FavoriteFolderSyncDiagnostic, FavoriteItem } from '../../shared/types/favorite';
+
+export interface FavoriteResourceApiItem {
+  id?: number;
+  avid?: number;
+  bvid?: string;
+  title?: string;
+  cover?: string;
+  intro?: string;
+  duration?: number;
+  pubtime?: number;
+  fav_time?: number;
+  ctime?: number;
+  type?: number;
+  upper?: {
+    mid?: number;
+    name?: string;
+  };
+  attr?: number;
+  state?: number;
+  cnt_info?: unknown;
+}
+
+export interface FavoriteResourcesData {
+  info?: {
+    id?: number;
+    title?: string;
+  };
+  medias?: FavoriteResourceApiItem[];
+  has_more?: boolean;
+}
+
+export interface FavoriteItemsFetchResult {
+  items: FavoriteItem[];
+  diagnostic: FavoriteFolderSyncDiagnostic;
+}
+
+export type FavoriteResourcePageFetcher = (pageNumber: number, signal?: AbortSignal) => Promise<FavoriteResourcesData>;
+
+export async function fetchFavoriteItemsWithPageFetcher(
+  folder: FavoriteFolder,
+  fetchPage: FavoriteResourcePageFetcher,
+  signal: AbortSignal | undefined,
+  maxPages: number,
+  pageSize: number,
+): Promise<FavoriteItemsFetchResult> {
+  const result: FavoriteItem[] = [];
+  const syncedAt = Date.now();
+  const diagnostic: FavoriteFolderSyncDiagnostic = {
+    mediaId: folder.mediaId,
+    title: folder.title,
+    reportedMediaCount: Math.max(0, Number(folder.mediaCount ?? 0)),
+    pagesFetched: 0,
+    rawResourcesSeen: 0,
+    storedVideoItems: 0,
+    filteredUnavailableItems: 0,
+    filteredMissingIdItems: 0,
+    filteredNonVideoItems: 0,
+    filteredItems: 0,
+    hasMoreAfterStop: false,
+    stoppedByMaxPages: false,
+    unexplainedDelta: 0,
+    errors: [],
+  };
+
+  for (let pn = 1; pn <= maxPages; pn++) {
+    let data: FavoriteResourcesData;
+    try {
+      data = await fetchPage(pn, signal);
+    } catch (error) {
+      diagnostic.errors.push(`page ${pn}: ${error instanceof Error ? error.message : String(error)}`);
+      diagnostic.hasMoreAfterStop = true;
+      break;
+    }
+
+    const medias = data.medias ?? [];
+    diagnostic.pagesFetched++;
+    diagnostic.rawResourcesSeen += medias.length;
+    if (medias.length === 0) break;
+
+    for (const media of medias) {
+      const parsed = toFavoriteItem(media, folder, syncedAt);
+      if (parsed.item) {
+        result.push(parsed.item);
+      } else {
+        if (parsed.reason === 'unavailable') diagnostic.filteredUnavailableItems++;
+        if (parsed.reason === 'missing-id') diagnostic.filteredMissingIdItems++;
+        if (parsed.reason === 'non-video') diagnostic.filteredNonVideoItems++;
+      }
+    }
+
+    if (data.has_more === false) break;
+    if (medias.length < pageSize) {
+      if (data.has_more === true) {
+        diagnostic.hasMoreAfterStop = true;
+        diagnostic.errors.push(`page ${pn}: has_more=true but returned ${medias.length}/${pageSize} resources`);
+      }
+      break;
+    }
+    if (pn === maxPages && data.has_more === true) {
+      diagnostic.hasMoreAfterStop = true;
+      diagnostic.stoppedByMaxPages = true;
+      diagnostic.errors.push(`reached max page limit ${maxPages} while has_more=true`);
+    }
+  }
+
+  diagnostic.storedVideoItems = result.length;
+  diagnostic.filteredItems = diagnostic.filteredUnavailableItems + diagnostic.filteredMissingIdItems + diagnostic.filteredNonVideoItems;
+  diagnostic.unexplainedDelta = Math.max(
+    0,
+    diagnostic.reportedMediaCount - diagnostic.storedVideoItems - diagnostic.filteredItems,
+  );
+
+  return { items: result, diagnostic };
+}
+
+function toFavoriteItem(
+  item: FavoriteResourceApiItem,
+  folder: FavoriteFolder,
+  syncedAt: number,
+): { item: FavoriteItem | null; reason?: 'unavailable' | 'missing-id' | 'non-video' } {
+  if (isUnavailableFavoriteResource(item)) return { item: null, reason: 'unavailable' };
+  if (item.type !== undefined && Number(item.type) !== 2) return { item: null, reason: 'non-video' };
+
+  const avid = Number(item.id ?? item.avid ?? 0);
+  const bvid = item.bvid ?? '';
+  if (!avid && !bvid) return { item: null, reason: 'missing-id' };
+
+  const itemKey = `${folder.mediaId}:${bvid || avid}`;
+  return {
+    item: {
+      itemKey,
+      mediaId: folder.mediaId,
+      folderTitle: folder.title,
+      avid,
+      bvid,
+      title: item.title ?? '',
+      intro: item.intro ?? '',
+      authorName: item.upper?.name ?? '',
+      authorMid: Number(item.upper?.mid ?? 0),
+      tagName: '',
+      tags: [],
+      cover: item.cover ?? '',
+      duration: Number(item.duration ?? 0),
+      pubtime: Number(item.pubtime ?? 0),
+      favTime: Number(item.fav_time ?? item.ctime ?? 0),
+      syncedAt,
+    },
+  };
+}
+
+function isUnavailableFavoriteResource(item: FavoriteResourceApiItem): boolean {
+  const title = (item.title ?? '').trim();
+  return item.attr === 1
+    || item.state === -1
+    || title === '已失效视频'
+    || title === '视频已失效'
+    || title === '稿件已失效'
+    || title === '已删除视频';
+}

--- a/src/background/favorites/smart.ts
+++ b/src/background/favorites/smart.ts
@@ -138,6 +138,9 @@ export async function getSmartFavoriteOverview(): Promise<SmartFavoriteOverview>
     failedItems,
     pendingItems,
     lastSyncedAt: Math.max(0, ...folders.map(folder => folder.syncedAt), ...items.map(item => item.syncedAt)),
+    lastSyncDiagnostics: folders
+      .map(folder => folder.lastSyncDiagnostic)
+      .filter(diagnostic => diagnostic !== undefined),
     tree: buildTree(items, indexMap),
   };
 }

--- a/src/background/favorites/sync-audit.ts
+++ b/src/background/favorites/sync-audit.ts
@@ -1,0 +1,45 @@
+import type { FavoriteFolderSyncDiagnostic } from '../../shared/types/favorite';
+
+export interface FavoriteSyncCompletenessAssessment {
+  complete: boolean;
+  reason?: string;
+}
+
+export function assessFavoriteSyncCompleteness(
+  diagnostics: FavoriteFolderSyncDiagnostic[],
+): FavoriteSyncCompletenessAssessment {
+  const failedFolders = diagnostics.filter(diagnostic =>
+    diagnostic.errors.length > 0
+    || diagnostic.hasMoreAfterStop
+    || diagnostic.stoppedByMaxPages
+    || diagnostic.unexplainedDelta > 0,
+  );
+
+  if (failedFolders.length === 0) return { complete: true };
+
+  const samples = failedFolders.slice(0, 3).map(diagnostic => {
+    const issues = [
+      diagnostic.errors.length > 0 ? `${diagnostic.errors.length} error(s)` : '',
+      diagnostic.unexplainedDelta > 0 ? `delta ${diagnostic.unexplainedDelta}` : '',
+      diagnostic.hasMoreAfterStop ? 'has_more after stop' : '',
+      diagnostic.stoppedByMaxPages ? 'max pages reached' : '',
+    ].filter(Boolean).join(', ');
+    return `${diagnostic.title || diagnostic.mediaId}(${diagnostic.mediaId}): ${issues}`;
+  });
+
+  return {
+    complete: false,
+    reason: `FAVORITE_SYNC_INCOMPLETE: ${samples.join('; ')}`,
+  };
+}
+
+export function attachFavoriteSyncDiagnostics<T extends { mediaId: number }>(
+  folders: T[],
+  diagnostics: FavoriteFolderSyncDiagnostic[],
+): T[] {
+  const byMediaId = new Map(diagnostics.map(diagnostic => [diagnostic.mediaId, diagnostic]));
+  return folders.map(folder => ({
+    ...folder,
+    lastSyncDiagnostic: byMediaId.get(folder.mediaId),
+  }));
+}

--- a/src/background/favorites/sync-persistence.ts
+++ b/src/background/favorites/sync-persistence.ts
@@ -1,0 +1,53 @@
+import type { FavoriteFolder, FavoriteFolderSyncDiagnostic, FavoriteItem } from '../../shared/types/favorite';
+
+export interface FavoriteSyncPersistenceRepo {
+  replaceFavoriteSnapshot(folders: FavoriteFolder[], items: FavoriteItem[]): Promise<number>;
+  updateFavoriteFolderSyncDiagnostics(
+    folders: FavoriteFolder[],
+    diagnostics: FavoriteFolderSyncDiagnostic[],
+  ): Promise<void>;
+  upsertFavoriteItems(items: FavoriteItem[]): Promise<number>;
+}
+
+export interface FavoriteSyncPersistenceInput {
+  complete: boolean;
+  folders: FavoriteFolder[];
+  items: FavoriteItem[];
+  diagnostics: FavoriteFolderSyncDiagnostic[];
+}
+
+export interface FavoriteSyncPersistenceResult {
+  insertedOrUpdated: number;
+  destructiveReplacement: boolean;
+}
+
+export async function persistFavoriteSyncData(
+  input: FavoriteSyncPersistenceInput,
+  repo: FavoriteSyncPersistenceRepo,
+): Promise<FavoriteSyncPersistenceResult> {
+  const foldersWithDiagnostics = attachDiagnosticsToFolders(input.folders, input.diagnostics);
+
+  if (input.complete) {
+    return {
+      insertedOrUpdated: await repo.replaceFavoriteSnapshot(foldersWithDiagnostics, input.items),
+      destructiveReplacement: true,
+    };
+  }
+
+  await repo.updateFavoriteFolderSyncDiagnostics(foldersWithDiagnostics, input.diagnostics);
+  return {
+    insertedOrUpdated: await repo.upsertFavoriteItems(input.items),
+    destructiveReplacement: false,
+  };
+}
+
+function attachDiagnosticsToFolders(
+  folders: FavoriteFolder[],
+  diagnostics: FavoriteFolderSyncDiagnostic[],
+): FavoriteFolder[] {
+  const byMediaId = new Map(diagnostics.map(diagnostic => [diagnostic.mediaId, diagnostic]));
+  return folders.map(folder => ({
+    ...folder,
+    lastSyncDiagnostic: byMediaId.get(folder.mediaId),
+  }));
+}

--- a/src/background/favorites/sync.ts
+++ b/src/background/favorites/sync.ts
@@ -1,9 +1,15 @@
 import { MAX_FAVORITE_SYNC_PAGES } from '../../shared/constants';
-import type { FavoriteItem, FavoriteSyncResult } from '../../shared/types/favorite';
+import type { FavoriteFolderSyncDiagnostic, FavoriteItem, FavoriteSyncResult } from '../../shared/types/favorite';
 import type { VideoInfo } from '../../shared/types/video-info';
 import { fetchFavoriteFolders, fetchFavoriteItems } from '../api/favorites';
 import { batchFetchVideoInfo } from '../api/video-info';
-import { countFavoriteFolders, countFavoriteItems, replaceFavoriteSnapshot } from '../storage/favorite-repo';
+import {
+  countFavoriteFolders,
+  countFavoriteItems,
+  replaceFavoriteSnapshot,
+  updateFavoriteFolderSyncDiagnostics,
+} from '../storage/favorite-repo';
+import { assessFavoriteSyncCompleteness, attachFavoriteSyncDiagnostics } from './sync-audit';
 
 export async function syncFavorites(): Promise<FavoriteSyncResult> {
   const [previousFolderCount, previousItemCount] = await Promise.all([
@@ -12,14 +18,17 @@ export async function syncFavorites(): Promise<FavoriteSyncResult> {
   ]);
   const folders = await fetchFavoriteFolders();
   const allItems: FavoriteItem[] = [];
+  const diagnostics: FavoriteFolderSyncDiagnostic[] = [];
+  const syncedAt = Date.now();
 
   if (folders.length === 0 && (previousFolderCount > 0 || previousItemCount > 0)) {
     throw new Error('FAVORITE_SYNC_EMPTY_SNAPSHOT');
   }
 
   for (const folder of folders) {
-    const folderItems = await fetchFavoriteItems(folder, undefined, MAX_FAVORITE_SYNC_PAGES);
+    const { items: folderItems, diagnostic } = await fetchFavoriteItems(folder, undefined, MAX_FAVORITE_SYNC_PAGES);
     allItems.push(...folderItems);
+    diagnostics.push(diagnostic);
   }
 
   const reportedItemCount = folders.reduce((sum, folder) => sum + Math.max(folder.mediaCount, 0), 0);
@@ -27,14 +36,37 @@ export async function syncFavorites(): Promise<FavoriteSyncResult> {
     throw new Error('FAVORITE_SYNC_EMPTY_ITEMS_SNAPSHOT');
   }
 
+  const assessment = assessFavoriteSyncCompleteness(diagnostics);
+  if (!assessment.complete) {
+    await updateFavoriteFolderSyncDiagnostics(folders, diagnostics);
+    return {
+      status: 'blocked',
+      folders: folders.length,
+      items: allItems.length,
+      insertedOrUpdated: 0,
+      reportedItems: reportedItemCount,
+      filteredItems: diagnostics.reduce((sum, diagnostic) => sum + diagnostic.filteredItems, 0),
+      blockedReason: assessment.reason,
+      diagnostics,
+      syncedAt,
+    };
+  }
+
   const enrichedItems = await enrichFavoriteItems(allItems);
-  const insertedOrUpdated = await replaceFavoriteSnapshot(folders, enrichedItems);
+  const insertedOrUpdated = await replaceFavoriteSnapshot(
+    attachFavoriteSyncDiagnostics(folders, diagnostics),
+    enrichedItems,
+  );
 
   return {
+    status: 'complete',
     folders: folders.length,
     items: enrichedItems.length,
     insertedOrUpdated,
-    syncedAt: Date.now(),
+    reportedItems: reportedItemCount,
+    filteredItems: diagnostics.reduce((sum, diagnostic) => sum + diagnostic.filteredItems, 0),
+    diagnostics,
+    syncedAt,
   };
 }
 

--- a/src/background/favorites/sync.ts
+++ b/src/background/favorites/sync.ts
@@ -7,9 +7,11 @@ import {
   countFavoriteFolders,
   countFavoriteItems,
   replaceFavoriteSnapshot,
+  upsertFavoriteItems,
   updateFavoriteFolderSyncDiagnostics,
 } from '../storage/favorite-repo';
-import { assessFavoriteSyncCompleteness, attachFavoriteSyncDiagnostics } from './sync-audit';
+import { assessFavoriteSyncCompleteness } from './sync-audit';
+import { persistFavoriteSyncData } from './sync-persistence';
 
 export async function syncFavorites(): Promise<FavoriteSyncResult> {
   const [previousFolderCount, previousItemCount] = await Promise.all([
@@ -36,14 +38,18 @@ export async function syncFavorites(): Promise<FavoriteSyncResult> {
     throw new Error('FAVORITE_SYNC_EMPTY_ITEMS_SNAPSHOT');
   }
 
+  const enrichedItems = await enrichFavoriteItems(allItems);
   const assessment = assessFavoriteSyncCompleteness(diagnostics);
   if (!assessment.complete) {
-    await updateFavoriteFolderSyncDiagnostics(folders, diagnostics);
+    const persistence = await persistFavoriteSyncData(
+      { complete: false, folders, items: enrichedItems, diagnostics },
+      { replaceFavoriteSnapshot, updateFavoriteFolderSyncDiagnostics, upsertFavoriteItems },
+    );
     return {
       status: 'blocked',
       folders: folders.length,
-      items: allItems.length,
-      insertedOrUpdated: 0,
+      items: enrichedItems.length,
+      insertedOrUpdated: persistence.insertedOrUpdated,
       reportedItems: reportedItemCount,
       filteredItems: diagnostics.reduce((sum, diagnostic) => sum + diagnostic.filteredItems, 0),
       blockedReason: assessment.reason,
@@ -52,17 +58,16 @@ export async function syncFavorites(): Promise<FavoriteSyncResult> {
     };
   }
 
-  const enrichedItems = await enrichFavoriteItems(allItems);
-  const insertedOrUpdated = await replaceFavoriteSnapshot(
-    attachFavoriteSyncDiagnostics(folders, diagnostics),
-    enrichedItems,
+  const persistence = await persistFavoriteSyncData(
+    { complete: true, folders, items: enrichedItems, diagnostics },
+    { replaceFavoriteSnapshot, updateFavoriteFolderSyncDiagnostics, upsertFavoriteItems },
   );
 
   return {
     status: 'complete',
     folders: folders.length,
     items: enrichedItems.length,
-    insertedOrUpdated,
+    insertedOrUpdated: persistence.insertedOrUpdated,
     reportedItems: reportedItemCount,
     filteredItems: diagnostics.reduce((sum, diagnostic) => sum + diagnostic.filteredItems, 0),
     diagnostics,

--- a/src/background/storage/favorite-repo.ts
+++ b/src/background/storage/favorite-repo.ts
@@ -1,4 +1,4 @@
-import type { FavoriteFolder, FavoriteItem, SmartFavoriteIndex } from '../../shared/types/favorite';
+import type { FavoriteFolder, FavoriteFolderSyncDiagnostic, FavoriteItem, SmartFavoriteIndex } from '../../shared/types/favorite';
 import { db } from './db';
 
 export async function replaceFavoriteSnapshot(folders: FavoriteFolder[], items: FavoriteItem[]): Promise<number> {
@@ -32,6 +32,24 @@ export async function replaceFavoriteSnapshot(folders: FavoriteFolder[], items: 
 export async function upsertFavoriteFolders(folders: FavoriteFolder[]): Promise<void> {
   if (folders.length === 0) return;
   await db.favoriteFolders.bulkPut(folders);
+}
+
+export async function updateFavoriteFolderSyncDiagnostics(
+  folders: FavoriteFolder[],
+  diagnostics: FavoriteFolderSyncDiagnostic[],
+): Promise<void> {
+  if (folders.length === 0) return;
+
+  const diagnosticByMediaId = new Map(diagnostics.map(diagnostic => [diagnostic.mediaId, diagnostic]));
+  const existingFolders = await db.favoriteFolders.toArray();
+  const existingByMediaId = new Map(existingFolders.map(folder => [folder.mediaId, folder]));
+  const merged = folders.map(folder => ({
+    ...(existingByMediaId.get(folder.mediaId) ?? folder),
+    ...folder,
+    lastSyncDiagnostic: diagnosticByMediaId.get(folder.mediaId),
+  }));
+
+  await db.favoriteFolders.bulkPut(merged);
 }
 
 export async function upsertFavoriteItems(items: FavoriteItem[]): Promise<number> {

--- a/src/shared/types/favorite.ts
+++ b/src/shared/types/favorite.ts
@@ -8,6 +8,7 @@ export interface FavoriteFolder {
   createdAt: number;
   updatedAt: number;
   syncedAt: number;
+  lastSyncDiagnostic?: FavoriteFolderSyncDiagnostic;
 }
 
 export interface FavoriteItem {
@@ -66,13 +67,38 @@ export interface SmartFavoriteOverview {
   failedItems: number;
   pendingItems: number;
   lastSyncedAt: number;
+  lastSyncDiagnostics: FavoriteFolderSyncDiagnostic[];
   tree: SmartFavoriteTreeNode[];
 }
 
+export type FavoriteSyncStatus = 'complete' | 'blocked';
+
+export interface FavoriteFolderSyncDiagnostic {
+  mediaId: number;
+  title: string;
+  reportedMediaCount: number;
+  pagesFetched: number;
+  rawResourcesSeen: number;
+  storedVideoItems: number;
+  filteredUnavailableItems: number;
+  filteredMissingIdItems: number;
+  filteredNonVideoItems: number;
+  filteredItems: number;
+  hasMoreAfterStop: boolean;
+  stoppedByMaxPages: boolean;
+  unexplainedDelta: number;
+  errors: string[];
+}
+
 export interface FavoriteSyncResult {
+  status: FavoriteSyncStatus;
   folders: number;
   items: number;
   insertedOrUpdated: number;
+  reportedItems: number;
+  filteredItems: number;
+  blockedReason?: string;
+  diagnostics: FavoriteFolderSyncDiagnostic[];
   syncedAt: number;
 }
 

--- a/tests/favorite-sync-audit.test.ts
+++ b/tests/favorite-sync-audit.test.ts
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { FAVORITE_PAGE_SIZE } from '../src/shared/constants.ts';
+import type { FavoriteFolder, FavoriteFolderSyncDiagnostic } from '../src/shared/types/favorite.ts';
+import {
+  fetchFavoriteItemsWithPageFetcher,
+  type FavoriteResourceApiItem,
+  type FavoriteResourcesData,
+} from '../src/background/favorites/favorite-fetch-loop.ts';
+import { assessFavoriteSyncCompleteness } from '../src/background/favorites/sync-audit.ts';
+
+const folder: FavoriteFolder = {
+  mediaId: 100,
+  title: 'Default',
+  cover: '',
+  intro: '',
+  mediaCount: 0,
+  createdAt: 0,
+  updatedAt: 0,
+  syncedAt: 0,
+};
+
+test('fetches all favorite resource pages until has_more is false', async () => {
+  const pages: FavoriteResourcesData[] = [
+    { medias: makeVideos(FAVORITE_PAGE_SIZE, 0), has_more: true },
+    { medias: makeVideos(5, FAVORITE_PAGE_SIZE), has_more: false },
+  ];
+
+  const result = await fetchFavoriteItemsWithPageFetcher(
+    { ...folder, mediaCount: 25 },
+    async pageNumber => pages[pageNumber - 1] ?? { medias: [], has_more: false },
+    undefined,
+    500,
+    FAVORITE_PAGE_SIZE,
+  );
+
+  assert.equal(result.items.length, 25);
+  assert.equal(result.diagnostic.pagesFetched, 2);
+  assert.equal(result.diagnostic.rawResourcesSeen, 25);
+  assert.equal(result.diagnostic.unexplainedDelta, 0);
+  assert.deepEqual(result.diagnostic.errors, []);
+});
+
+test('counts unavailable, non-video, and missing-id favorite resources as filtered', async () => {
+  const medias: FavoriteResourceApiItem[] = [
+    makeVideo(1),
+    { id: 2, bvid: 'BV2', title: '已失效视频', type: 2, attr: 1 },
+    { id: 3, bvid: 'BV3', title: 'Audio resource', type: 12 },
+    { title: 'Missing id', type: 2 },
+  ];
+
+  const result = await fetchFavoriteItemsWithPageFetcher(
+    { ...folder, mediaCount: 4 },
+    async () => ({ medias, has_more: false }),
+    undefined,
+    500,
+    FAVORITE_PAGE_SIZE,
+  );
+
+  assert.equal(result.items.length, 1);
+  assert.equal(result.diagnostic.filteredUnavailableItems, 1);
+  assert.equal(result.diagnostic.filteredNonVideoItems, 1);
+  assert.equal(result.diagnostic.filteredMissingIdItems, 1);
+  assert.equal(result.diagnostic.filteredItems, 3);
+  assert.equal(result.diagnostic.unexplainedDelta, 0);
+});
+
+test('blocks incomplete favorite sync diagnostics before snapshot replacement', () => {
+  const diagnostics: FavoriteFolderSyncDiagnostic[] = [{
+    mediaId: 100,
+    title: 'Default',
+    reportedMediaCount: 158,
+    pagesFetched: 7,
+    rawResourcesSeen: 137,
+    storedVideoItems: 137,
+    filteredUnavailableItems: 0,
+    filteredMissingIdItems: 0,
+    filteredNonVideoItems: 0,
+    filteredItems: 0,
+    hasMoreAfterStop: false,
+    stoppedByMaxPages: false,
+    unexplainedDelta: 21,
+    errors: [],
+  }];
+
+  const assessment = assessFavoriteSyncCompleteness(diagnostics);
+
+  assert.equal(assessment.complete, false);
+  assert.match(assessment.reason ?? '', /FAVORITE_SYNC_INCOMPLETE/);
+  assert.match(assessment.reason ?? '', /delta 21/);
+});
+
+function makeVideos(count: number, offset: number): FavoriteResourceApiItem[] {
+  return Array.from({ length: count }, (_, index) => makeVideo(offset + index + 1));
+}
+
+function makeVideo(id: number): FavoriteResourceApiItem {
+  return {
+    id,
+    avid: id,
+    bvid: `BV${id}`,
+    title: `Video ${id}`,
+    type: 2,
+    upper: { mid: id, name: `UP ${id}` },
+  };
+}

--- a/tests/favorite-sync-audit.test.ts
+++ b/tests/favorite-sync-audit.test.ts
@@ -1,13 +1,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { FAVORITE_PAGE_SIZE } from '../src/shared/constants.ts';
-import type { FavoriteFolder, FavoriteFolderSyncDiagnostic } from '../src/shared/types/favorite.ts';
+import type { FavoriteFolder, FavoriteFolderSyncDiagnostic, FavoriteItem } from '../src/shared/types/favorite.ts';
 import {
   fetchFavoriteItemsWithPageFetcher,
   type FavoriteResourceApiItem,
   type FavoriteResourcesData,
 } from '../src/background/favorites/favorite-fetch-loop.ts';
 import { assessFavoriteSyncCompleteness } from '../src/background/favorites/sync-audit.ts';
+import { persistFavoriteSyncData } from '../src/background/favorites/sync-persistence.ts';
 
 const folder: FavoriteFolder = {
   mediaId: 100,
@@ -90,6 +91,41 @@ test('blocks incomplete favorite sync diagnostics before snapshot replacement', 
   assert.match(assessment.reason ?? '', /delta 21/);
 });
 
+test('incomplete favorite sync upserts fetched items without snapshot replacement', async () => {
+  const calls: string[] = [];
+  const item = makeFavoriteItem(1);
+  const diagnostic = makeIncompleteDiagnostic();
+
+  const result = await persistFavoriteSyncData(
+    {
+      complete: false,
+      folders: [{ ...folder, mediaCount: 158 }],
+      items: [item],
+      diagnostics: [diagnostic],
+    },
+    {
+      async replaceFavoriteSnapshot() {
+        calls.push('replace');
+        return 0;
+      },
+      async updateFavoriteFolderSyncDiagnostics(folders, diagnostics) {
+        calls.push('diagnostics');
+        assert.equal(folders[0].lastSyncDiagnostic?.unexplainedDelta, 21);
+        assert.equal(diagnostics[0].mediaId, 100);
+      },
+      async upsertFavoriteItems(items) {
+        calls.push('upsert-items');
+        assert.deepEqual(items.map(saved => saved.itemKey), [item.itemKey]);
+        return items.length;
+      },
+    },
+  );
+
+  assert.deepEqual(calls, ['diagnostics', 'upsert-items']);
+  assert.equal(result.destructiveReplacement, false);
+  assert.equal(result.insertedOrUpdated, 1);
+});
+
 function makeVideos(count: number, offset: number): FavoriteResourceApiItem[] {
   return Array.from({ length: count }, (_, index) => makeVideo(offset + index + 1));
 }
@@ -102,5 +138,45 @@ function makeVideo(id: number): FavoriteResourceApiItem {
     title: `Video ${id}`,
     type: 2,
     upper: { mid: id, name: `UP ${id}` },
+  };
+}
+
+function makeFavoriteItem(id: number): FavoriteItem {
+  return {
+    itemKey: `100:BV${id}`,
+    mediaId: 100,
+    folderTitle: 'Default',
+    avid: id,
+    bvid: `BV${id}`,
+    title: `Video ${id}`,
+    intro: '',
+    authorName: `UP ${id}`,
+    authorMid: id,
+    tagName: '',
+    tags: [],
+    cover: '',
+    duration: 0,
+    pubtime: 0,
+    favTime: id,
+    syncedAt: 0,
+  };
+}
+
+function makeIncompleteDiagnostic(): FavoriteFolderSyncDiagnostic {
+  return {
+    mediaId: 100,
+    title: 'Default',
+    reportedMediaCount: 158,
+    pagesFetched: 7,
+    rawResourcesSeen: 137,
+    storedVideoItems: 137,
+    filteredUnavailableItems: 0,
+    filteredMissingIdItems: 0,
+    filteredNonVideoItems: 0,
+    filteredItems: 0,
+    hasMoreAfterStop: false,
+    stoppedByMaxPages: false,
+    unexplainedDelta: 21,
+    errors: [],
   };
 }

--- a/tests/smart-favorites-sync-diagnostics.mock.html
+++ b/tests/smart-favorites-sync-diagnostics.mock.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Smart Favorites Sync Audit Mock</title>
+    <style>
+      body {
+        margin: 0;
+        background: #18182c;
+        color: #fff;
+        font-family: Arial, sans-serif;
+        padding: 16px;
+      }
+
+      .card {
+        background: #222244;
+        border: 1px solid #333355;
+        border-radius: 8px;
+        padding: 12px;
+      }
+
+      .summary {
+        font-size: 13px;
+        font-weight: 700;
+        margin-bottom: 8px;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: 1.5fr repeat(6, 72px) 1.8fr;
+        min-width: 720px;
+        gap: 1px;
+        background: #333355;
+        border: 1px solid #333355;
+        border-radius: 6px;
+        overflow: hidden;
+      }
+
+      .cell {
+        background: #1a1a2e;
+        color: #a0a0b0;
+        font-size: 11px;
+        overflow: hidden;
+        padding: 7px 8px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .header {
+        background: #252545;
+        color: #fff;
+        font-weight: 700;
+      }
+
+      .warn {
+        color: #ffb347;
+      }
+
+      .error {
+        color: #ff6b6b;
+      }
+    </style>
+  </head>
+  <body>
+    <section class="card" aria-label="Smart Favorites sync diagnostics">
+      <div class="summary">Sync audit: reported 304, stored 137, filtered 4, delta 163, errors 1</div>
+      <div class="grid">
+        <div class="cell header">Folder</div>
+        <div class="cell header">Reported</div>
+        <div class="cell header">Pages</div>
+        <div class="cell header">Raw</div>
+        <div class="cell header">Stored</div>
+        <div class="cell header">Filtered</div>
+        <div class="cell header">Delta</div>
+        <div class="cell header">Errors</div>
+
+        <div class="cell">Default #100</div>
+        <div class="cell warn">158</div>
+        <div class="cell">7</div>
+        <div class="cell">137</div>
+        <div class="cell">137</div>
+        <div class="cell">0</div>
+        <div class="cell warn">21</div>
+        <div class="cell">-</div>
+
+        <div class="cell">Watch Later #200</div>
+        <div class="cell">146</div>
+        <div class="cell">1</div>
+        <div class="cell">4</div>
+        <div class="cell">0</div>
+        <div class="cell">4</div>
+        <div class="cell warn">142</div>
+        <div class="cell error">page 2: RATE_LIMITED</div>
+      </div>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
Closes #34

## Root cause

Smart Favorites previously collapsed the `/x/v3/fav/resource/list` response into a filtered `FavoriteItem[]` too early. The sync path lost per-folder pagination and filtering evidence, so unavailable/private/deleted/non-video or missing-id resources were silently dropped. The replacement snapshot then deleted any old local items not present in the latest filtered fetch, which meant a partial or unexplained smaller fetch could overwrite a better previous snapshot.

## Fix

- Added per-folder sync diagnostics for `mediaId`, title, Bilibili `media_count`, pages fetched, raw resources seen, stored video items, filtered unavailable/missing-id/non-video counts, `has_more`/max-page stop state, unexplained delta, and page errors.
- Refactored favorite resource fetching into a mockable pagination/filter loop.
- Treat page failures, `has_more` inconsistencies, max-page truncation, and unexplained reported-vs-stored deltas as incomplete syncs.
- Complete syncs still use destructive snapshot replacement so removed Bilibili favorites are cleaned locally when the fetched snapshot is trustworthy.
- Incomplete syncs do not call destructive replacement and do not delete old items or smart indexes. They persist folder diagnostics and non-destructively upsert the successfully fetched/enriched valid videos, so first-time users still get a partial usable local snapshot and existing users keep old missing items.
- Surface the latest sync audit in Smart Favorites with reported/stored/filtered/delta/error data per folder and blocked/partial copy that says usable data was kept and nothing was deleted.

## Diagnostics fields

Each folder now exposes:

- `mediaId`, `title`, `reportedMediaCount`
- `pagesFetched`, `rawResourcesSeen`, `storedVideoItems`
- `filteredUnavailableItems`, `filteredMissingIdItems`, `filteredNonVideoItems`, `filteredItems`
- `hasMoreAfterStop`, `stoppedByMaxPages`, `unexplainedDelta`, `errors`

## Validation

- `npm run test:favorites` passed.
- `npm run typecheck` passed.
- `npm run build` passed. Vite still reports the existing large chunk warning for `chunks/theme-*.js`.
- `git diff --check` passed with only Windows LF-to-CRLF warnings.
- Browser/mock QA passed against `tests/smart-favorites-sync-diagnostics.mock.html`: verified visible reported/stored/filtered/delta/error fields and a default-folder delta row.

## Must-fix / follow-up

- Must-fix addressed: incomplete smaller syncs no longer overwrite old snapshots, and they now preserve/update successfully fetched usable videos via non-destructive upsert.
- Follow-up: run a real extension smoke using the current browser runtime login state only, then inspect the new per-folder diagnostics for the user account with default folder reported count 158. I did not perform this here because the safety boundary prohibits reading/copying cookies or browser profiles; real account validation should be done by the main Agent/user through the installed extension runtime.
- No merge blocker remains from this implementation pass beyond that runtime smoke follow-up.

## Safety

This change does not write back to Bilibili favorites and does not create, move, delete, or rename Bilibili folders. I did not read or copy cookies, browser profiles, local key files, or `C:\Users\LittleNub\Desktop\Key.txt`.