### PR TITLE
[codex] Add coverage-aware interest drift granularity

### DIFF
--- a/dashboard/modules/preference/PreferencePage.tsx
+++ b/dashboard/modules/preference/PreferencePage.tsx
@@ -1,14 +1,29 @@
-import { useEffect } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 import { prefData, prefLoading, prefError } from '../../signals';
 import { requestSW } from '../../utils/messaging';
-import type { CategoryDistribution, InterestDrift, DurationBucket } from '../../../src/shared/types/analytics';
+import type {
+  CategoryDistribution,
+  DurationBucket,
+  InterestDrift,
+  InterestDriftGranularity,
+} from '../../../src/shared/types/analytics';
 import { ChartContainer } from '../../components/ChartContainer';
 import { LoadingSkeleton } from '../../components/LoadingSkeleton';
 import { EmptyState } from '../../components/EmptyState';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
-import { CHART_COLORS, DURATION_BUCKETS } from '../../../src/shared/constants';
+import { CHART_COLORS } from '../../../src/shared/constants';
+
+const GRANULARITY_OPTIONS: Array<{ value: InterestDriftGranularity; label: string }> = [
+  { value: 'daily', label: '日' },
+  { value: 'weekly', label: '周' },
+  { value: 'monthly', label: '月' },
+];
+
+const DRIFT_CATEGORY_LIMIT = 5;
 
 export function PreferencePage() {
+  const [selectedGranularity, setSelectedGranularity] = useState<InterestDriftGranularity | null>(null);
+
   useEffect(() => { fetchData(); }, []);
 
   async function fetchData() {
@@ -16,6 +31,7 @@ export function PreferencePage() {
     prefError.value = null;
     try {
       prefData.value = await requestSW<typeof prefData.value>('GET_PREFERENCE_DATA');
+      setSelectedGranularity(null);
     } catch (e) {
       prefError.value = (e as Error).message;
     } finally {
@@ -28,28 +44,41 @@ export function PreferencePage() {
   const d = prefData.value;
   if (!d) return <EmptyState />;
 
+  const activeGranularity = selectedGranularity ?? d.defaultDriftGranularity;
+  const drift = d.driftByGranularity?.[activeGranularity] ?? d.drift;
+  const driftDisplay = buildDriftDisplay(drift, DRIFT_CATEGORY_LIMIT);
+  const hasDriftData = drift.some((period: InterestDrift) => period.recordCount > 0 && period.totalWatchTime > 0);
+  const driftTitle = getDriftTitle(activeGranularity, d.coverage.coveredDays);
+  const driftCaveat = getDriftCaveat(activeGranularity, d.coverage.coveredDays, d.coverage.totalRecords, hasDriftData);
+
   const pieOption = {
     tooltip: { trigger: 'item' as const, formatter: '{b}: {d}%' },
     series: [{
       type: 'pie' as const,
       radius: ['40%', '70%'],
-      data: d.categories.slice(0, 8).map((c: CategoryDistribution, i: number) => ({ name: c.name, value: c.watchTime })),
+      data: d.categories.slice(0, 8).map((c: CategoryDistribution) => ({ name: c.name, value: c.watchTime })),
       label: { color: '#A0A0B0' },
     }],
   };
 
-  const driftCategories = [...new Set(d.drift.flatMap((m: InterestDrift) => Object.keys(m.categories)))].slice(0, 5);
   const driftOption = {
     tooltip: { trigger: 'axis' as const },
-    legend: { textStyle: { color: '#A0A0B0' }, top: 0 },
-    grid: { top: 30, right: 10, bottom: 20, left: 40 },
-    xAxis: { type: 'category' as const, data: d.drift.map((m: InterestDrift) => m.month) },
+    legend: { type: 'scroll' as const, textStyle: { color: '#A0A0B0' }, top: 0 },
+    grid: { top: 46, right: 10, bottom: 34, left: 40 },
+    xAxis: {
+      type: 'category' as const,
+      data: drift.map((m: InterestDrift) => m.label),
+      axisLabel: { hideOverlap: true, rotate: activeGranularity === 'daily' ? 35 : 0 },
+    },
     yAxis: { type: 'value' as const, max: 100, axisLabel: { formatter: '{value}%' } },
-    series: driftCategories.map((cat, i) => ({
+    series: driftDisplay.seriesNames.map((cat, i) => ({
       name: cat,
       type: 'line' as const,
-      data: d.drift.map((m: InterestDrift) => m.categories[cat] ?? 0),
+      data: driftDisplay.series[cat] ?? [],
       smooth: true,
+      symbolSize: 5,
+      lineStyle: { width: 2 },
+      itemStyle: { color: CHART_COLORS[i % CHART_COLORS.length] },
     })),
   };
 
@@ -60,7 +89,10 @@ export function PreferencePage() {
     yAxis: { type: 'value' as const },
     series: [{
       type: 'bar' as const,
-      data: d.durationBuckets.map((b: DurationBucket, i: number) => ({ value: b.count, itemStyle: { color: CHART_COLORS[i % CHART_COLORS.length], borderRadius: [4, 4, 0, 0] } })),
+      data: d.durationBuckets.map((b: DurationBucket, i: number) => ({
+        value: b.count,
+        itemStyle: { color: CHART_COLORS[i % CHART_COLORS.length], borderRadius: [4, 4, 0, 0] },
+      })),
     }],
   };
 
@@ -71,7 +103,10 @@ export function PreferencePage() {
       shape: 'circle',
       sizeRange: [12, 40],
       rotationRange: [-45, 45],
-      textStyle: { fontFamily: '"Noto Sans SC", sans-serif', color: () => CHART_COLORS[Math.floor(Math.random() * CHART_COLORS.length)] },
+      textStyle: {
+        fontFamily: '"Noto Sans SC", sans-serif',
+        color: () => CHART_COLORS[Math.floor(Math.random() * CHART_COLORS.length)],
+      },
       data: d.topTags.slice(0, 50).map((t: { name: string; count: number }) => ({ name: t.name, value: t.count })),
     }],
   };
@@ -84,8 +119,52 @@ export function PreferencePage() {
           <ChartContainer option={pieOption} height={280} />
         </div>
         <div style={{ background: '#222244', borderRadius: '10px', padding: '12px' }}>
-          <h3 style={{ color: '#A0A0B0', fontSize: '13px', margin: '0 0 4px 12px' }}>兴趣漂移（近3月）</h3>
-          <ChartContainer option={driftOption} height={250} />
+          <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', alignItems: 'flex-start', margin: '0 0 8px 12px', flexWrap: 'wrap' }}>
+            <div>
+              <h3 style={{ color: '#EAEAF2', fontSize: '14px', margin: '0 0 4px 0' }}>{driftTitle}</h3>
+              <div style={{ color: '#A0A0B0', fontSize: '12px', lineHeight: 1.6 }}>
+                覆盖 {formatCoverageDate(d.coverage.earliestDate)} 至 {formatCoverageDate(d.coverage.latestDate)}
+                {' · '}活跃 {d.coverage.activeDays} 天
+                {' · '}样本 {d.coverage.totalRecords} 条
+              </div>
+            </div>
+            <div style={{ display: 'inline-flex', border: '1px solid rgba(160, 160, 176, 0.28)', borderRadius: '8px', overflow: 'hidden' }} aria-label="兴趣粒度选择">
+              {GRANULARITY_OPTIONS.map(option => {
+                const selected = option.value === activeGranularity;
+                return (
+                  <button
+                    type="button"
+                    onClick={() => setSelectedGranularity(option.value)}
+                    title={getGranularityHint(option.value, d.coverage.coveredDays, option.value === d.defaultDriftGranularity)}
+                    style={{
+                      minWidth: '42px',
+                      height: '30px',
+                      border: 0,
+                      borderRight: option.value === 'monthly' ? 0 : '1px solid rgba(160, 160, 176, 0.2)',
+                      background: selected ? '#6C5CE7' : 'transparent',
+                      color: selected ? '#FFFFFF' : '#C8C8D8',
+                      cursor: 'pointer',
+                      fontSize: '13px',
+                    }}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          {driftCaveat && (
+            <div style={{ margin: '0 12px 8px', padding: '8px 10px', borderRadius: '8px', background: 'rgba(255, 210, 102, 0.1)', color: '#FFD166', fontSize: '12px', lineHeight: 1.5 }}>
+              {driftCaveat}
+            </div>
+          )}
+          {hasDriftData ? (
+            <ChartContainer option={driftOption} height={270} />
+          ) : (
+            <div style={{ height: '220px', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#A0A0B0', fontSize: '13px', textAlign: 'center', padding: '0 16px' }}>
+              暂无足够观看时长用于生成兴趣分布；同步更多历史后会显示日/周/月视图。
+            </div>
+          )}
         </div>
         <div style={{ background: '#222244', borderRadius: '10px', padding: '12px' }}>
           <h3 style={{ color: '#A0A0B0', fontSize: '13px', margin: '0 0 4px 12px' }}>视频时长偏好</h3>
@@ -98,4 +177,75 @@ export function PreferencePage() {
       </div>
     </ErrorBoundary>
   );
+}
+
+function buildDriftDisplay(drift: InterestDrift[], limit: number): {
+  seriesNames: string[];
+  series: Record<string, number[]>;
+} {
+  const totals = new Map<string, number>();
+  for (const period of drift) {
+    for (const [category, value] of Object.entries(period.categories)) {
+      totals.set(category, (totals.get(category) ?? 0) + value);
+    }
+  }
+
+  const topCategories = Array.from(totals.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([category]) => category);
+  const hiddenCategories = Array.from(totals.keys()).filter(category => !topCategories.includes(category));
+  const seriesNames = hiddenCategories.length > 0 ? [...topCategories, '其他'] : topCategories;
+  const series: Record<string, number[]> = {};
+
+  for (const category of topCategories) {
+    series[category] = drift.map(period => period.categories[category] ?? 0);
+  }
+  if (hiddenCategories.length > 0) {
+    series['其他'] = drift.map(period => roundOne(
+      hiddenCategories.reduce((sum, category) => sum + (period.categories[category] ?? 0), 0),
+    ));
+  }
+
+  return { seriesNames, series };
+}
+
+function getDriftTitle(granularity: InterestDriftGranularity, coveredDays: number): string {
+  if (granularity === 'monthly' && coveredDays >= 90) return '长期兴趣漂移';
+  if (granularity === 'weekly') return '近期兴趣趋势';
+  return '近期兴趣分布';
+}
+
+function getDriftCaveat(
+  granularity: InterestDriftGranularity,
+  coveredDays: number,
+  totalRecords: number,
+  hasData: boolean,
+): string {
+  if (totalRecords === 0) return '本地还没有观看历史记录，无法计算兴趣分布。';
+  if (!hasData) return '已同步记录缺少有效观看时长，图表暂不计算百分比。';
+  if (totalRecords < 10) return '样本量较少，百分比容易被单个视频放大，请把它作为近期分布参考。';
+  if (granularity === 'monthly' && coveredDays < 90) return '历史覆盖不足 90 天，月粒度只适合粗略查看，不代表长期兴趣漂移。';
+  if (granularity === 'weekly' && coveredDays < 14) return '历史覆盖不足 14 天，周粒度样本不足；默认日粒度更可信。';
+  if (granularity === 'daily' && coveredDays >= 14) return '日粒度适合排查短期波动，覆盖较长时会比周/月视图更碎。';
+  return '';
+}
+
+function getGranularityHint(
+  granularity: InterestDriftGranularity,
+  coveredDays: number,
+  isDefault: boolean,
+): string {
+  const prefix = isDefault ? '当前默认：' : '';
+  if (granularity === 'daily') return `${prefix}少于 14 天历史时最可信`;
+  if (granularity === 'weekly') return `${prefix}14 至 90 天历史时最可信`;
+  return `${prefix}90 天以上历史时最适合观察长期漂移`;
+}
+
+function formatCoverageDate(value: string | null): string {
+  return value ?? '暂无';
+}
+
+function roundOne(value: number): number {
+  return Math.round(value * 10) / 10;
 }

--- a/dashboard/signals.ts
+++ b/dashboard/signals.ts
@@ -1,7 +1,7 @@
 import { signal } from '@preact/signals';
 import type {
   DashboardOverview,
-  CategoryDistribution, InterestDrift, DurationBucket,
+  PreferenceAnalytics,
   CreatorFollowDataCoverage, CreatorFollowStatusGroup, CreatorRanking, NewCreator,
   BehaviorMetrics,
   WeeklyTip, BlindBoxItem,
@@ -13,12 +13,7 @@ export const overviewLoading = signal(true);
 export const overviewError = signal<string | null>(null);
 
 // Module 2: Preference
-export const prefData = signal<{
-  categories: CategoryDistribution[];
-  drift: InterestDrift[];
-  durationBuckets: DurationBucket[];
-  topTags: { name: string; count: number }[];
-} | null>(null);
+export const prefData = signal<PreferenceAnalytics | null>(null);
 export const prefLoading = signal(true);
 export const prefError = signal<string | null>(null);
 

--- a/src/background/analytics/category.ts
+++ b/src/background/analytics/category.ts
@@ -1,9 +1,20 @@
-import type { WatchHistoryRecord, DailyAggregate } from '../../shared/types/watch-event';
-import type { CategoryDistribution, InterestDrift, DurationBucket } from '../../shared/types/analytics';
+import type { WatchHistoryRecord } from '../../shared/types/watch-event';
+import type {
+  CategoryDistribution,
+  HistoryCoverage,
+  InterestDrift,
+  InterestDriftGranularity,
+  DurationBucket,
+  PreferenceAnalytics,
+} from '../../shared/types/analytics';
 import { DURATION_BUCKETS } from '../../shared/constants';
-import { getAggregatesSince } from '../storage/aggregate-repo';
-import { getRecordsByDateRange } from '../storage/watch-history-repo';
-import { dateKey } from '../../shared/utils/time';
+import {
+  getNewestRecord,
+  getOldestRecord,
+  getRecordsByDateRange,
+  getTotalCount,
+} from '../storage/watch-history-repo';
+import { dateKey, daysBetween, startOfMonth, startOfWeek } from '../../shared/utils/time';
 
 export function computeCategoryDistribution(records: WatchHistoryRecord[]): CategoryDistribution[] {
   const map = new Map<string, number>();
@@ -64,61 +75,203 @@ export function computeTopTags(records: WatchHistoryRecord[], limit = 30): { nam
     .slice(0, limit);
 }
 
-export async function computeInterestDrift(months = 3): Promise<InterestDrift[]> {
-  const now = new Date();
-  const results: InterestDrift[] = [];
-
-  for (let i = months - 1; i >= 0; i--) {
-    const year = now.getFullYear();
-    const month = now.getMonth() - i;
-    const startDate = new Date(year, month, 1);
-    const endDate = new Date(year, month + 1, 0);
-
-    const startKey = dateKey(startDate);
-    const endKey = dateKey(endDate);
-    const aggs = await getAggregatesSince(startKey);
-    const monthly = aggs.filter(a => a.date >= startKey && a.date <= endKey);
-
-    const merged: Record<string, number> = {};
-    for (const a of monthly) {
-      for (const [cat, sec] of Object.entries(a.categoryBreakdown)) {
-        merged[cat] = (merged[cat] ?? 0) + sec;
-      }
-    }
-
-    const totalSec = Object.values(merged).reduce((s, v) => s + v, 0);
-    const categories: Record<string, number> = {};
-    for (const [cat, sec] of Object.entries(merged)) {
-      categories[cat] = totalSec > 0 ? Math.round((sec / totalSec) * 1000) / 10 : 0;
-    }
-
-    results.push({
-      month: `${startDate.getFullYear()}-${String(startDate.getMonth() + 1).padStart(2, '0')}`,
-      categories,
-    });
-  }
-
-  return results;
+export function getDefaultInterestDriftGranularity(coverage: HistoryCoverage): InterestDriftGranularity {
+  if (coverage.coveredDays < 14) return 'daily';
+  if (coverage.coveredDays < 90) return 'weekly';
+  return 'monthly';
 }
 
-export async function getPreferenceData(): Promise<{
-  categories: CategoryDistribution[];
-  drift: InterestDrift[];
-  durationBuckets: DurationBucket[];
-  topTags: { name: string; count: number }[];
-}> {
+export function computeInterestDrift(
+  records: WatchHistoryRecord[],
+  coverage: HistoryCoverage,
+  granularity: InterestDriftGranularity,
+): InterestDrift[] {
+  if (!coverage.earliestDate || !coverage.latestDate) return [];
+
+  const periods = buildPeriods(coverage.earliestDate, coverage.latestDate, granularity);
+  const byPeriod = new Map(periods.map(period => [period.period, period]));
+
+  for (const record of records) {
+    const recordDate = dateKeyFromRecord(record);
+    const period = byPeriod.get(periodKey(recordDate, granularity));
+    if (!period) continue;
+
+    const category = record.tagName || '其他';
+    const watchTime = Math.max(0, record.progress || 0);
+    period.recordCount++;
+    period.totalWatchTime += watchTime;
+    period.activeDates.add(recordDate);
+    period.merged[category] = (period.merged[category] ?? 0) + watchTime;
+  }
+
+  return periods.map((period) => {
+    const totalSec = Object.values(period.merged).reduce((sum, value) => sum + value, 0);
+    const categories: Record<string, number> = {};
+    for (const [category, seconds] of Object.entries(period.merged)) {
+      categories[category] = totalSec > 0 ? Math.round((seconds / totalSec) * 1000) / 10 : 0;
+    }
+
+    return {
+      month: period.period,
+      period: period.period,
+      label: period.label,
+      granularity,
+      startDate: period.startDate,
+      endDate: period.endDate,
+      categories,
+      recordCount: period.recordCount,
+      activeDays: period.activeDates.size,
+      totalWatchTime: Math.round(period.totalWatchTime),
+    };
+  });
+}
+
+export async function getPreferenceData(): Promise<PreferenceAnalytics> {
   const now = new Date();
   const thirtyDaysAgo = new Date(now);
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
   const startKey = dateKey(thirtyDaysAgo);
   const endKey = dateKey(now);
 
-  const records = await getRecordsByDateRange(startKey, endKey);
+  const [records, oldest, newest, totalRecords] = await Promise.all([
+    getRecordsByDateRange(startKey, endKey),
+    getOldestRecord(),
+    getNewestRecord(),
+    getTotalCount(),
+  ]);
+  const earliestDate = oldest ? dateKeyFromRecord(oldest) : null;
+  const latestDate = newest ? dateKeyFromRecord(newest) : null;
+  const allRecords = earliestDate && latestDate && totalRecords > 0
+    ? await getRecordsByDateRange(earliestDate, latestDate)
+    : [];
+  const coverage = buildHistoryCoverage(oldest, newest, totalRecords, allRecords);
+  const defaultDriftGranularity = getDefaultInterestDriftGranularity(coverage);
+  const driftByGranularity: Record<InterestDriftGranularity, InterestDrift[]> = {
+    daily: computeInterestDrift(allRecords, coverage, 'daily'),
+    weekly: computeInterestDrift(allRecords, coverage, 'weekly'),
+    monthly: computeInterestDrift(allRecords, coverage, 'monthly'),
+  };
 
   return {
     categories: computeCategoryDistribution(records),
-    drift: await computeInterestDrift(3),
+    drift: driftByGranularity[defaultDriftGranularity],
+    driftByGranularity,
+    defaultDriftGranularity,
+    coverage,
     durationBuckets: computeDurationBuckets(records),
     topTags: computeTopTags(records),
   };
+}
+
+function buildHistoryCoverage(
+  oldest: WatchHistoryRecord | undefined,
+  newest: WatchHistoryRecord | undefined,
+  totalRecords: number,
+  records: WatchHistoryRecord[],
+): HistoryCoverage {
+  if (!oldest || !newest || totalRecords === 0) {
+    return {
+      earliestDate: null,
+      latestDate: null,
+      activeDays: 0,
+      totalRecords,
+      coveredDays: 0,
+    };
+  }
+
+  const earliestDate = dateKeyFromRecord(oldest);
+  const latestDate = dateKeyFromRecord(newest);
+  const activeDates = new Set(records.map(dateKeyFromRecord));
+
+  return {
+    earliestDate,
+    latestDate,
+    activeDays: activeDates.size,
+    totalRecords,
+    coveredDays: daysBetween(parseDateKey(earliestDate), parseDateKey(latestDate)) + 1,
+  };
+}
+
+interface InterestPeriod {
+  period: string;
+  label: string;
+  startDate: string;
+  endDate: string;
+  merged: Record<string, number>;
+  recordCount: number;
+  activeDates: Set<string>;
+  totalWatchTime: number;
+}
+
+function buildPeriods(
+  earliestDate: string,
+  latestDate: string,
+  granularity: InterestDriftGranularity,
+): InterestPeriod[] {
+  const periods: InterestPeriod[] = [];
+  const end = parseDateKey(latestDate);
+  let cursor = periodStart(parseDateKey(earliestDate), granularity);
+
+  while (cursor.getTime() <= end.getTime()) {
+    const start = new Date(cursor);
+    const next = addPeriod(start, granularity);
+    const periodEnd = new Date(Math.min(next.getTime() - 1, end.getTime()));
+    const period = dateKey(start);
+    periods.push({
+      period,
+      label: periodLabel(start, periodEnd, granularity),
+      startDate: period,
+      endDate: dateKey(periodEnd),
+      merged: {},
+      recordCount: 0,
+      activeDates: new Set<string>(),
+      totalWatchTime: 0,
+    });
+    cursor = next;
+  }
+
+  return periods;
+}
+
+function periodKey(recordDate: string, granularity: InterestDriftGranularity): string {
+  return dateKey(periodStart(parseDateKey(recordDate), granularity));
+}
+
+function periodStart(date: Date, granularity: InterestDriftGranularity): Date {
+  if (granularity === 'weekly') return startOfWeek(date);
+  if (granularity === 'monthly') return startOfMonth(date);
+  return parseDateKey(dateKey(date));
+}
+
+function addPeriod(date: Date, granularity: InterestDriftGranularity): Date {
+  const next = new Date(date);
+  if (granularity === 'monthly') {
+    next.setMonth(next.getMonth() + 1);
+  } else {
+    next.setDate(next.getDate() + (granularity === 'weekly' ? 7 : 1));
+  }
+  return next;
+}
+
+function periodLabel(start: Date, end: Date, granularity: InterestDriftGranularity): string {
+  if (granularity === 'monthly') {
+    return `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}`;
+  }
+
+  const startLabel = shortDateLabel(start);
+  if (granularity === 'daily') return startLabel;
+  return `${startLabel}~${shortDateLabel(end)}`;
+}
+
+function shortDateLabel(date: Date): string {
+  return `${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+function parseDateKey(value: string): Date {
+  const [year, month, day] = value.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+function dateKeyFromRecord(record: WatchHistoryRecord): string {
+  return dateKey(new Date(record.viewAt * 1000));
 }

--- a/src/shared/types/analytics.ts
+++ b/src/shared/types/analytics.ts
@@ -41,9 +41,27 @@ export interface CategoryDistribution {
   percentage: number;
 }
 
+export type InterestDriftGranularity = 'daily' | 'weekly' | 'monthly';
+
+export interface HistoryCoverage {
+  earliestDate: string | null;
+  latestDate: string | null;
+  activeDays: number;
+  totalRecords: number;
+  coveredDays: number;
+}
+
 export interface InterestDrift {
   month: string;
+  period: string;
+  label: string;
+  granularity: InterestDriftGranularity;
+  startDate: string;
+  endDate: string;
   categories: Record<string, number>;
+  recordCount: number;
+  activeDays: number;
+  totalWatchTime: number;
 }
 
 export interface DurationBucket {
@@ -51,6 +69,16 @@ export interface DurationBucket {
   min: number;
   max: number;
   count: number;
+}
+
+export interface PreferenceAnalytics {
+  categories: CategoryDistribution[];
+  drift: InterestDrift[];
+  driftByGranularity: Record<InterestDriftGranularity, InterestDrift[]>;
+  defaultDriftGranularity: InterestDriftGranularity;
+  coverage: HistoryCoverage;
+  durationBuckets: DurationBucket[];
+  topTags: { name: string; count: number }[];
 }
 
 export interface CreatorRanking {

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -1,9 +1,7 @@
 import type {
   QuickStats,
   DashboardOverview,
-  CategoryDistribution,
-  InterestDrift,
-  DurationBucket,
+  PreferenceAnalytics,
   CreatorFollowDataCoverage,
   CreatorFollowStatusGroup,
   CreatorRanking,
@@ -140,12 +138,7 @@ export interface SyncProgress {
 // Typed response data
 export type QuickStatsResponse = BiliVizResponse<QuickStats>;
 export type DashboardResponse = BiliVizResponse<DashboardOverview>;
-export type PreferenceResponse = BiliVizResponse<{
-  categories: CategoryDistribution[];
-  drift: InterestDrift[];
-  durationBuckets: DurationBucket[];
-  topTags: { name: string; count: number }[];
-}>;
+export type PreferenceResponse = BiliVizResponse<PreferenceAnalytics>;
 export type CreatorResponse = BiliVizResponse<{
   topCreators: CreatorRanking[];
   deepBondCreators: CreatorRanking[];


### PR DESCRIPTION
﻿Closes #36

## Summary
- Makes the Preference interest drift view coverage-aware by returning local history coverage plus daily, weekly, and monthly drift series from `GET_PREFERENCE_DATA`.
- Adds a day/week/month segmented control in the dashboard and changes copy so short history is shown as recent interest distribution, not long-term drift.
- Limits the drift legend to the top five categories plus `其他` to keep the chart readable.

## Statistical scope
- Coverage comes from local `watchHistory`: earliest synced day, latest synced day, active days, total records, and inclusive covered days.
- Drift buckets are computed from local watch-history records across the synced range, grouped by `tagName` and weighted by positive `progress` watch time.
- Each bucket reports category percentages, record count, active days, and total watch time.

## Default granularity rules
- `< 14` covered days: default `daily` and use `近期兴趣分布` copy.
- `14-89` covered days: default `weekly` and use `近期兴趣趋势` copy.
- `>= 90` covered days: default `monthly` and allow `长期兴趣漂移` copy.
- Manual day/week/month switching remains available; insufficient-history selections show caveats instead of claiming long-term drift.

## UI changes
- Shows coverage line: earliest/latest synced day, active days, total records.
- Adds day/week/month controls with default-granularity tooltips.
- Shows no-data and low-sample caveats clearly.
- Keeps dynamic bill positioning unchanged; this PR does not touch dynamic bill generation, AI, smart favorites, release packaging, or docs wording.

## Validation
- `npm run typecheck` passed.
- `npm run build` passed. Vite still reports the existing large chunk warning for `chunks/theme-*.js`.
- `git diff --check` passed.
- Browser/mock QA passed against the built dashboard bundle with mocked `GET_PREFERENCE_DATA` responses:
  - 7-day coverage defaults to `日`, title `近期兴趣分布`, coverage/sample copy visible, weekly/monthly switches show insufficient-history caveats.
  - 30-day coverage defaults to `周`, title `近期兴趣趋势`, day/month switches work and show the expected caveats where applicable.
  - 120-day coverage defaults to `月`, title `长期兴趣漂移`, day/week/month switches work without long-term copy on non-month views.
  - Empty coverage shows `暂无` coverage, zero samples, and a clear empty state.

## Blocker / must-fix / follow-up
- Blocker: none.
- Must-fix: none known.
- Follow-up: if very large local histories become slow, add a stored daily category aggregate/query path for the drift response; the current implementation intentionally keeps this scoped to existing local history records.

## Privacy check
- Did not read local key files, Cookie files, browser profiles, Bilibili login state, or `C:\Users\LittleNub\Desktop\Key.txt`.
