### PR TITLE
[codex] Add current video assistant context slice

### DIFF
--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -373,7 +373,7 @@ function CurrentVideoAssistantStatus({ context }: { context: CurrentVideoContext
           <div style={{ color: '#A0A0B0', fontSize: '10px', lineHeight: 1.5, marginTop: '4px' }}>
             BVID {context.bvid} / CID {context.cid ?? 'unknown'}
             <br />
-            Transcript {context.sources.transcript}; content text {context.sources.contentText}
+            Description {context.sources.description}; transcript {context.sources.transcript}; content text {context.sources.contentText}
           </div>
           <div style={{
             marginTop: '6px',
@@ -381,7 +381,7 @@ function CurrentVideoAssistantStatus({ context }: { context: CurrentVideoContext
             fontSize: '10px',
             lineHeight: 1.45,
           }}>
-            No AI summary is generated. No transcript is available in this slice.
+            No AI summary is generated. Description is not treated as full content text.
           </div>
         </>
       ) : (

--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -1,8 +1,9 @@
-import { useEffect } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 import { quickStats, loading, error, lastSyncResult, syncInProgress, syncProgress, syncPageLimit } from './signals';
 import { requestSW } from './utils/messaging';
 import type { QuickStats } from '../src/shared/types/analytics';
 import type { SyncNowResult, SyncProgress } from '../src/shared/types/messages';
+import type { CurrentVideoContextResult } from '../src/shared/types/current-video-context';
 import { ProgressRing } from './components/ProgressRing';
 import { QuickStats as QuickStatsPanel } from './components/QuickStats';
 import { OpenDashboard } from './components/OpenDashboard';
@@ -14,8 +15,11 @@ interface SyncStatus {
 }
 
 export function App() {
+  const [currentVideoContext, setCurrentVideoContext] = useState<CurrentVideoContextResult | null>(null);
+
   useEffect(() => {
     fetchStats(false);
+    fetchCurrentVideoContext();
     const timer = window.setInterval(refreshSyncStatus, 1500);
     return () => window.clearInterval(timer);
   }, []);
@@ -32,6 +36,15 @@ export function App() {
       }
     } catch {
       // The floating window can outlive a restarting service worker.
+    }
+  }
+
+  async function fetchCurrentVideoContext() {
+    try {
+      const context = await requestSW<CurrentVideoContextResult>('GET_CURRENT_VIDEO_CONTEXT');
+      setCurrentVideoContext(context);
+    } catch {
+      setCurrentVideoContext(null);
     }
   }
 
@@ -164,6 +177,7 @@ export function App() {
         )}
       </div>
       <OpenDashboard />
+      <CurrentVideoAssistantStatus context={currentVideoContext} />
 
       {loading.value && (
         <div style={{ textAlign: 'center', padding: '40px', color: '#9090A0' }}>
@@ -329,5 +343,52 @@ export function App() {
         </div>
       )}
     </div>
+  );
+}
+
+function CurrentVideoAssistantStatus({ context }: { context: CurrentVideoContextResult | null }) {
+  const isVideo = context?.kind === 'video';
+
+  return (
+    <section style={{
+      margin: '10px 18px 12px',
+      padding: '10px 12px',
+      border: '1px solid rgba(251, 114, 153, 0.25)',
+      borderRadius: '8px',
+      background: 'rgba(251, 114, 153, 0.08)',
+    }}>
+      <div style={{
+        color: '#FB7299',
+        fontSize: '12px',
+        fontWeight: 700,
+        marginBottom: '6px',
+      }}>
+        Local assistant context
+      </div>
+      {isVideo ? (
+        <>
+          <div style={{ color: '#E8E8F2', fontSize: '12px', lineHeight: 1.45, fontWeight: 600 }}>
+            {context.title ?? context.bvid}
+          </div>
+          <div style={{ color: '#A0A0B0', fontSize: '10px', lineHeight: 1.5, marginTop: '4px' }}>
+            BVID {context.bvid} / CID {context.cid ?? 'unknown'}
+            <br />
+            Transcript {context.sources.transcript}; content text {context.sources.contentText}
+          </div>
+          <div style={{
+            marginTop: '6px',
+            color: '#FFCF8A',
+            fontSize: '10px',
+            lineHeight: 1.45,
+          }}>
+            No AI summary is generated. No transcript is available in this slice.
+          </div>
+        </>
+      ) : (
+        <div style={{ color: '#A0A0B0', fontSize: '11px', lineHeight: 1.45 }}>
+          No current video context. Open a Bilibili video page to see metadata and source availability.
+        </div>
+      )}
+    </section>
   );
 }

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -1,4 +1,5 @@
 import type { BiliVizRequest, BiliVizContentMessage, BiliVizResponse, PlayerActionPayload, PlayerHeartbeatPayload, SyncNowResult } from '../../shared/types/messages';
+import type { CurrentVideoContextResult, CurrentVideoNoContext } from '../../shared/types/current-video-context';
 import type { DynamicBillFeedbackScope, DynamicBillStatusFilter } from '../../shared/types/dynamic-bill';
 import { runInitialBackfill } from '../sync/initial-backfill';
 import {
@@ -41,13 +42,14 @@ import {
 } from '../storage/dynamic-bill-repo';
 
 const EXPORT_PAGE_LIMIT_MAX = 1000;
+const currentVideoContexts = new Map<number, CurrentVideoContextResult>();
 
 export function setupMessageHandlers(): void {
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // Handle content script messages
     const contentMsg = message as BiliVizContentMessage;
-    if (contentMsg.action && ['PLAYER_HEARTBEAT', 'PLAYER_ACTION', 'PAGE_NAVIGATION'].includes(contentMsg.action)) {
-      handleContentMessage(contentMsg).then(() => {
+    if (contentMsg.action && ['PLAYER_HEARTBEAT', 'PLAYER_ACTION', 'PAGE_NAVIGATION', 'CURRENT_VIDEO_CONTEXT_UPDATE'].includes(contentMsg.action)) {
+      handleContentMessage(contentMsg, sender.tab?.id ?? 0).then(() => {
         sendResponse({ success: true });
       }).catch((err) => {
         sendResponse({ success: false, error: String(err) });
@@ -66,10 +68,20 @@ export function setupMessageHandlers(): void {
 
     return false;
   });
+
+  chrome.tabs.onRemoved.addListener((tabId) => {
+    currentVideoContexts.delete(tabId);
+  });
 }
 
-async function handleContentMessage(msg: BiliVizContentMessage): Promise<void> {
+async function handleContentMessage(msg: BiliVizContentMessage, tabId: number): Promise<void> {
   switch (msg.action) {
+    case 'CURRENT_VIDEO_CONTEXT_UPDATE': {
+      if (tabId > 0) {
+        currentVideoContexts.set(tabId, msg.payload as CurrentVideoContextResult);
+      }
+      break;
+    }
     case 'PLAYER_HEARTBEAT': {
       const p = msg.payload as PlayerHeartbeatPayload;
       await db.playerEvents.add({
@@ -80,7 +92,7 @@ async function handleContentMessage(msg: BiliVizContentMessage): Promise<void> {
         currentTime: p.currentTime,
         duration: p.duration,
         playbackRate: p.playbackRate ?? 1,
-        tabId: 0,
+        tabId,
       });
       await markConsumedFromPlayerEvent(p);
       break;
@@ -97,7 +109,7 @@ async function handleContentMessage(msg: BiliVizContentMessage): Promise<void> {
         playbackRate: p.playbackRate ?? 1,
         seekFrom: p.seekFrom,
         seekTo: p.seekTo,
-        tabId: 0,
+        tabId,
       });
       await markConsumedFromPlayerEvent(p);
       break;
@@ -203,6 +215,8 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
       const syncProgress = await getHistorySyncProgress();
       return { success: true, data: { lastSyncTime: lastSync, totalRecords: count, syncProgress } as T };
     }
+    case 'GET_CURRENT_VIDEO_CONTEXT':
+      return { success: true, data: await getCurrentVideoContextForActiveTab() as T };
     case 'GET_SMART_FAVORITES':
       return { success: true, data: await getSmartFavoriteOverview() as T };
     case 'GET_SMART_FAVORITES_BY_PATH': {
@@ -288,6 +302,55 @@ async function markConsumedFromPlayerEvent(
 ): Promise<void> {
   if (!payload.bvid || !isEffectivePlayerWatch(payload)) return;
   await markDynamicBillItemsConsumedByBvid(payload.bvid, Date.now());
+}
+
+async function getCurrentVideoContextForActiveTab(): Promise<CurrentVideoContextResult> {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const url = tab?.url ?? null;
+  const tabId = tab?.id ?? 0;
+
+  if (!url || !isBilibiliVideoUrl(url)) {
+    return buildNoContext(url, 'non_video_page', 'non_video');
+  }
+
+  const context = tabId > 0 ? currentVideoContexts.get(tabId) : null;
+  if (context?.kind === 'video' && context.bvid === extractBvidFromUrl(url)) {
+    return context;
+  }
+
+  return buildNoContext(url, 'video_context_unavailable', 'video');
+}
+
+function buildNoContext(
+  url: string | null,
+  reason: CurrentVideoNoContext['reason'],
+  pageType: CurrentVideoNoContext['pageType'],
+): CurrentVideoContextResult {
+  return {
+    kind: 'no_context',
+    url,
+    collectedAt: Date.now(),
+    reason,
+    pageType,
+  };
+}
+
+function isBilibiliVideoUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname.endsWith('bilibili.com') && parsed.pathname.startsWith('/video/');
+  } catch {
+    return false;
+  }
+}
+
+function extractBvidFromUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return parsed.pathname.match(/\/video\/(BV[A-Za-z0-9]+)/)?.[1] ?? '';
+  } catch {
+    return '';
+  }
 }
 
 function isEffectivePlayerWatch(payload: PlayerHeartbeatPayload | PlayerActionPayload): boolean {

--- a/src/content/player-monitor/assistant-status.ts
+++ b/src/content/player-monitor/assistant-status.ts
@@ -122,10 +122,16 @@ export function renderCurrentVideoAssistant(context: CurrentVideoContextResult):
     appendText(
       card,
       'div',
+      'bdc-assistant-row bdc-assistant-muted',
+      `Transcript ${context.sources.transcript}; content text ${context.sources.contentText}`,
+    );
+    appendText(
+      card,
+      'div',
       'bdc-assistant-warning',
-      context.sources.contentText === 'available'
-        ? 'No transcript is available in this slice. Any future help must be limited to metadata and description sources.'
-        : 'No transcript or content text source is available. This is not a full video summary.',
+      context.sources.description === 'available'
+        ? 'Description is available, but transcript and full content text are unavailable. This is not a full video summary.'
+        : 'No transcript, description, or full content text source is available. This is not a full video summary.',
     );
   } else {
     appendText(card, 'div', 'bdc-assistant-video', 'No current video context');

--- a/src/content/player-monitor/assistant-status.ts
+++ b/src/content/player-monitor/assistant-status.ts
@@ -1,0 +1,173 @@
+import type { CurrentVideoContextResult } from '../../shared/types/current-video-context';
+
+const CARD_ID = 'bdc-current-video-assistant';
+const STYLE_ID = 'bdc-current-video-assistant-style';
+
+const CSS = `
+#${CARD_ID} {
+  position: fixed;
+  right: 18px;
+  bottom: 18px;
+  z-index: 2147483646;
+  width: min(320px, calc(100vw - 36px));
+  box-sizing: border-box;
+  border: 1px solid rgba(251, 114, 153, 0.28);
+  border-radius: 8px;
+  background: rgba(26, 26, 46, 0.96);
+  color: #f2f2f6;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.28);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  padding: 12px;
+}
+#${CARD_ID} .bdc-assistant-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+  color: #fb7299;
+  font-size: 13px;
+  font-weight: 700;
+}
+#${CARD_ID} .bdc-assistant-close {
+  border: 0;
+  background: transparent;
+  color: #b8b8c8;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 2px;
+}
+#${CARD_ID} .bdc-assistant-video {
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.35;
+  margin-bottom: 8px;
+}
+#${CARD_ID} .bdc-assistant-row {
+  color: #c8c8d8;
+  font-size: 12px;
+  line-height: 1.45;
+  margin-top: 4px;
+}
+#${CARD_ID} .bdc-assistant-muted {
+  color: #9090a0;
+}
+#${CARD_ID} .bdc-assistant-warning {
+  margin-top: 10px;
+  padding: 8px;
+  border-radius: 6px;
+  background: rgba(255, 179, 71, 0.12);
+  color: #ffcf8a;
+  font-size: 12px;
+  line-height: 1.45;
+}
+#${CARD_ID} .bdc-assistant-link {
+  display: inline-block;
+  margin-top: 10px;
+  color: #ffffff;
+  background: #fb7299;
+  border-radius: 6px;
+  padding: 7px 10px;
+  text-decoration: none;
+  font-size: 12px;
+  font-weight: 650;
+}
+`;
+
+export function renderCurrentVideoAssistant(context: CurrentVideoContextResult): void {
+  injectStyle();
+
+  const existing = document.getElementById(CARD_ID);
+  const card = existing ?? document.createElement('aside');
+  card.id = CARD_ID;
+  card.setAttribute('aria-label', 'Bili-Bill local assistant status');
+  card.textContent = '';
+
+  const header = document.createElement('div');
+  header.className = 'bdc-assistant-title';
+  header.textContent = 'Bili-Bill local assistant';
+
+  const close = document.createElement('button');
+  close.className = 'bdc-assistant-close';
+  close.type = 'button';
+  close.title = 'Hide';
+  close.textContent = 'x';
+  close.addEventListener('click', () => card.remove());
+  header.appendChild(close);
+  card.appendChild(header);
+
+  if (context.kind === 'video') {
+    appendText(card, 'div', 'bdc-assistant-video', context.title ?? context.bvid);
+    appendText(card, 'div', 'bdc-assistant-row', `BVID ${context.bvid} / CID ${context.cid ?? 'unknown'}`);
+    appendText(
+      card,
+      'div',
+      'bdc-assistant-row',
+      `UP ${context.authorName ?? 'unknown'} / MID ${context.authorMid ?? 'unknown'}`,
+    );
+    appendText(
+      card,
+      'div',
+      'bdc-assistant-row',
+      `Duration ${formatDuration(context.durationSeconds)} / Part ${context.currentPart.page}${context.currentPart.total ? ` of ${context.currentPart.total}` : ''}`,
+    );
+    appendText(
+      card,
+      'div',
+      'bdc-assistant-row bdc-assistant-muted',
+      `Sources: metadata ${context.sources.metadata}, description ${context.sources.description}, pages ${context.sources.pages}, chapters ${context.sources.chapters}`,
+    );
+    appendText(
+      card,
+      'div',
+      'bdc-assistant-warning',
+      context.sources.contentText === 'available'
+        ? 'No transcript is available in this slice. Any future help must be limited to metadata and description sources.'
+        : 'No transcript or content text source is available. This is not a full video summary.',
+    );
+  } else {
+    appendText(card, 'div', 'bdc-assistant-video', 'No current video context');
+    appendText(
+      card,
+      'div',
+      'bdc-assistant-row bdc-assistant-muted',
+      'Open a Bilibili video page to use the local current-video assistant context.',
+    );
+  }
+
+  const dashboard = document.createElement('a');
+  dashboard.className = 'bdc-assistant-link';
+  dashboard.href = chrome.runtime.getURL('dashboard/index.html');
+  dashboard.target = '_blank';
+  dashboard.rel = 'noopener noreferrer';
+  dashboard.textContent = 'Open dashboard';
+  card.appendChild(dashboard);
+
+  if (!existing) {
+    document.body.appendChild(card);
+  }
+}
+
+function appendText(parent: HTMLElement, tag: 'div' | 'p', className: string, text: string): void {
+  const el = document.createElement(tag);
+  el.className = className;
+  el.textContent = text;
+  parent.appendChild(el);
+}
+
+function injectStyle(): void {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = CSS;
+  document.head.appendChild(style);
+}
+
+function formatDuration(seconds: number | null): string {
+  if (!seconds) return 'unknown';
+  const minutes = Math.floor(seconds / 60);
+  const rest = seconds % 60;
+  return `${minutes}:${String(rest).padStart(2, '0')}`;
+}

--- a/src/content/player-monitor/current-video-context.ts
+++ b/src/content/player-monitor/current-video-context.ts
@@ -108,7 +108,7 @@ export function collectCurrentVideoContext(): CurrentVideoContext | CurrentVideo
       pages: pagesAvailability,
       chapters: chaptersAvailability,
       transcript: 'unavailable',
-      contentText: descriptionText ? 'available' : 'unavailable',
+      contentText: 'unavailable',
     },
     warnings,
   };

--- a/src/content/player-monitor/current-video-context.ts
+++ b/src/content/player-monitor/current-video-context.ts
@@ -1,0 +1,226 @@
+import type {
+  CurrentVideoChapter,
+  CurrentVideoContext,
+  CurrentVideoNoContext,
+  CurrentVideoPart,
+} from '../../shared/types/current-video-context';
+
+const DESCRIPTION_LIMIT = 2000;
+
+interface BiliInitialState {
+  bvid?: string;
+  cid?: number;
+  videoData?: {
+    bvid?: string;
+    cid?: number;
+    title?: string;
+    duration?: number;
+    desc?: string;
+    description?: string;
+    owner?: { mid?: number; name?: string };
+    pages?: Array<{ page?: number; cid?: number; part?: string; title?: string; duration?: number }>;
+    chapters?: Array<{ title?: string; start?: number; startSeconds?: number; start_time?: number }>;
+    ugc_season?: {
+      sections?: Array<{
+        episodes?: Array<{ title?: string; bvid?: string; cid?: number; page?: number; duration?: number }>;
+      }>;
+    };
+  };
+  upData?: { mid?: number; name?: string };
+}
+
+export function isVideoPage(): boolean {
+  return location.pathname.startsWith('/video/');
+}
+
+export function collectCurrentVideoContext(): CurrentVideoContext | CurrentVideoNoContext {
+  if (!isVideoPage()) {
+    return buildNoContext('non_video_page', 'non_video');
+  }
+
+  const state = getInitialState();
+  const urlBvid = extractBvidFromUrl();
+  const stateBvid = normalizeString(state?.bvid ?? state?.videoData?.bvid);
+  const bvid = urlBvid || stateBvid;
+
+  if (!bvid) {
+    return buildNoContext('video_context_unavailable', 'video');
+  }
+
+  const pageNumber = extractPageFromUrl();
+  const canTrustState = !urlBvid || !stateBvid || stateBvid === urlBvid;
+  const parts = canTrustState ? collectParts(state) : [];
+  const currentPart = parts.find(part => part.page === pageNumber) ?? parts[0] ?? null;
+  const cid = canTrustState
+    ? currentPart?.cid ?? normalizeNumber(state?.cid ?? state?.videoData?.cid)
+    : null;
+  const title = canTrustState
+    ? normalizeString(state?.videoData?.title) ?? collectTitleFromDocument()
+    : collectTitleFromDocument();
+  const authorName = canTrustState
+    ? normalizeString(state?.videoData?.owner?.name ?? state?.upData?.name)
+    : null;
+  const authorMid = canTrustState
+    ? normalizeNumber(state?.videoData?.owner?.mid ?? state?.upData?.mid)
+    : null;
+  const durationSeconds = canTrustState
+    ? currentPart?.durationSeconds ?? normalizeNumber(state?.videoData?.duration)
+    : null;
+  const descriptionText = canTrustState ? collectDescription(state) : null;
+  const chapters = canTrustState ? collectChapters(state) : [];
+  const descriptionAvailability = descriptionText ? 'available' : 'unavailable';
+  const pagesAvailability = parts.length > 0 ? 'available' : 'unavailable';
+  const chaptersAvailability = chapters.length > 0 ? 'available' : 'unknown';
+  const warnings: string[] = [];
+
+  if (!cid) warnings.push('cid_unknown');
+  if (!title) warnings.push('title_unknown');
+  if (!authorName && !authorMid) warnings.push('author_unknown');
+  if (!durationSeconds) warnings.push('duration_unknown');
+  if (!descriptionText) warnings.push('description_unavailable');
+  warnings.push('transcript_unavailable');
+
+  return {
+    kind: 'video',
+    url: location.href,
+    collectedAt: Date.now(),
+    bvid,
+    cid,
+    title,
+    authorName,
+    authorMid,
+    durationSeconds,
+    currentPart: {
+      page: pageNumber,
+      title: currentPart?.title ?? null,
+      total: parts.length > 0 ? parts.length : null,
+    },
+    parts,
+    chapters,
+    description: {
+      availability: descriptionAvailability,
+      text: descriptionText,
+      length: descriptionText?.length ?? null,
+    },
+    sources: {
+      metadata: 'available',
+      description: descriptionAvailability,
+      pages: pagesAvailability,
+      chapters: chaptersAvailability,
+      transcript: 'unavailable',
+      contentText: descriptionText ? 'available' : 'unavailable',
+    },
+    warnings,
+  };
+}
+
+export function withVideoElementDuration(
+  context: CurrentVideoContext,
+  video: HTMLVideoElement,
+): CurrentVideoContext {
+  if (context.durationSeconds || !Number.isFinite(video.duration) || video.duration <= 0) {
+    return context;
+  }
+
+  return {
+    ...context,
+    collectedAt: Date.now(),
+    durationSeconds: Math.round(video.duration),
+    warnings: context.warnings.filter(warning => warning !== 'duration_unknown'),
+  };
+}
+
+function buildNoContext(
+  reason: CurrentVideoNoContext['reason'],
+  pageType: CurrentVideoNoContext['pageType'],
+): CurrentVideoNoContext {
+  return {
+    kind: 'no_context',
+    url: location.href,
+    collectedAt: Date.now(),
+    reason,
+    pageType,
+  };
+}
+
+function getInitialState(): BiliInitialState | null {
+  try {
+    return (window as any).__INITIAL_STATE__ ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function extractBvidFromUrl(): string {
+  const match = location.pathname.match(/\/video\/(BV[A-Za-z0-9]+)/);
+  return match?.[1] ?? '';
+}
+
+function extractPageFromUrl(): number {
+  const page = Number(new URLSearchParams(location.search).get('p') ?? '1');
+  return Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
+}
+
+function collectParts(state: BiliInitialState | null): CurrentVideoPart[] {
+  const pages = state?.videoData?.pages;
+  if (Array.isArray(pages) && pages.length > 0) {
+    return pages.map((page, index) => ({
+      page: normalizeNumber(page.page) ?? index + 1,
+      cid: normalizeNumber(page.cid),
+      title: normalizeString(page.part ?? page.title),
+      durationSeconds: normalizeNumber(page.duration),
+    }));
+  }
+
+  const episodes = state?.videoData?.ugc_season?.sections?.flatMap(section => section.episodes ?? []) ?? [];
+  return episodes.map((episode, index) => ({
+    page: normalizeNumber(episode.page) ?? index + 1,
+    cid: normalizeNumber(episode.cid),
+    title: normalizeString(episode.title),
+    durationSeconds: normalizeNumber(episode.duration),
+  }));
+}
+
+function collectChapters(state: BiliInitialState | null): CurrentVideoChapter[] {
+  const chapters = state?.videoData?.chapters;
+  if (!Array.isArray(chapters)) return [];
+
+  return chapters
+    .map(chapter => ({
+      title: normalizeString(chapter.title) ?? '',
+      startSeconds: normalizeNumber(chapter.startSeconds ?? chapter.start ?? chapter.start_time),
+    }))
+    .filter(chapter => chapter.title);
+}
+
+function collectDescription(state: BiliInitialState | null): string | null {
+  const fromState = normalizeString(state?.videoData?.desc ?? state?.videoData?.description);
+  const fromMeta = normalizeString(
+    document.querySelector<HTMLMetaElement>('meta[name="description"]')?.content,
+  );
+  const fromDom = normalizeString(
+    document.querySelector<HTMLElement>('.desc-info-text, .video-desc-container, #v_desc .desc-info')?.textContent,
+  );
+  const text = fromState ?? fromDom ?? fromMeta;
+  return text ? text.slice(0, DESCRIPTION_LIMIT) : null;
+}
+
+function collectTitleFromDocument(): string | null {
+  const rawTitle = normalizeString(document.title);
+  if (!rawTitle) return null;
+  return rawTitle
+    .replace(/_bilibili$/iu, '')
+    .trim() || rawTitle;
+}
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  return normalized || null;
+}
+
+function normalizeNumber(value: unknown): number | null {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) return null;
+  return Math.floor(numeric);
+}

--- a/src/content/player-monitor/index.ts
+++ b/src/content/player-monitor/index.ts
@@ -1,65 +1,14 @@
-import { detectVideo } from './video-detector';
+import { renderCurrentVideoAssistant } from './assistant-status';
+import { collectCurrentVideoContext, isVideoPage, withVideoElementDuration } from './current-video-context';
 import { attachEventListeners, type VideoContext } from './event-capture';
 import { startHeartbeat } from './heartbeat';
-
-interface BiliInitialState {
-  bvid?: string;
-  cid?: number;
-  videoData?: {
-    bvid?: string;
-    cid?: number;
-    title?: string;
-    duration?: number;
-    owner?: { mid?: number; name?: string };
-    pages?: Array<{ cid?: number; duration?: number }>;
-  };
-  upData?: { mid?: number; name?: string };
-}
+import { detectVideo } from './video-detector';
+import type { BiliVizContentMessage } from '../../shared/types/messages';
+import type { CurrentVideoContextResult } from '../../shared/types/current-video-context';
 
 let cleanup: (() => void) | null = null;
 let lastContextKey = '';
 let retryTimer: number | null = null;
-
-function isVideoPage(): boolean {
-  return location.pathname.startsWith('/video/');
-}
-
-function extractBvidFromUrl(): string {
-  const match = location.pathname.match(/\/video\/(BV[A-Za-z0-9]+)/);
-  return match?.[1] ?? '';
-}
-
-function extractPageFromUrl(): number {
-  const page = Number(new URLSearchParams(location.search).get('p') ?? '1');
-  return Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
-}
-
-function getInitialState(): BiliInitialState | null {
-  try {
-    return (window as any).__INITIAL_STATE__ ?? null;
-  } catch {
-    return null;
-  }
-}
-
-function getVideoContext() {
-  const state = getInitialState();
-  const urlBvid = extractBvidFromUrl();
-  const pageIndex = extractPageFromUrl();
-  const stateBvid = state?.bvid ?? state?.videoData?.bvid ?? '';
-  const bvid = urlBvid || stateBvid;
-  const canTrustState = !urlBvid || !stateBvid || stateBvid === urlBvid;
-  const currentPage = state?.videoData?.pages?.[pageIndex - 1];
-  const cid = canTrustState ? currentPage?.cid ?? state?.cid ?? state?.videoData?.cid ?? state?.videoData?.pages?.[0]?.cid ?? 0 : 0;
-  const title = canTrustState && state?.videoData?.title
-    ? state.videoData.title
-    : document.title.replace('_哔哩哔哩_bilibili', '').trim();
-  const duration = canTrustState ? currentPage?.duration ?? state?.videoData?.duration ?? state?.videoData?.pages?.[0]?.duration ?? 0 : 0;
-  const authorMid = canTrustState ? state?.videoData?.owner?.mid ?? state?.upData?.mid ?? 0 : 0;
-  const authorName = canTrustState ? state?.videoData?.owner?.name ?? state?.upData?.name ?? '' : '';
-
-  return { bvid, cid, title, duration, authorMid, authorName, pageIndex };
-}
 
 function scheduleInitialize(delay = 0): void {
   if (retryTimer !== null) {
@@ -74,35 +23,43 @@ function scheduleInitialize(delay = 0): void {
 }
 
 async function initializeMonitor(): Promise<void> {
-  if (!isVideoPage()) return;
+  const context = collectCurrentVideoContext();
+  renderCurrentVideoAssistant(context);
+  sendCurrentVideoContext(context);
 
-  const ctx = getVideoContext();
-  if (!ctx.bvid) {
+  if (!isVideoPage()) {
+    cleanupMonitor();
+    lastContextKey = '';
+    return;
+  }
+
+  if (context.kind !== 'video') {
     console.warn('[BiliViz] No BVID found on video page');
     return;
   }
 
-  const contextKey = `${ctx.bvid}:${ctx.cid || `p${ctx.pageIndex}`}`;
+  const contextKey = `${context.bvid}:${context.cid || `p${context.currentPart.page}`}`;
   if (contextKey === lastContextKey) return;
 
-  // Clean up previous listeners
-  if (cleanup) {
-    cleanup();
-    cleanup = null;
-  }
+  cleanupMonitor();
 
   try {
     const video = await detectVideo();
+    const contextWithDuration = withVideoElementDuration(context, video);
+    renderCurrentVideoAssistant(contextWithDuration);
+    sendCurrentVideoContext(contextWithDuration);
     lastContextKey = contextKey;
-    console.log(`[BiliViz] Monitoring: ${ctx.title} (${ctx.bvid}, cid=${ctx.cid || 'unknown'}, p=${ctx.pageIndex})`);
+    console.log(
+      `[BiliViz] Monitoring: ${contextWithDuration.title} (${contextWithDuration.bvid}, cid=${contextWithDuration.cid || 'unknown'}, p=${contextWithDuration.currentPart.page})`,
+    );
 
     const videoCtx: VideoContext = {
-      bvid: ctx.bvid,
-      cid: ctx.cid,
-      title: ctx.title,
-      duration: ctx.duration,
-      authorMid: ctx.authorMid,
-      authorName: ctx.authorName,
+      bvid: contextWithDuration.bvid,
+      cid: contextWithDuration.cid ?? 0,
+      title: contextWithDuration.title ?? '',
+      duration: contextWithDuration.durationSeconds ?? 0,
+      authorMid: contextWithDuration.authorMid ?? 0,
+      authorName: contextWithDuration.authorName ?? '',
     };
 
     const removeEvents = attachEventListeners(video, videoCtx, (msg) => {
@@ -124,10 +81,25 @@ async function initializeMonitor(): Promise<void> {
   }
 }
 
-// Initial run
+function cleanupMonitor(): void {
+  if (!cleanup) return;
+  cleanup();
+  cleanup = null;
+}
+
+function sendCurrentVideoContext(context: CurrentVideoContextResult): void {
+  const message: BiliVizContentMessage = {
+    action: 'CURRENT_VIDEO_CONTEXT_UPDATE',
+    payload: context,
+  };
+
+  chrome.runtime.sendMessage(message).catch(() => {
+    // SW may be inactive; the next page update or player event will retry.
+  });
+}
+
 scheduleInitialize();
 
-// Handle B站 SPA navigation: monitor URL changes
 let lastUrl = location.href;
 const navObserver = new MutationObserver(() => {
   if (location.href !== lastUrl) {
@@ -139,7 +111,6 @@ const navObserver = new MutationObserver(() => {
 });
 navObserver.observe(document.body, { childList: true, subtree: true });
 
-// Also check periodically as fallback
 setInterval(() => {
   if (location.href !== lastUrl) {
     lastUrl = location.href;

--- a/src/shared/types/current-video-context.ts
+++ b/src/shared/types/current-video-context.ts
@@ -1,0 +1,58 @@
+export type CurrentVideoAvailability = 'available' | 'unavailable' | 'unknown';
+
+export interface CurrentVideoPart {
+  page: number;
+  cid: number | null;
+  title: string | null;
+  durationSeconds: number | null;
+}
+
+export interface CurrentVideoChapter {
+  title: string;
+  startSeconds: number | null;
+}
+
+export interface CurrentVideoSourceAvailability {
+  metadata: CurrentVideoAvailability;
+  description: CurrentVideoAvailability;
+  pages: CurrentVideoAvailability;
+  chapters: CurrentVideoAvailability;
+  transcript: CurrentVideoAvailability;
+  contentText: CurrentVideoAvailability;
+}
+
+export interface CurrentVideoContext {
+  kind: 'video';
+  url: string;
+  collectedAt: number;
+  bvid: string;
+  cid: number | null;
+  title: string | null;
+  authorName: string | null;
+  authorMid: number | null;
+  durationSeconds: number | null;
+  currentPart: {
+    page: number;
+    title: string | null;
+    total: number | null;
+  };
+  parts: CurrentVideoPart[];
+  chapters: CurrentVideoChapter[];
+  description: {
+    availability: CurrentVideoAvailability;
+    text: string | null;
+    length: number | null;
+  };
+  sources: CurrentVideoSourceAvailability;
+  warnings: string[];
+}
+
+export interface CurrentVideoNoContext {
+  kind: 'no_context';
+  url: string | null;
+  collectedAt: number;
+  reason: 'non_video_page' | 'video_context_unavailable' | 'unsupported_page' | 'unknown';
+  pageType: 'video' | 'non_video' | 'unknown';
+}
+
+export type CurrentVideoContextResult = CurrentVideoContext | CurrentVideoNoContext;

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,5 +1,6 @@
 export * from './watch-event';
 export * from './video-info';
+export * from './current-video-context';
 export * from './analytics';
 export * from './messages';
 export * from './config';

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -20,6 +20,7 @@ import type {
   DynamicSyncResult,
 } from './dynamic-bill';
 import type { FavoriteSyncResult, SmartFavoriteOverview, SmartFavoriteResult, SmartFavoriteSearchResponse, SmartIndexResult } from './favorite';
+import type { CurrentVideoContextResult } from './current-video-context';
 
 // Popup / Dashboard → Service Worker
 export type RequestAction =
@@ -37,6 +38,7 @@ export type RequestAction =
   | 'EXPORT_DATA'
   | 'EXPORT_DATA_PAGE'
   | 'GET_SYNC_STATUS'
+  | 'GET_CURRENT_VIDEO_CONTEXT'
   | 'GET_SMART_FAVORITES'
   | 'GET_SMART_FAVORITES_BY_PATH'
   | 'SYNC_FAVORITES'
@@ -57,7 +59,8 @@ export type RequestAction =
 export type ContentAction =
   | 'PLAYER_HEARTBEAT'
   | 'PLAYER_ACTION'
-  | 'PAGE_NAVIGATION';
+  | 'PAGE_NAVIGATION'
+  | 'CURRENT_VIDEO_CONTEXT_UPDATE';
 
 // Player events from content script
 export interface PlayerHeartbeatPayload {
@@ -92,7 +95,7 @@ export interface BiliVizRequest {
 
 export interface BiliVizContentMessage {
   action: ContentAction;
-  payload: PlayerHeartbeatPayload | PlayerActionPayload | PageNavigationPayload;
+  payload: PlayerHeartbeatPayload | PlayerActionPayload | PageNavigationPayload | CurrentVideoContextResult;
 }
 
 export interface BiliVizResponse<T = unknown> {
@@ -162,6 +165,7 @@ export type FavoriteSyncResponse = BiliVizResponse<FavoriteSyncResult>;
 export type SmartFavoriteIndexResponse = BiliVizResponse<SmartIndexResult>;
 export type SmartFavoriteSearchMessageResponse = BiliVizResponse<SmartFavoriteSearchResponse>;
 export type SmartFavoritePathResponse = BiliVizResponse<SmartFavoriteResult[]>;
+export type CurrentVideoContextResponse = BiliVizResponse<CurrentVideoContextResult>;
 export type DynamicBillOverviewResponse = BiliVizResponse<DynamicBillOverview>;
 export type DynamicSyncResponse = BiliVizResponse<DynamicSyncResult>;
 export type DynamicBillGenerateResponse = BiliVizResponse<DynamicBillGenerateResult>;

--- a/tests/current-video-context.test.ts
+++ b/tests/current-video-context.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { collectCurrentVideoContext } from '../src/content/player-monitor/current-video-context.ts';
+
+test('collects Bilibili video metadata and source availability from page runtime state', () => {
+  setMockPage('https://www.bilibili.com/video/BV1CurrentCtx9?p=2', {
+    videoData: {
+      bvid: 'BV1CurrentCtx9',
+      title: 'Mock current video',
+      duration: 600,
+      desc: 'Visible description text',
+      owner: { mid: 42, name: 'Mock UP' },
+      pages: [
+        { page: 1, cid: 1001, part: 'Intro', duration: 120 },
+        { page: 2, cid: 1002, part: 'Main part', duration: 480 },
+      ],
+    },
+  });
+
+  const context = collectCurrentVideoContext();
+
+  assert.equal(context.kind, 'video');
+  assert.equal(context.bvid, 'BV1CurrentCtx9');
+  assert.equal(context.cid, 1002);
+  assert.equal(context.title, 'Mock current video');
+  assert.equal(context.authorName, 'Mock UP');
+  assert.equal(context.authorMid, 42);
+  assert.equal(context.currentPart.page, 2);
+  assert.equal(context.parts.length, 2);
+  assert.equal(context.sources.metadata, 'available');
+  assert.equal(context.sources.description, 'available');
+  assert.equal(context.sources.pages, 'available');
+  assert.equal(context.sources.transcript, 'unavailable');
+  assert.equal(context.description.text, 'Visible description text');
+});
+
+test('marks missing description and transcript as unavailable without summary claims', () => {
+  setMockPage('https://www.bilibili.com/video/BV1NoTextCtx9', {
+    videoData: {
+      bvid: 'BV1NoTextCtx9',
+      title: 'Metadata only video',
+      owner: { mid: 7, name: 'Metadata UP' },
+    },
+  });
+
+  const context = collectCurrentVideoContext();
+
+  assert.equal(context.kind, 'video');
+  assert.equal(context.sources.description, 'unavailable');
+  assert.equal(context.sources.contentText, 'unavailable');
+  assert.equal(context.sources.transcript, 'unavailable');
+  assert.equal(context.description.text, null);
+  assert.deepEqual(context.warnings.includes('transcript_unavailable'), true);
+});
+
+test('returns no-context fallback outside Bilibili video pages', () => {
+  setMockPage('https://www.bilibili.com/', {});
+
+  const context = collectCurrentVideoContext();
+
+  assert.equal(context.kind, 'no_context');
+  assert.equal(context.reason, 'non_video_page');
+  assert.equal(context.pageType, 'non_video');
+});
+
+function setMockPage(url: string, initialState: unknown): void {
+  const parsed = new URL(url);
+  const documentMock = {
+    title: 'Mock title_bilibili',
+    querySelector() {
+      return null;
+    },
+  };
+
+  Object.defineProperty(globalThis, 'location', {
+    value: parsed,
+    configurable: true,
+  });
+  Object.defineProperty(globalThis, 'document', {
+    value: documentMock,
+    configurable: true,
+  });
+  Object.defineProperty(globalThis, 'window', {
+    value: { __INITIAL_STATE__: initialState },
+    configurable: true,
+  });
+}

--- a/tests/current-video-context.test.ts
+++ b/tests/current-video-context.test.ts
@@ -31,6 +31,7 @@ test('collects Bilibili video metadata and source availability from page runtime
   assert.equal(context.sources.description, 'available');
   assert.equal(context.sources.pages, 'available');
   assert.equal(context.sources.transcript, 'unavailable');
+  assert.equal(context.sources.contentText, 'unavailable');
   assert.equal(context.description.text, 'Visible description text');
 });
 


### PR DESCRIPTION
﻿Closes #47

## Scope

- Adds a shared current-video context contract for Bilibili video pages.
- Collects current page metadata from content script runtime state and visible DOM metadata only.
- Stores the latest current-video context in background memory by tab and exposes `GET_CURRENT_VIDEO_CONTEXT`.
- Adds a local assistant status card on video pages and a compact popup status entry.
- Adds mock QA coverage for video context, no transcript/content text, and non-video fallback.

## Current-video context contract

The contract is `CurrentVideoContextResult`:

- `kind`: `video` or `no_context`
- `url`, `collectedAt`
- `bvid`, `cid`
- `title`
- `authorName`, `authorMid`
- `durationSeconds`
- `currentPart`: `page`, `title`, `total`
- `parts`: page/CID/title/duration metadata when available
- `chapters`: chapter title/start metadata when available
- `description`: availability, bounded text, and length
- `sources`: `metadata`, `description`, `pages`, `chapters`, `transcript`, `contentText`
- `warnings`: explicit unknown/unavailable markers such as `cid_unknown`, `description_unavailable`, `transcript_unavailable`

`transcript` is always `unavailable` in this slice because no transcript extraction is implemented.

## Boundaries

- No AI summary, AI call, transcript extraction, Smart Favorites Q&A, key nodes, jump, or write-back to Bilibili.
- Popup remains a compact status/launcher surface, not a full chat entry screen.
- Context uses current page runtime/DOM metadata only. It does not read local key files, Cookie files, browser profiles, or Bilibili login-state files.
- No full history, full favorites, full following, or feedback payload is uploaded.

## Validation

- `git diff --check`: pass
- `git diff --cached --check`: pass, including new files
- `npm run typecheck`: pass
- `npm run build`: pass; existing Vite large chunk warning remains non-blocking
- `node --test tests/current-video-context.test.ts`: pass
- Copy scan on staged diff for `dashboard popup public src README.md docs`: no `未消费` or `猜你喜欢` introduced
- Full repository scan still finds pre-existing planning-doc references to those phrases as forbidden/positioning context; this PR does not modify those docs.

## Blocker / must-fix / follow-up

- Blocker: none.
- Must-fix: none known.
- Follow-up: #48 can reuse `CurrentVideoContextResult` for metadata/description summary once source-tier labeling is implemented.
