### PR TITLE
[codex] Refactor creator relationships by follow status

### DIFF
--- a/dashboard/modules/creator/CreatorPage.tsx
+++ b/dashboard/modules/creator/CreatorPage.tsx
@@ -1,12 +1,44 @@
+import type { ComponentChildren } from 'preact';
 import { useEffect } from 'preact/hooks';
 import { creatorData, creatorLoading, creatorError } from '../../signals';
 import { requestSW } from '../../utils/messaging';
-import type { CreatorRanking } from '../../../src/shared/types/analytics';
+import type {
+  CreatorFollowDataCoverage,
+  CreatorFollowStatus,
+  CreatorFollowStatusGroup,
+  CreatorRanking,
+  NewCreator,
+} from '../../../src/shared/types/analytics';
 import { LoadingSkeleton } from '../../components/LoadingSkeleton';
 import { EmptyState } from '../../components/EmptyState';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
 import { formatTimeHHMM } from '../../../src/shared/utils/format';
-import { BILI_PINK } from '../../../src/shared/constants';
+
+const GROUP_ORDER: CreatorFollowStatus[] = ['followed', 'not_followed', 'unknown'];
+
+const GROUP_COPY: Record<CreatorFollowStatus, { title: string; description: string; empty: string }> = {
+  followed: {
+    title: '已关注',
+    description: '这些 UP 出现在最近观看历史中，并且仍在当前本地关注快照的 active 关注列表里。',
+    empty: '最近观看历史里暂时没有匹配到仍在关注的 UP。',
+  },
+  not_followed: {
+    title: '未关注',
+    description: '这些 UP 出现在最近观看历史中，但不在当前本地 active 关注快照里。',
+    empty: '在关注快照可用时，未发现最近看过但当前未关注的 UP。',
+  },
+  unknown: {
+    title: '状态未知',
+    description: '关注快照尚不可用或无法可靠判断时，观看过的 UP 会先放在这里。',
+    empty: '当前没有需要标记为状态未知的 UP。',
+  },
+};
+
+const STATUS_TONE: Record<CreatorFollowStatus, string> = {
+  followed: 'is-followed',
+  not_followed: 'is-not-followed',
+  unknown: 'is-unknown',
+};
 
 export function CreatorPage() {
   useEffect(() => { fetchData(); }, []);
@@ -28,65 +60,243 @@ export function CreatorPage() {
   const d = creatorData.value;
   if (!d) return <EmptyState />;
 
+  const followGroups = normalizeFollowGroups(d.followGroups, d.topCreators);
+
   return (
     <ErrorBoundary>
-      <div style={{ padding: '16px', display: 'flex', flexDirection: 'column', gap: '12px' }}>
-        <div style={{ background: '#222244', borderRadius: '10px', padding: '12px' }}>
-          <h3 style={{ color: '#A0A0B0', fontSize: '13px', margin: '0 0 8px 12px' }}>TOP 10 UP主</h3>
-          {d.topCreators.map((c: CreatorRanking, i: number) => (
-            <div key={c.mid} style={{
-              display: 'flex', alignItems: 'center', gap: '10px',
-              padding: '8px 12px', borderRadius: '8px',
-              background: i % 2 === 0 ? '#1A1A2E' : 'transparent',
-            }}>
-              <span style={{ color: '#9090A0', fontSize: '12px', minWidth: '20px' }}>{i + 1}</span>
-              <div style={{ flex: 1 }}>
-                <div style={{ color: '#FFFFFF', fontSize: '14px', fontWeight: 500 }}>{c.name}</div>
-                <div style={{ color: '#9090A0', fontSize: '11px' }}>
-                  {c.videoCount}个视频 · {formatTimeHHMM(c.totalWatchTime)} · 完播{Math.round(c.avgCompletion * 100)}%
-                </div>
-              </div>
-              {c.isDeepBond && <span style={{ background: BILI_PINK, color: '#FFF', fontSize: '10px', padding: '2px 8px', borderRadius: '10px' }}>深度绑定</span>}
-            </div>
+      <div className="creator-page" data-testid="creator-relationships-page">
+        <section className="creator-hero">
+          <div>
+            <span>Creator Relationships</span>
+            <h2>按关注状态理解 UP 关系</h2>
+            <p>
+              这里只使用本地观看历史和本地关注快照做判断。没有关注快照时会显示状态未知，不会把未知误写成未关注。
+            </p>
+          </div>
+          <div className={`creator-coverage ${d.followDataCoverage?.hasSnapshot ? 'is-ready' : 'is-missing'}`} data-testid="creator-follow-coverage">
+            <strong>{d.followDataCoverage?.hasSnapshot ? '关注快照可用' : '关注状态不可判定'}</strong>
+            <span>{coverageCopy(d.followDataCoverage)}</span>
+          </div>
+        </section>
+
+        <section className="creator-follow-board" aria-label="创作者关注状态分组">
+          {followGroups.map(group => (
+            <FollowStatusColumn key={group.status} group={group} coverage={d.followDataCoverage} />
           ))}
-          {d.topCreators.length === 0 && <div style={{ padding: '20px', textAlign: 'center', color: '#666' }}>暂无数据</div>}
-        </div>
+        </section>
 
-        {d.deepBondCreators.length > 0 && (
-          <div style={{ background: '#222244', borderRadius: '10px', padding: '12px' }}>
-            <h3 style={{ color: BILI_PINK, fontSize: '13px', margin: '0 0 8px 12px' }}>深度绑定 UP主</h3>
-            {d.deepBondCreators.map((c: CreatorRanking) => (
-              <div key={c.mid} style={{ padding: '8px 12px', color: '#FFFFFF', fontSize: '13px' }}>
-                {c.name} — {c.videoCount}个视频，完播{Math.round(c.avgCompletion * 100)}%
+        <section className="creator-secondary-grid">
+          <CreatorPanel title="TOP 10 UP" data-testid="creator-top-panel">
+            {d.topCreators.length > 0 ? (
+              <div className="creator-list is-compact">
+                {d.topCreators.map((creator, index) => (
+                  <CreatorListItem key={creator.mid} creator={creator} rank={index + 1} />
+                ))}
               </div>
-            ))}
-          </div>
-        )}
+            ) : (
+              <PanelEmpty copy="暂无最近 30 天创作者观看数据。" />
+            )}
+          </CreatorPanel>
 
-        {d.newCreators.length > 0 && (
-          <div style={{ background: '#222244', borderRadius: '10px', padding: '12px' }}>
-            <h3 style={{ color: '#A0A0B0', fontSize: '13px', margin: '0 0 8px 12px' }}>本月新发现的 UP主</h3>
-            {d.newCreators.map((c) => (
-              <div key={c.mid} style={{ padding: '6px 12px', display: 'flex', justifyContent: 'space-between', color: '#CCCCCC', fontSize: '13px' }}>
-                <span>{c.name}</span>
-                <span style={{ color: c.retained ? '#00D4AA' : '#9090A0', fontSize: '11px' }}>{c.retained ? '已留存' : '仅一次'}</span>
+          <CreatorPanel title="深度绑定" data-testid="creator-deep-bond-panel">
+            {d.deepBondCreators.length > 0 ? (
+              <div className="creator-list is-compact">
+                {d.deepBondCreators.map(creator => (
+                  <CreatorListItem key={creator.mid} creator={creator} evidence="高完播和连续观看" />
+                ))}
               </div>
-            ))}
-          </div>
-        )}
+            ) : (
+              <PanelEmpty copy="暂未发现高完播、连续观看都明显集中的 UP。" />
+            )}
+          </CreatorPanel>
+        </section>
 
-        {d.overDependency && (
-          <div style={{ background: '#332222', borderRadius: '10px', padding: '14px', borderLeft: '3px solid #FF6B6B' }}>
-            <div style={{ color: '#FF6B6B', fontSize: '13px', fontWeight: 600, marginBottom: '4px' }}>
-              过度依赖提醒
-            </div>
-            <div style={{ color: '#CCCCCC', fontSize: '13px' }}>
-              你已经把 {d.overDependency.percentage}% 的B站时间给了 "{d.overDependency.creator.name}"，
-              试试探索其他同类型UP主？
-            </div>
-          </div>
-        )}
+        <section className="creator-secondary-grid">
+          <CreatorPanel title="本月新发现" data-testid="creator-new-panel">
+            {d.newCreators.length > 0 ? (
+              <div className="creator-list is-compact">
+                {d.newCreators.map(creator => (
+                  <NewCreatorItem key={creator.mid} creator={creator} />
+                ))}
+              </div>
+            ) : (
+              <PanelEmpty copy="本月暂未发现首次进入观看历史的 UP。" />
+            )}
+          </CreatorPanel>
+
+          <CreatorPanel title="过度依赖提醒" data-testid="creator-overdependency-panel">
+            {d.overDependency ? (
+              <div className="creator-alert">
+                <strong>{d.overDependency.creator.name}</strong>
+                <span>
+                  最近 30 天约 {d.overDependency.percentage}% 的 B 站观看时间集中在这位 UP。可以把它当作消费集中度提示，而不是关注关系结论。
+                </span>
+              </div>
+            ) : (
+              <PanelEmpty copy="最近 30 天没有发现观看时间过度集中到单一 UP。" />
+            )}
+          </CreatorPanel>
+        </section>
       </div>
     </ErrorBoundary>
   );
+}
+
+function FollowStatusColumn({
+  group,
+  coverage,
+}: {
+  group: CreatorFollowStatusGroup;
+  coverage?: CreatorFollowDataCoverage;
+}) {
+  const copy = GROUP_COPY[group.status];
+  return (
+    <section className={`creator-follow-column ${STATUS_TONE[group.status]}`} data-testid={`creator-follow-group-${group.status}`}>
+      <div className="creator-follow-head">
+        <div>
+          <h3>{copy.title}</h3>
+          <p>{groupDescription(group.status, coverage)}</p>
+        </div>
+        <strong data-testid={`creator-follow-count-${group.status}`}>{group.count}</strong>
+      </div>
+      {group.creators.length > 0 ? (
+        <div className="creator-list">
+          {group.creators.map(creator => (
+            <CreatorListItem key={creator.mid} creator={creator} />
+          ))}
+        </div>
+      ) : (
+        <div className="creator-empty" data-testid={`creator-follow-empty-${group.status}`}>
+          <strong>{copy.empty}</strong>
+          <p>{emptyStateDetail(group.status, coverage)}</p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function CreatorPanel({
+  title,
+  children,
+  ...props
+}: {
+  title: string;
+  children: ComponentChildren;
+  'data-testid'?: string;
+}) {
+  return (
+    <section className="creator-panel" {...props}>
+      <h3>{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function CreatorListItem({
+  creator,
+  rank,
+  evidence,
+}: {
+  creator: CreatorRanking;
+  rank?: number;
+  evidence?: string;
+}) {
+  return (
+    <article className="creator-item" data-testid="creator-item">
+      {rank !== undefined && <span className="creator-rank">{rank}</span>}
+      <div className="creator-item-main">
+        <strong>{creator.name || `UP ${creator.mid}`}</strong>
+        <span>
+          {creator.videoCount} 个视频 · {formatTimeHHMM(creator.totalWatchTime)} · 完播 {Math.round(creator.avgCompletion * 100)}%
+        </span>
+        {evidence && <small>{evidence}</small>}
+      </div>
+      <div className="creator-item-tags">
+        <StatusChip status={creator.followStatus ?? 'unknown'} />
+        {creator.isDeepBond && <em>深度绑定</em>}
+      </div>
+    </article>
+  );
+}
+
+function NewCreatorItem({ creator }: { creator: NewCreator }) {
+  return (
+    <article className="creator-item" data-testid="creator-new-item">
+      <div className="creator-item-main">
+        <strong>{creator.name || `UP ${creator.mid}`}</strong>
+        <span>
+          首次观看 {creator.firstWatchDate} · 后续观看 {creator.subsequentViews} 次
+        </span>
+        <small>{creator.retained ? '证据：本月重复观看' : '证据：本月首次出现'}</small>
+      </div>
+      <div className="creator-item-tags">
+        <StatusChip status={creator.followStatus ?? 'unknown'} />
+      </div>
+    </article>
+  );
+}
+
+function StatusChip({ status }: { status: CreatorFollowStatus }) {
+  return <span className={`creator-status ${STATUS_TONE[status]}`}>{GROUP_COPY[status].title}</span>;
+}
+
+function PanelEmpty({ copy }: { copy: string }) {
+  return (
+    <div className="creator-panel-empty">
+      {copy}
+    </div>
+  );
+}
+
+function normalizeFollowGroups(
+  groups: CreatorFollowStatusGroup[] | undefined,
+  topCreators: CreatorRanking[],
+): CreatorFollowStatusGroup[] {
+  const byStatus = new Map((groups ?? []).map(group => [group.status, group]));
+  return GROUP_ORDER.map(status => byStatus.get(status) ?? {
+    status,
+    creators: status === 'unknown' ? topCreators.map(creator => ({ ...creator, followStatus: 'unknown' as const })) : [],
+    count: status === 'unknown' ? topCreators.length : 0,
+  });
+}
+
+function coverageCopy(coverage?: CreatorFollowDataCoverage): string {
+  if (!coverage) return '旧版数据未提供关注快照覆盖信息，页面会按状态未知处理。';
+  if (coverage.hasSnapshot) {
+    const syncedAt = coverage.snapshotSyncedAt ? ` · 快照时间 ${formatSnapshotTime(coverage.snapshotSyncedAt)}` : '';
+    return `当前 active 关注 UP ${coverage.activeFollowedCreatorCount} 个${syncedAt}。`;
+  }
+
+  switch (coverage.reason) {
+    case 'syncing':
+      return '关注快照正在同步，完成前不会判断已关注或未关注。';
+    case 'not_logged_in':
+      return '关注数据不可用：当前浏览器未登录或 B 站接口拒绝返回关注列表。';
+    case 'sync_failed':
+      return `关注快照同步失败，暂不判断关注状态${coverage.lastError ? `：${coverage.lastError}` : '。'}`;
+    default:
+      return '尚未同步关注快照，请先在动态账单中同步关注数据。';
+  }
+}
+
+function groupDescription(status: CreatorFollowStatus, coverage?: CreatorFollowDataCoverage): string {
+  if (status === 'unknown' && !coverage?.hasSnapshot) return coverageCopy(coverage);
+  return GROUP_COPY[status].description;
+}
+
+function emptyStateDetail(status: CreatorFollowStatus, coverage?: CreatorFollowDataCoverage): string {
+  if (status === 'followed' && !coverage?.hasSnapshot) return '需要可用的本地关注快照后才能确认哪些 UP 仍被关注。';
+  if (status === 'not_followed' && !coverage?.hasSnapshot) return '关注快照缺失时不会把任何 UP 判定为未关注。';
+  if (status === 'unknown' && coverage?.hasSnapshot) return '本地关注快照已经可用，最近观看过的 UP 均已完成已关注或未关注判断。';
+  return GROUP_COPY[status].description;
+}
+
+function formatSnapshotTime(value: number): string {
+  const millis = value < 10_000_000_000 ? value * 1000 : value;
+  return new Date(millis).toLocaleString('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
 }

--- a/dashboard/signals.ts
+++ b/dashboard/signals.ts
@@ -2,7 +2,7 @@ import { signal } from '@preact/signals';
 import type {
   DashboardOverview,
   CategoryDistribution, InterestDrift, DurationBucket,
-  CreatorRanking, NewCreator,
+  CreatorFollowDataCoverage, CreatorFollowStatusGroup, CreatorRanking, NewCreator,
   BehaviorMetrics,
   WeeklyTip, BlindBoxItem,
 } from '../src/shared/types/analytics';
@@ -27,6 +27,8 @@ export const creatorData = signal<{
   topCreators: CreatorRanking[];
   deepBondCreators: CreatorRanking[];
   newCreators: NewCreator[];
+  followGroups: CreatorFollowStatusGroup[];
+  followDataCoverage: CreatorFollowDataCoverage;
   overDependency: { creator: CreatorRanking; percentage: number } | null;
 } | null>(null);
 export const creatorLoading = signal(true);

--- a/dashboard/styles/dashboard.css
+++ b/dashboard/styles/dashboard.css
@@ -885,6 +885,316 @@ button {
   line-height: 1.55;
 }
 
+.creator-page {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+}
+
+.creator-hero,
+.creator-panel,
+.creator-follow-column {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-card);
+}
+
+.creator-hero {
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  background:
+    linear-gradient(135deg, rgba(0, 161, 214, 0.16), rgba(20, 184, 166, 0.1)),
+    var(--bg-card);
+}
+
+.creator-hero span {
+  display: block;
+  color: #8FDDF6;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.creator-hero h2 {
+  margin: 5px 0 0;
+  color: #FFFFFF;
+  font-size: 24px;
+  letter-spacing: 0;
+}
+
+.creator-hero p {
+  max-width: 760px;
+  margin: 8px 0 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.creator-coverage {
+  display: grid;
+  align-content: center;
+  gap: 5px;
+  min-width: 260px;
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(26, 26, 46, 0.58);
+}
+
+.creator-coverage.is-ready {
+  border-color: rgba(20, 184, 166, 0.38);
+  background: rgba(20, 184, 166, 0.1);
+}
+
+.creator-coverage.is-missing {
+  border-color: rgba(245, 158, 11, 0.38);
+  background: rgba(245, 158, 11, 0.1);
+}
+
+.creator-coverage strong {
+  color: #FFFFFF;
+  font-size: 13px;
+}
+
+.creator-coverage span {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.creator-follow-board {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.creator-follow-column {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.creator-follow-column.is-followed {
+  border-top: 2px solid var(--bb-mint);
+}
+
+.creator-follow-column.is-not-followed {
+  border-top: 2px solid var(--bili-blue);
+}
+
+.creator-follow-column.is-unknown {
+  border-top: 2px solid var(--bb-amber);
+}
+
+.creator-follow-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 116px;
+  padding: 13px;
+  border-bottom: 1px solid var(--border);
+}
+
+.creator-follow-head h3,
+.creator-panel h3 {
+  margin: 0;
+  color: #FFFFFF;
+  font-size: 15px;
+  letter-spacing: 0;
+}
+
+.creator-follow-head p {
+  margin: 6px 0 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.creator-follow-head > strong {
+  display: grid;
+  flex: none;
+  min-width: 28px;
+  height: 24px;
+  place-items: center;
+  border-radius: 999px;
+  color: #FFFFFF;
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 12px;
+}
+
+.creator-list {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+}
+
+.creator-list.is-compact {
+  padding: 0;
+}
+
+.creator-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-height: 76px;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(26, 26, 46, 0.5);
+}
+
+.creator-rank {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  border-radius: 7px;
+  color: #9AA5B6;
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.creator-item-main {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.creator-item-main strong,
+.creator-item-main span,
+.creator-item-main small {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.creator-item-main strong {
+  color: #FFFFFF;
+  font-size: 14px;
+}
+
+.creator-item-main span {
+  color: #AEB7C6;
+  font-size: 12px;
+}
+
+.creator-item-main small {
+  color: #7F8CA0;
+  font-size: 11px;
+}
+
+.creator-item-tags {
+  display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.creator-status,
+.creator-item-tags em {
+  min-height: 22px;
+  padding: 4px 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-style: normal;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.creator-status.is-followed {
+  color: #67E8D4;
+  background: rgba(20, 184, 166, 0.15);
+}
+
+.creator-status.is-not-followed {
+  color: #8FDDF6;
+  background: rgba(0, 161, 214, 0.16);
+}
+
+.creator-status.is-unknown {
+  color: #FBBF24;
+  background: rgba(245, 158, 11, 0.15);
+}
+
+.creator-item-tags em {
+  color: #FFFFFF;
+  background: rgba(251, 114, 153, 0.18);
+}
+
+.creator-empty,
+.creator-panel-empty {
+  display: grid;
+  align-content: center;
+  min-height: 188px;
+  margin: 10px;
+  padding: 18px;
+  border: 1px dashed rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  color: #8792A5;
+  background: rgba(26, 26, 46, 0.42);
+  text-align: center;
+}
+
+.creator-empty strong {
+  color: #D8DCE6;
+  font-size: 13px;
+}
+
+.creator-empty p {
+  margin: 8px 0 0;
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.creator-secondary-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.creator-panel {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+  padding: 13px;
+}
+
+.creator-panel-empty {
+  min-height: 116px;
+  margin: 0;
+  color: #8F9BAD;
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.creator-alert {
+  display: grid;
+  gap: 6px;
+  padding: 12px;
+  border: 1px solid rgba(255, 107, 107, 0.32);
+  border-radius: 8px;
+  background: rgba(255, 107, 107, 0.1);
+}
+
+.creator-alert strong {
+  color: #FF8A8A;
+  font-size: 14px;
+}
+
+.creator-alert span {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
 @media (max-width: 1180px) {
   .dynamic-bill-layout {
     grid-template-columns: minmax(0, 1fr);
@@ -923,8 +1233,18 @@ button {
   }
 
   .dynamic-bill-status-grid,
-  .dynamic-bill-board {
+  .dynamic-bill-board,
+  .creator-follow-board {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .creator-hero,
+  .creator-secondary-grid {
+    display: grid;
+  }
+
+  .creator-coverage {
+    min-width: 0;
   }
 }
 
@@ -1004,7 +1324,30 @@ button {
   }
 
   .dynamic-bill-status-grid,
-  .dynamic-bill-board {
+  .dynamic-bill-board,
+  .creator-follow-board,
+  .creator-secondary-grid {
     grid-template-columns: 1fr;
+  }
+
+  .creator-page {
+    padding: 12px;
+  }
+
+  .creator-hero {
+    display: grid;
+  }
+
+  .creator-item {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .creator-rank {
+    display: none;
+  }
+
+  .creator-item-tags {
+    justify-content: flex-start;
   }
 }

--- a/src/background/analytics/creator.ts
+++ b/src/background/analytics/creator.ts
@@ -1,8 +1,17 @@
 import type { WatchHistoryRecord } from '../../shared/types/watch-event';
-import type { CreatorRanking, NewCreator } from '../../shared/types/analytics';
+import type {
+  CreatorFollowDataCoverage,
+  CreatorFollowDataCoverageReason,
+  CreatorFollowStatus,
+  CreatorFollowStatusGroup,
+  CreatorRanking,
+  NewCreator,
+} from '../../shared/types/analytics';
+import type { FollowedCreator } from '../../shared/types/dynamic-bill';
 import { getRecordsByDateRange } from '../storage/watch-history-repo';
 import { dateKey, startOfMonth } from '../../shared/utils/time';
 import { loadConfig } from '../storage/config-store';
+import { getDynamicSyncState, getFollowedCreatorSnapshot } from '../storage/dynamic-bill-repo';
 
 interface CreatorStats {
   mid: number;
@@ -143,6 +152,8 @@ export async function getCreatorData(): Promise<{
   topCreators: CreatorRanking[];
   deepBondCreators: CreatorRanking[];
   newCreators: NewCreator[];
+  followGroups: CreatorFollowStatusGroup[];
+  followDataCoverage: CreatorFollowDataCoverage;
   overDependency: { creator: CreatorRanking; percentage: number } | null;
 }> {
   const now = new Date();
@@ -150,15 +161,117 @@ export async function getCreatorData(): Promise<{
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
   const records = await getRecordsByDateRange(dateKey(thirtyDaysAgo), dateKey(now));
-  const ranking = computeCreatorRanking(records);
-  const deepBond = detectDeepBond(records);
-  const newCreators = await computeNewCreators(records);
+  const [followedSnapshot, syncState] = await Promise.all([
+    getFollowedCreatorSnapshot(),
+    getDynamicSyncState(),
+  ]);
+  const followDataCoverage = buildFollowDataCoverage(followedSnapshot, syncState);
+  const activeFollowedMids = new Set(
+    followedSnapshot
+      .filter(creator => creator.isActive !== false)
+      .map(creator => creator.mid),
+  );
+  const ranking = applyFollowStatus(computeCreatorRanking(records), activeFollowedMids, followDataCoverage);
+  const deepBond = applyFollowStatus(detectDeepBond(records), activeFollowedMids, followDataCoverage);
+  const newCreators = applyNewCreatorFollowStatus(await computeNewCreators(records), activeFollowedMids, followDataCoverage);
   const overDep = await detectOverDependency(ranking);
 
   return {
     topCreators: ranking.slice(0, 10),
     deepBondCreators: deepBond,
     newCreators,
+    followGroups: buildFollowGroups(ranking),
+    followDataCoverage,
     overDependency: overDep,
   };
+}
+
+function applyFollowStatus(
+  creators: CreatorRanking[],
+  activeFollowedMids: Set<number>,
+  coverage: CreatorFollowDataCoverage,
+): CreatorRanking[] {
+  return creators.map(creator => ({
+    ...creator,
+    followStatus: getCreatorFollowStatus(creator.mid, activeFollowedMids, coverage),
+  }));
+}
+
+function applyNewCreatorFollowStatus(
+  creators: NewCreator[],
+  activeFollowedMids: Set<number>,
+  coverage: CreatorFollowDataCoverage,
+): NewCreator[] {
+  return creators.map(creator => ({
+    ...creator,
+    followStatus: getCreatorFollowStatus(creator.mid, activeFollowedMids, coverage),
+  }));
+}
+
+function getCreatorFollowStatus(
+  mid: number,
+  activeFollowedMids: Set<number>,
+  coverage: CreatorFollowDataCoverage,
+): CreatorFollowStatus {
+  if (!coverage.hasSnapshot) return 'unknown';
+  return activeFollowedMids.has(mid) ? 'followed' : 'not_followed';
+}
+
+function buildFollowGroups(creators: CreatorRanking[]): CreatorFollowStatusGroup[] {
+  const groups: Record<CreatorFollowStatus, CreatorRanking[]> = {
+    followed: [],
+    not_followed: [],
+    unknown: [],
+  };
+
+  for (const creator of creators) {
+    groups[creator.followStatus ?? 'unknown'].push(creator);
+  }
+
+  return (['followed', 'not_followed', 'unknown'] as const).map(status => ({
+    status,
+    creators: groups[status],
+    count: groups[status].length,
+  }));
+}
+
+function buildFollowDataCoverage(
+  followedSnapshot: FollowedCreator[],
+  syncState: Awaited<ReturnType<typeof getDynamicSyncState>>,
+): CreatorFollowDataCoverage {
+  const activeFollowedCreatorCount = followedSnapshot.filter(creator => creator.isActive !== false).length;
+  const snapshotSyncedAt = latestSnapshotSyncedAt(followedSnapshot, syncState.lastSuccessAt);
+  const hasSnapshot = snapshotSyncedAt !== null || followedSnapshot.length > 0;
+
+  return {
+    hasSnapshot,
+    reason: hasSnapshot ? 'snapshot_available' : followDataUnavailableReason(syncState.status),
+    activeFollowedCreatorCount,
+    snapshotSyncedAt,
+    lastError: syncState.lastError,
+  };
+}
+
+function latestSnapshotSyncedAt(followedSnapshot: FollowedCreator[], lastSuccessAt: number): number | null {
+  const latestCreatorSync = followedSnapshot.reduce(
+    (latest, creator) => Math.max(latest, creator.syncedAt || creator.lastSeenAt || 0),
+    0,
+  );
+  const latest = Math.max(latestCreatorSync, lastSuccessAt || 0);
+  return latest > 0 ? latest : null;
+}
+
+function followDataUnavailableReason(
+  status: Awaited<ReturnType<typeof getDynamicSyncState>>['status'],
+): CreatorFollowDataCoverageReason {
+  switch (status) {
+    case 'syncing':
+      return 'syncing';
+    case 'not_logged_in':
+      return 'not_logged_in';
+    case 'failed':
+      return 'sync_failed';
+    default:
+      return 'not_synced';
+  }
 }

--- a/src/background/storage/dynamic-bill-repo.ts
+++ b/src/background/storage/dynamic-bill-repo.ts
@@ -106,6 +106,10 @@ export async function getActiveFollowedCreators(): Promise<FollowedCreator[]> {
   return creators.filter(creator => creator.isActive !== false);
 }
 
+export async function getFollowedCreatorSnapshot(): Promise<FollowedCreator[]> {
+  return db.followedCreators.toArray();
+}
+
 export async function replaceDynamicBillItemsForColumn(
   column: DynamicBillColumn,
   items: DynamicBillItem[],

--- a/src/shared/types/analytics.ts
+++ b/src/shared/types/analytics.ts
@@ -61,6 +61,7 @@ export interface CreatorRanking {
   totalWatchTime: number;
   avgCompletion: number;
   isDeepBond: boolean;
+  followStatus?: CreatorFollowStatus;
 }
 
 export interface NewCreator {
@@ -70,6 +71,30 @@ export interface NewCreator {
   firstWatchDate: string;
   subsequentViews: number;
   retained: boolean;
+  followStatus?: CreatorFollowStatus;
+}
+
+export type CreatorFollowStatus = 'followed' | 'not_followed' | 'unknown';
+
+export type CreatorFollowDataCoverageReason =
+  | 'snapshot_available'
+  | 'not_synced'
+  | 'syncing'
+  | 'not_logged_in'
+  | 'sync_failed';
+
+export interface CreatorFollowDataCoverage {
+  hasSnapshot: boolean;
+  reason: CreatorFollowDataCoverageReason;
+  activeFollowedCreatorCount: number;
+  snapshotSyncedAt: number | null;
+  lastError?: string;
+}
+
+export interface CreatorFollowStatusGroup {
+  status: CreatorFollowStatus;
+  creators: CreatorRanking[];
+  count: number;
 }
 
 export interface SessionPattern {

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -1,4 +1,17 @@
-import type { QuickStats, DashboardOverview, CategoryDistribution, InterestDrift, DurationBucket, CreatorRanking, NewCreator, BehaviorMetrics, WeeklyTip, BlindBoxItem } from './analytics';
+import type {
+  QuickStats,
+  DashboardOverview,
+  CategoryDistribution,
+  InterestDrift,
+  DurationBucket,
+  CreatorFollowDataCoverage,
+  CreatorFollowStatusGroup,
+  CreatorRanking,
+  NewCreator,
+  BehaviorMetrics,
+  WeeklyTip,
+  BlindBoxItem,
+} from './analytics';
 import type {
   DynamicBillExplanationResult,
   DynamicBillFeedbackResult,
@@ -137,6 +150,8 @@ export type CreatorResponse = BiliVizResponse<{
   topCreators: CreatorRanking[];
   deepBondCreators: CreatorRanking[];
   newCreators: NewCreator[];
+  followGroups: CreatorFollowStatusGroup[];
+  followDataCoverage: CreatorFollowDataCoverage;
   overDependency: { creator: CreatorRanking; percentage: number } | null;
 }>;
 export type BehaviorResponse = BiliVizResponse<BehaviorMetrics>;

--- a/tests/creator-follow-status.mock.html
+++ b/tests/creator-follow-status.mock.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Creator Follow Status Mock</title>
+  <link rel="stylesheet" href="/dashboard/styles/dashboard.css" />
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    const now = Date.now();
+    const creator = (mid, name, followStatus, extra = {}) => ({
+      mid,
+      name,
+      face: '',
+      videoCount: extra.videoCount ?? 4,
+      totalWatchTime: extra.totalWatchTime ?? 4200,
+      avgCompletion: extra.avgCompletion ?? 0.72,
+      isDeepBond: extra.isDeepBond ?? false,
+      followStatus,
+    });
+    const followed = creator(101, '仍在关注的科技 UP', 'followed', { videoCount: 8, totalWatchTime: 8600, avgCompletion: 0.86, isDeepBond: true });
+    const notFollowed = creator(202, '看过但未关注的游戏 UP', 'not_followed', { videoCount: 3, totalWatchTime: 2400, avgCompletion: 0.61 });
+    const unknown = creator(303, '快照缺失时的未知 UP', 'unknown', { videoCount: 5, totalWatchTime: 3600, avgCompletion: 0.78 });
+
+    const snapshotData = {
+      topCreators: [followed, notFollowed],
+      deepBondCreators: [followed],
+      newCreators: [
+        {
+          mid: 202,
+          name: notFollowed.name,
+          face: '',
+          firstWatchDate: '2026-06-01',
+          subsequentViews: 2,
+          retained: true,
+          followStatus: 'not_followed',
+        },
+      ],
+      followGroups: [
+        { status: 'followed', creators: [followed], count: 1 },
+        { status: 'not_followed', creators: [notFollowed], count: 1 },
+        { status: 'unknown', creators: [], count: 0 },
+      ],
+      followDataCoverage: {
+        hasSnapshot: true,
+        reason: 'snapshot_available',
+        activeFollowedCreatorCount: 1,
+        snapshotSyncedAt: now,
+      },
+      overDependency: { creator: followed, percentage: 43.6 },
+    };
+
+    const missingSnapshotData = {
+      ...snapshotData,
+      topCreators: [unknown],
+      deepBondCreators: [],
+      newCreators: [
+        {
+          mid: 303,
+          name: unknown.name,
+          face: '',
+          firstWatchDate: '2026-06-02',
+          subsequentViews: 0,
+          retained: false,
+          followStatus: 'unknown',
+        },
+      ],
+      followGroups: [
+        { status: 'followed', creators: [], count: 0 },
+        { status: 'not_followed', creators: [], count: 0 },
+        { status: 'unknown', creators: [unknown], count: 1 },
+      ],
+      followDataCoverage: {
+        hasSnapshot: false,
+        reason: 'not_synced',
+        activeFollowedCreatorCount: 0,
+        snapshotSyncedAt: null,
+      },
+      overDependency: null,
+    };
+
+    const emptyData = {
+      topCreators: [],
+      deepBondCreators: [],
+      newCreators: [],
+      followGroups: [
+        { status: 'followed', creators: [], count: 0 },
+        { status: 'not_followed', creators: [], count: 0 },
+        { status: 'unknown', creators: [], count: 0 },
+      ],
+      followDataCoverage: {
+        hasSnapshot: true,
+        reason: 'snapshot_available',
+        activeFollowedCreatorCount: 0,
+        snapshotSyncedAt: now,
+      },
+      overDependency: null,
+    };
+
+    function selectedCreatorData() {
+      const scenario = new URLSearchParams(window.location.search).get('scenario');
+      if (scenario === 'missing') return missingSnapshotData;
+      if (scenario === 'empty') return emptyData;
+      return snapshotData;
+    }
+
+    window.chrome = {
+      runtime: {
+        sendMessage(message) {
+          if (message.action === 'GET_SYNC_STATUS') {
+            return Promise.resolve({
+              success: true,
+              data: { lastSyncTime: now, totalRecords: 18 },
+            });
+          }
+          if (message.action === 'GET_CREATOR_DATA') {
+            return Promise.resolve({ success: true, data: selectedCreatorData() });
+          }
+          return Promise.resolve({ success: true, data: {} });
+        },
+      },
+    };
+  </script>
+  <script type="module" src="/dashboard/main.tsx"></script>
+</body>
+</html>


### PR DESCRIPTION
﻿Closes #35

## 修改范围
- 重构 Creator Relationships 页面，将一级语义改为 `已关注` / `未关注` / `状态未知` 三组，并补齐每组说明与空状态。
- 扩展 creator analytics 返回 `followStatus`、`followGroups` 和 `followDataCoverage`。
- 增加 `followedCreators` 快照只读读取方法，用于判断当前本地 active 关注快照。
- 保留 TOP 10 UP、深度绑定、本月新发现、过度依赖提醒等辅助信息；本月新发现不再使用“已留存”作为用户可见状态词。
- 增加 `tests/creator-follow-status.mock.html`，用于本地 mock QA 覆盖有快照、无快照、空数据场景。

## Follow status 判定逻辑
- `已关注`：最近观看历史中的 creator mid 存在于当前本地 `followedCreators` 快照，且 `isActive !== false`。
- `未关注`：关注快照可用时，最近观看历史中出现过、但不在 active follows 集合中的 UP。
- `状态未知`：本地关注快照尚未同步、同步中、未登录/不可用或同步失败且没有可用快照时，所有无法可靠判断的 UP 都进入未知组。
- 不会把缺失快照的未知状态降级成未关注；不调用关注/取关写接口，也不写回 B 站关注关系。

## 验证
- `npm run typecheck` 通过。
- `npm run build` 通过；仍有既有 Vite large chunk warning。
- `git diff --check` 通过，仅 Windows CRLF 工作区提示。
- `rg` 检查 Creator 页面和 mock 中无用户可见“已留存”文案。
- Browser/mock QA：Browser 插件连接成功，但打开 `127.0.0.1` / `localhost` mock 页面时被客户端以 `net::ERR_BLOCKED_BY_CLIENT` 拦截；已改用 static mock fallback 校验：
  - 有关注快照：`followed=1`、`not_followed=1`、`unknown=0`。
  - 无关注快照：`followed=0`、`not_followed=0`、`unknown=1`，确认未知不会误判为未关注。
  - 空数据：三组均为 `0`，用于覆盖空状态。

## Blocker / must-fix / follow-up
- Blocker: 无。
- Must-fix: 无。
- Follow-up: Browser 本地 URL 被客户端拦截，后续可在可打开 localhost 的环境补一次真实渲染截图 QA；Vite large chunk warning 为既有构建提示，非本次功能阻塞。

## 隐私与边界
- 未读取本地 key 文件、Cookie、浏览器 profile 或 Bilibili 登录态文件。
- 未读取 `C:\Users\LittleNub\Desktop\Key.txt`。
- 未修改动态账单规则、AI、智能收藏夹同步、发布包或 release。
