### PR TITLE
[codex] Implement current video summary v0

### DIFF
--- a/dashboard/modules/favorites/SmartFavoritesPage.tsx
+++ b/dashboard/modules/favorites/SmartFavoritesPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'preact/hooks';
 import { requestSW } from '../../utils/messaging';
 import { BILI_BLUE, BILI_PINK } from '../../../src/shared/constants';
-import type { AiConfig, UserConfig } from '../../../src/shared/types/config';
+import type { AiConfig, AssistantConfig, UserConfig } from '../../../src/shared/types/config';
 import type {
   FavoriteFolderSyncDiagnostic,
   FavoriteSyncResult,
@@ -23,6 +23,7 @@ const CARD = {
 export function SmartFavoritesPage() {
   const [overview, setOverview] = useState<SmartFavoriteOverview | null>(null);
   const [config, setConfig] = useState<AiConfig>({ baseURL: 'https://api.deepseek.com', apiKey: '', chatModel: 'deepseek-v4-flash' });
+  const [assistantConfig, setAssistantConfig] = useState<AssistantConfig>({ aiSummariesEnabled: false });
   const [query, setQuery] = useState('');
   const [search, setSearch] = useState<SmartFavoriteSearchResponse | null>(null);
   const [selectedPath, setSelectedPath] = useState<string[]>([]);
@@ -46,6 +47,7 @@ export function SmartFavoritesPage() {
         requestSW<SmartFavoriteOverview>('GET_SMART_FAVORITES'),
       ]);
       setConfig(cfg.ai);
+      setAssistantConfig(cfg.assistant);
       setOverview(data);
       if (selectedPath.length > 0) {
         setPathResults(await requestSW<SmartFavoriteResult[]>('GET_SMART_FAVORITES_BY_PATH', { path: selectedPath, limit: 200 }));
@@ -62,7 +64,7 @@ export function SmartFavoritesPage() {
     setError(null);
     try {
       await ensureAiHostPermission(config.baseURL);
-      await requestSW('UPDATE_CONFIG', { ai: config });
+      await requestSW('UPDATE_CONFIG', { ai: config, assistant: assistantConfig });
       setNotice('AI 配置已保存');
     } catch (e) {
       setError((e as Error).message);
@@ -217,8 +219,25 @@ export function SmartFavoritesPage() {
           <TextInput value={config.baseURL} onInput={value => setConfig({ ...config, baseURL: value })} placeholder="Base URL" />
           <TextInput value={config.chatModel} onInput={value => setConfig({ ...config, chatModel: value })} placeholder="模型" />
         </div>
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: '8px' }}>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr auto auto', gap: '8px', alignItems: 'center' }}>
           <TextInput value={config.apiKey} onInput={value => setConfig({ ...config, apiKey: value })} placeholder="API Key" password />
+          <label style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+            color: '#C8C8D8',
+            fontSize: '11px',
+          }}>
+            <input
+              type="checkbox"
+              checked={assistantConfig.aiSummariesEnabled}
+              onChange={(event) => setAssistantConfig({
+                ...assistantConfig,
+                aiSummariesEnabled: (event.currentTarget as HTMLInputElement).checked,
+              })}
+            />
+            Assistant summaries
+          </label>
           <ActionButton label={busy === 'save' ? '保存中...' : '保存'} onClick={saveAiConfig} disabled={!!busy} />
         </div>
       </section>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite build --watch --mode development",
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
-    "test:favorites": "node --test tests/favorite-sync-audit.test.ts"
+    "test:favorites": "node --test tests/favorite-sync-audit.test.ts",
+    "test:current-video-summary": "node --test tests/current-video-summary.test.ts"
   },
   "dependencies": {
     "preact": "^10.24.0",

--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import { quickStats, loading, error, lastSyncResult, syncInProgress, syncProgress, syncPageLimit } from './signals';
 import { requestSW } from './utils/messaging';
 import type { QuickStats } from '../src/shared/types/analytics';
 import type { SyncNowResult, SyncProgress } from '../src/shared/types/messages';
 import type { CurrentVideoContextResult } from '../src/shared/types/current-video-context';
+import type { CurrentVideoSummaryResult } from '../src/shared/types/current-video-summary';
+import { cancelledCurrentVideoSummary, loadingCurrentVideoSummary } from '../src/shared/current-video-summary';
 import { ProgressRing } from './components/ProgressRing';
 import { QuickStats as QuickStatsPanel } from './components/QuickStats';
 import { OpenDashboard } from './components/OpenDashboard';
@@ -16,10 +18,14 @@ interface SyncStatus {
 
 export function App() {
   const [currentVideoContext, setCurrentVideoContext] = useState<CurrentVideoContextResult | null>(null);
+  const [currentVideoSummary, setCurrentVideoSummary] = useState<CurrentVideoSummaryResult | null>(null);
+  const [summaryLoading, setSummaryLoading] = useState(false);
+  const summaryRequestRef = useRef(0);
 
   useEffect(() => {
     fetchStats(false);
     fetchCurrentVideoContext();
+    fetchCurrentVideoSummary();
     const timer = window.setInterval(refreshSyncStatus, 1500);
     return () => window.clearInterval(timer);
   }, []);
@@ -46,6 +52,35 @@ export function App() {
     } catch {
       setCurrentVideoContext(null);
     }
+  }
+
+  async function fetchCurrentVideoSummary() {
+    const requestId = summaryRequestRef.current + 1;
+    summaryRequestRef.current = requestId;
+    setSummaryLoading(true);
+    setCurrentVideoSummary(loadingCurrentVideoSummary());
+    try {
+      const summary = await requestSW<CurrentVideoSummaryResult>('GET_CURRENT_VIDEO_SUMMARY');
+      if (summaryRequestRef.current !== requestId) return;
+      setCurrentVideoSummary(summary);
+    } catch (e) {
+      if (summaryRequestRef.current !== requestId) return;
+      setCurrentVideoSummary({
+        ...loadingCurrentVideoSummary(),
+        status: 'cancelled',
+        title: 'Current video summary unavailable',
+        summary: (e as Error).message,
+        limitations: ['The local summary request failed before an AI result was accepted.'],
+      });
+    } finally {
+      if (summaryRequestRef.current === requestId) setSummaryLoading(false);
+    }
+  }
+
+  function cancelCurrentVideoSummary() {
+    summaryRequestRef.current += 1;
+    setSummaryLoading(false);
+    setCurrentVideoSummary(cancelledCurrentVideoSummary(currentVideoContext));
   }
 
   async function fetchStats(forceSync = true) {
@@ -177,7 +212,13 @@ export function App() {
         )}
       </div>
       <OpenDashboard />
-      <CurrentVideoAssistantStatus context={currentVideoContext} />
+      <CurrentVideoAssistantStatus
+        context={currentVideoContext}
+        summary={currentVideoSummary}
+        loading={summaryLoading}
+        onRefresh={fetchCurrentVideoSummary}
+        onCancel={cancelCurrentVideoSummary}
+      />
 
       {loading.value && (
         <div style={{ textAlign: 'center', padding: '40px', color: '#9090A0' }}>
@@ -346,7 +387,19 @@ export function App() {
   );
 }
 
-function CurrentVideoAssistantStatus({ context }: { context: CurrentVideoContextResult | null }) {
+function CurrentVideoAssistantStatus({
+  context,
+  summary,
+  loading,
+  onRefresh,
+  onCancel,
+}: {
+  context: CurrentVideoContextResult | null;
+  summary: CurrentVideoSummaryResult | null;
+  loading: boolean;
+  onRefresh: () => void;
+  onCancel: () => void;
+}) {
   const isVideo = context?.kind === 'video';
 
   return (
@@ -363,7 +416,7 @@ function CurrentVideoAssistantStatus({ context }: { context: CurrentVideoContext
         fontWeight: 700,
         marginBottom: '6px',
       }}>
-        Local assistant context
+        Current video assistant
       </div>
       {isVideo ? (
         <>
@@ -375,13 +428,92 @@ function CurrentVideoAssistantStatus({ context }: { context: CurrentVideoContext
             <br />
             Description {context.sources.description}; transcript {context.sources.transcript}; content text {context.sources.contentText}
           </div>
+          {summary && (
+            <div style={{
+              marginTop: '8px',
+              padding: '8px',
+              border: '1px solid rgba(255,255,255,0.12)',
+              borderRadius: '6px',
+              background: 'rgba(0,0,0,0.12)',
+            }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '8px', alignItems: 'center' }}>
+                <span style={{
+                  color: '#FFD6E2',
+                  background: 'rgba(251, 114, 153, 0.16)',
+                  borderRadius: '6px',
+                  padding: '3px 6px',
+                  fontSize: '10px',
+                  fontWeight: 700,
+                }}>
+                  {summary.sourceTierLabel ?? summary.status}
+                </span>
+                <span style={{ color: '#A0A0B0', fontSize: '10px' }}>
+                  {summary.generationMode === 'ai' ? 'AI' : 'local'} / {summary.confidence}
+                </span>
+              </div>
+              <p style={{
+                color: '#E8E8F2',
+                fontSize: '11px',
+                lineHeight: 1.5,
+                margin: '8px 0 0',
+              }}>
+                {summary.summary}
+              </p>
+              {summary.bullets.slice(0, 2).map((bullet, index) => (
+                <div key={index} style={{ color: '#C8C8D8', fontSize: '10px', lineHeight: 1.45, marginTop: '4px' }}>
+                  - {bullet}
+                </div>
+              ))}
+              <div style={{ color: '#FFCF8A', fontSize: '10px', lineHeight: 1.45, marginTop: '6px' }}>
+                {summary.limitations[0]}
+              </div>
+              <div style={{ color: '#9090A0', fontSize: '10px', lineHeight: 1.45, marginTop: '4px' }}>
+                AI status: {summary.ai.status}. {summary.ai.note}
+              </div>
+            </div>
+          )}
           <div style={{
             marginTop: '6px',
             color: '#FFCF8A',
             fontSize: '10px',
             lineHeight: 1.45,
           }}>
-            No AI summary is generated. Description is not treated as full content text.
+            No transcript is available. This assistant does not claim a full-video summary.
+          </div>
+          <div style={{ display: 'flex', gap: '6px', marginTop: '8px' }}>
+            <button
+              onClick={onRefresh}
+              disabled={loading}
+              style={{
+                flex: 1,
+                background: '#FB7299',
+                color: '#fff',
+                border: 'none',
+                borderRadius: '6px',
+                cursor: loading ? 'default' : 'pointer',
+                fontSize: '11px',
+                padding: '6px 8px',
+                opacity: loading ? 0.7 : 1,
+              }}
+            >
+              {loading ? 'Loading...' : 'Refresh summary'}
+            </button>
+            {loading && (
+              <button
+                onClick={onCancel}
+                style={{
+                  background: 'rgba(255, 179, 71, 0.12)',
+                  color: '#FFB347',
+                  border: '1px solid rgba(255, 179, 71, 0.32)',
+                  borderRadius: '6px',
+                  cursor: 'pointer',
+                  fontSize: '11px',
+                  padding: '6px 8px',
+                }}
+              >
+                Cancel
+              </button>
+            )}
           </div>
         </>
       ) : (

--- a/src/background/current-video-summary.ts
+++ b/src/background/current-video-summary.ts
@@ -1,0 +1,147 @@
+import type { AiConfig, UserConfig } from '../shared/types/config';
+import type { CurrentVideoContextResult } from '../shared/types/current-video-context';
+import type { CurrentVideoSummaryResult } from '../shared/types/current-video-summary';
+import {
+  buildCurrentVideoSummaryAiPayload,
+  buildLocalCurrentVideoSummary,
+} from '../shared/current-video-summary';
+import { chatJson } from './ai/openai-compatible';
+import { loadConfig } from './storage/config-store';
+
+interface AiSummaryResponse {
+  summary?: unknown;
+  bullets?: unknown;
+  confidence?: unknown;
+}
+
+export interface GenerateCurrentVideoSummaryOptions {
+  config?: UserConfig;
+  chat?: (config: AiConfig, messages: Parameters<typeof chatJson>[1]) => Promise<AiSummaryResponse>;
+  now?: number;
+}
+
+const LOW_AI_CONFIDENCE_THRESHOLD = 0.45;
+
+export async function generateCurrentVideoSummary(
+  context: CurrentVideoContextResult,
+  options: GenerateCurrentVideoSummaryOptions = {},
+): Promise<CurrentVideoSummaryResult> {
+  const config = options.config ?? await loadConfig();
+  const now = options.now ?? Date.now();
+  const local = buildLocalCurrentVideoSummary(context, {
+    aiStatus: 'disabled',
+    aiModel: config.ai.chatModel,
+    aiNote: 'AI summaries are disabled; local evidence fallback is shown.',
+    now,
+  });
+
+  if (context.kind !== 'video') {
+    return buildLocalCurrentVideoSummary(context, {
+      aiStatus: 'not_requested',
+      aiModel: config.ai.chatModel,
+      aiNote: 'AI was not requested because no current video context is available.',
+      now,
+    });
+  }
+
+  if (!config.assistant.aiSummariesEnabled) {
+    return local;
+  }
+
+  if (!config.ai.apiKey.trim()) {
+    return buildLocalCurrentVideoSummary(context, {
+      aiStatus: 'not_configured',
+      aiModel: config.ai.chatModel,
+      aiNote: 'AI summaries are enabled but no API key is configured; local evidence fallback is shown.',
+      now,
+    });
+  }
+
+  try {
+    const payload = buildCurrentVideoSummaryAiPayload(context);
+    const ai = await (options.chat ?? chatJson)(config.ai, [
+      {
+        role: 'system',
+        content: [
+          'You are Bili-Bill current video assistant. Return JSON only.',
+          'You may summarize only the provided metadata and description payload.',
+          'Do not claim a full video summary, full understanding, transcript coverage, audio analysis, comments, danmaku, or visual analysis.',
+          'Keep the source tier exactly aligned with the payload sourceTier.',
+          'JSON fields: summary string, bullets string[], confidence number from 0 to 1.',
+        ].join('\n'),
+      },
+      {
+        role: 'user',
+        content: JSON.stringify(payload),
+      },
+    ]);
+    const normalized = normalizeAiSummary(ai, local);
+    if (normalized.confidence < LOW_AI_CONFIDENCE_THRESHOLD) {
+      return buildLocalCurrentVideoSummary(context, {
+        aiStatus: 'low_confidence',
+        aiModel: config.ai.chatModel,
+        aiNote: `AI confidence ${normalized.confidence.toFixed(2)} was below the local fallback threshold.`,
+        now,
+      });
+    }
+
+    return {
+      ...local,
+      generationMode: 'ai',
+      summary: normalized.summary,
+      bullets: normalized.bullets,
+      ai: {
+        status: 'generated',
+        model: config.ai.chatModel,
+        error: null,
+        note: 'AI generated from bounded current-video metadata and description payload only.',
+      },
+      generatedAt: now,
+    };
+  } catch (error) {
+    return buildLocalCurrentVideoSummary(context, {
+      aiStatus: 'failed',
+      aiModel: config.ai.chatModel,
+      aiError: errorMessage(error),
+      aiNote: 'AI generation failed; local evidence fallback is shown.',
+      now,
+    });
+  }
+}
+
+function normalizeAiSummary(
+  ai: AiSummaryResponse,
+  fallback: CurrentVideoSummaryResult,
+): { summary: string; bullets: string[]; confidence: number } {
+  const summary = normalizeText(ai.summary, fallback.summary, 520);
+  const bullets = normalizeBullets(ai.bullets, fallback.bullets);
+  const confidence = normalizeConfidence(ai.confidence);
+  return { summary, bullets, confidence };
+}
+
+function normalizeBullets(value: unknown, fallback: string[]): string[] {
+  if (!Array.isArray(value)) return fallback;
+  const bullets = value
+    .map(item => normalizeText(item, '', 220))
+    .filter(Boolean)
+    .slice(0, 5);
+  return bullets.length > 0 ? bullets : fallback;
+}
+
+function normalizeText(value: unknown, fallback: string, maxLength: number): string {
+  const raw = typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
+  const text = raw || fallback;
+  if (text.length <= maxLength) return text;
+  if (maxLength <= 3) return text.slice(0, maxLength);
+  return `${text.slice(0, maxLength - 3)}...`;
+}
+
+function normalizeConfidence(value: unknown): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 0.5;
+  return Math.round(Math.max(0, Math.min(1, numeric)) * 100) / 100;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -14,6 +14,7 @@ import {
 } from '../storage/config-store';
 import { db } from '../storage/db';
 import type { UserConfig } from '../../shared/types/config';
+import { generateCurrentVideoSummary } from '../current-video-summary';
 import {
   getQuickStats,
   getDashboardOverview,
@@ -217,6 +218,8 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
     }
     case 'GET_CURRENT_VIDEO_CONTEXT':
       return { success: true, data: await getCurrentVideoContextForActiveTab() as T };
+    case 'GET_CURRENT_VIDEO_SUMMARY':
+      return { success: true, data: await generateCurrentVideoSummary(await getCurrentVideoContextForActiveTab()) as T };
     case 'GET_SMART_FAVORITES':
       return { success: true, data: await getSmartFavoriteOverview() as T };
     case 'GET_SMART_FAVORITES_BY_PATH': {

--- a/src/background/storage/config-store.ts
+++ b/src/background/storage/config-store.ts
@@ -16,6 +16,10 @@ export async function loadConfig(): Promise<UserConfig> {
         ...DEFAULT_CONFIG.ai,
         ...(result[CONFIG_KEY].ai ?? {}),
       },
+      assistant: {
+        ...DEFAULT_CONFIG.assistant,
+        ...(result[CONFIG_KEY].assistant ?? {}),
+      },
       dynamicBill: {
         ...DEFAULT_CONFIG.dynamicBill,
         ...(result[CONFIG_KEY].dynamicBill ?? {}),
@@ -33,6 +37,10 @@ export async function saveConfig(config: Partial<UserConfig>): Promise<void> {
     ai: {
       ...current.ai,
       ...(config.ai ?? {}),
+    },
+    assistant: {
+      ...current.assistant,
+      ...(config.assistant ?? {}),
     },
     dynamicBill: {
       ...current.dynamicBill,

--- a/src/content/player-monitor/assistant-status.ts
+++ b/src/content/player-monitor/assistant-status.ts
@@ -1,4 +1,5 @@
 import type { CurrentVideoContextResult } from '../../shared/types/current-video-context';
+import { buildLocalCurrentVideoSummary } from '../../shared/current-video-summary';
 
 const CARD_ID = 'bdc-current-video-assistant';
 const STYLE_ID = 'bdc-current-video-assistant-style';
@@ -63,6 +64,22 @@ const CSS = `
   font-size: 12px;
   line-height: 1.45;
 }
+#${CARD_ID} .bdc-assistant-tier {
+  display: inline-block;
+  margin: 4px 0 6px;
+  padding: 3px 6px;
+  border-radius: 6px;
+  background: rgba(251, 114, 153, 0.16);
+  color: #ffd6e2;
+  font-size: 11px;
+  font-weight: 700;
+}
+#${CARD_ID} .bdc-assistant-summary {
+  color: #f2f2f6;
+  font-size: 12px;
+  line-height: 1.5;
+  margin-top: 4px;
+}
 #${CARD_ID} .bdc-assistant-link {
   display: inline-block;
   margin-top: 10px;
@@ -99,13 +116,19 @@ export function renderCurrentVideoAssistant(context: CurrentVideoContextResult):
   card.appendChild(header);
 
   if (context.kind === 'video') {
+    const summary = buildLocalCurrentVideoSummary(context, {
+      aiStatus: 'not_requested',
+      aiNote: 'Page overlay shows local evidence only; AI summary is available from the popup when enabled.',
+    });
     appendText(card, 'div', 'bdc-assistant-video', context.title ?? context.bvid);
+    appendText(card, 'div', 'bdc-assistant-tier', `${summary.sourceTierLabel} / ${summary.confidence} confidence`);
+    appendText(card, 'div', 'bdc-assistant-summary', summary.summary);
     appendText(card, 'div', 'bdc-assistant-row', `BVID ${context.bvid} / CID ${context.cid ?? 'unknown'}`);
     appendText(
       card,
       'div',
       'bdc-assistant-row',
-      `UP ${context.authorName ?? 'unknown'} / MID ${context.authorMid ?? 'unknown'}`,
+      `UP ${context.authorName ?? 'unknown'}`,
     );
     appendText(
       card,

--- a/src/shared/current-video-summary.ts
+++ b/src/shared/current-video-summary.ts
@@ -1,0 +1,397 @@
+import type { CurrentVideoContext, CurrentVideoContextResult } from './types/current-video-context';
+import type {
+  CurrentVideoSummaryAiStatus,
+  CurrentVideoSummaryEvidence,
+  CurrentVideoSummaryResult,
+  CurrentVideoSummarySourceTier,
+} from './types/current-video-summary';
+
+export interface LocalSummaryOptions {
+  aiStatus?: CurrentVideoSummaryAiStatus;
+  aiModel?: string | null;
+  aiError?: string | null;
+  aiNote?: string;
+  now?: number;
+}
+
+const DESCRIPTION_EVIDENCE_LIMIT = 360;
+const DESCRIPTION_AI_PAYLOAD_LIMIT = 1200;
+const LIST_LIMIT = 6;
+
+export function buildLocalCurrentVideoSummary(
+  context: CurrentVideoContextResult,
+  options: LocalSummaryOptions = {},
+): CurrentVideoSummaryResult {
+  const now = options.now ?? Date.now();
+  if (context.kind !== 'video') {
+    return {
+      status: 'no_context',
+      sourceTier: null,
+      sourceTierLabel: null,
+      confidence: 'low',
+      generationMode: 'local_fallback',
+      title: 'No current video context',
+      summary: noContextSummary(context.reason),
+      bullets: ['Open a Bilibili video page so Bili-Bill can read the current video metadata.'],
+      evidence: [],
+      missingSources: ['metadata', 'description', 'transcript', 'content text'],
+      warnings: [],
+      limitations: ['No video metadata is available for this tab.'],
+      nextQuestions: [],
+      ai: {
+        status: options.aiStatus ?? 'not_requested',
+        model: options.aiModel ?? null,
+        error: options.aiError ?? null,
+        note: options.aiNote ?? 'AI was not requested because no current video context is available.',
+      },
+      generatedAt: now,
+    };
+  }
+
+  const tier = selectSourceTier(context);
+  const confidence = tier === 'description_summary' && usefulDescriptionLength(context) >= 80 ? 'medium' : 'low';
+  const evidence = buildEvidence(context, tier);
+  const missingSources = buildMissingSources(context);
+  const limitations = buildLimitations(context, tier);
+
+  return {
+    status: 'ready',
+    sourceTier: tier,
+    sourceTierLabel: sourceTierLabel(tier),
+    confidence,
+    generationMode: 'local_fallback',
+    title: context.title ?? context.bvid,
+    summary: buildSummarySentence(context, tier),
+    bullets: buildSummaryBullets(context, tier),
+    evidence,
+    missingSources,
+    warnings: Array.from(new Set(context.warnings)),
+    limitations,
+    nextQuestions: buildNextQuestions(tier),
+    ai: {
+      status: options.aiStatus ?? 'not_requested',
+      model: options.aiModel ?? null,
+      error: options.aiError ?? null,
+      note: options.aiNote ?? localAiNote(options.aiStatus),
+    },
+    generatedAt: now,
+  };
+}
+
+export function loadingCurrentVideoSummary(now = Date.now()): CurrentVideoSummaryResult {
+  return {
+    status: 'loading',
+    sourceTier: null,
+    sourceTierLabel: null,
+    confidence: 'low',
+    generationMode: 'local_fallback',
+    title: 'Preparing current video summary',
+    summary: 'Reading the current video context and checking whether AI generation is allowed.',
+    bullets: [],
+    evidence: [],
+    missingSources: [],
+    warnings: [],
+    limitations: ['You can cancel this request; local evidence remains available after cancellation.'],
+    nextQuestions: [],
+    ai: {
+      status: 'not_requested',
+      model: null,
+      error: null,
+      note: 'Loading state before any AI request result is accepted.',
+    },
+    generatedAt: now,
+  };
+}
+
+export function cancelledCurrentVideoSummary(
+  context: CurrentVideoContextResult | null,
+  now = Date.now(),
+): CurrentVideoSummaryResult {
+  if (context) {
+    return {
+      ...buildLocalCurrentVideoSummary(context, {
+        aiStatus: 'not_requested',
+        aiNote: 'The visible AI summary request was cancelled; this is the local evidence fallback.',
+        now,
+      }),
+      status: 'cancelled',
+    };
+  }
+
+  return {
+    ...loadingCurrentVideoSummary(now),
+    status: 'cancelled',
+    title: 'Summary request cancelled',
+    summary: 'The visible summary request was cancelled before a current video context was available.',
+    limitations: ['No AI result was accepted after cancellation.'],
+  };
+}
+
+export interface CurrentVideoSummaryAiPayload {
+  intent: 'current_video_summary_v0';
+  video: {
+    bvid: string;
+    cid: number | null;
+    title: string | null;
+    authorName: string | null;
+    durationSeconds: number | null;
+    currentPart: {
+      page: number;
+      title: string | null;
+      total: number | null;
+    };
+    parts: Array<{
+      page: number;
+      cid: number | null;
+      title: string | null;
+      durationSeconds: number | null;
+    }>;
+    chapters: Array<{
+      title: string;
+      startSeconds: number | null;
+    }>;
+    description: {
+      availability: string;
+      text: string | null;
+      length: number | null;
+    };
+  };
+  availableSources: {
+    metadata: string;
+    description: string;
+    pages: string;
+    chapters: string;
+    transcript: string;
+    contentText: string;
+  };
+  sourceTier: 'metadata summary' | 'description summary';
+  warnings: string[];
+  safetyRules: string[];
+}
+
+export function buildCurrentVideoSummaryAiPayload(
+  context: CurrentVideoContext,
+): CurrentVideoSummaryAiPayload {
+  const tier = selectSourceTier(context);
+  return {
+    intent: 'current_video_summary_v0',
+    video: {
+      bvid: context.bvid,
+      cid: context.cid,
+      title: limitNullableText(context.title, 160),
+      authorName: limitNullableText(context.authorName, 80),
+      durationSeconds: context.durationSeconds,
+      currentPart: {
+        page: context.currentPart.page,
+        title: limitNullableText(context.currentPart.title, 120),
+        total: context.currentPart.total,
+      },
+      parts: context.parts.slice(0, LIST_LIMIT).map(part => ({
+        page: part.page,
+        cid: part.cid,
+        title: limitNullableText(part.title, 120),
+        durationSeconds: part.durationSeconds,
+      })),
+      chapters: context.chapters.slice(0, LIST_LIMIT).map(chapter => ({
+        title: limitText(chapter.title, 120),
+        startSeconds: chapter.startSeconds,
+      })),
+      description: {
+        availability: context.description.availability,
+        text: tier === 'description_summary'
+          ? limitNullableText(context.description.text, DESCRIPTION_AI_PAYLOAD_LIMIT)
+          : null,
+        length: context.description.length,
+      },
+    },
+    availableSources: {
+      metadata: context.sources.metadata,
+      description: context.sources.description,
+      pages: context.sources.pages,
+      chapters: context.sources.chapters,
+      transcript: context.sources.transcript,
+      contentText: context.sources.contentText,
+    },
+    sourceTier: sourceTierLabel(tier),
+    warnings: Array.from(new Set(context.warnings)).slice(0, 12),
+    safetyRules: [
+      'Do not claim a full-video summary because transcript and content text are unavailable.',
+      'Do not infer body content beyond visible metadata, description, page titles, or chapter titles.',
+      'Return the same source tier provided in sourceTier.',
+    ],
+  };
+}
+
+function selectSourceTier(context: CurrentVideoContext): CurrentVideoSummarySourceTier {
+  return context.sources.description === 'available' && Boolean(context.description.text?.trim())
+    ? 'description_summary'
+    : 'metadata_summary';
+}
+
+function sourceTierLabel(tier: CurrentVideoSummarySourceTier): 'metadata summary' | 'description summary' {
+  return tier === 'description_summary' ? 'description summary' : 'metadata summary';
+}
+
+function usefulDescriptionLength(context: CurrentVideoContext): number {
+  return context.description.text?.trim().length ?? 0;
+}
+
+function buildSummarySentence(
+  context: CurrentVideoContext,
+  tier: CurrentVideoSummarySourceTier,
+): string {
+  const title = context.title ?? context.bvid;
+  const author = context.authorName ? ` by ${context.authorName}` : '';
+  if (tier === 'description_summary') {
+    return `Description summary: based on the visible description and metadata, "${title}"${author} appears to center on ${descriptionLead(context.description.text)}.`;
+  }
+  return `Metadata summary: based only on visible metadata, "${title}"${author} can be described by its title, creator, duration, and available page or chapter labels.`;
+}
+
+function buildSummaryBullets(
+  context: CurrentVideoContext,
+  tier: CurrentVideoSummarySourceTier,
+): string[] {
+  const bullets: string[] = [];
+  if (context.authorName) bullets.push(`Creator shown in metadata: ${context.authorName}.`);
+  if (context.durationSeconds) bullets.push(`Visible duration: ${formatDuration(context.durationSeconds)}.`);
+  if (context.currentPart.total && context.currentPart.total > 1) {
+    bullets.push(`Current part: ${context.currentPart.page} of ${context.currentPart.total}${context.currentPart.title ? `, "${context.currentPart.title}"` : ''}.`);
+  }
+  if (context.parts.length > 1) {
+    bullets.push(`Page labels are available for ${context.parts.length} parts, so navigation context is stronger than a single title.`);
+  }
+  if (context.chapters.length > 0) {
+    bullets.push(`Chapter labels are available, but they are treated as structure labels, not transcript evidence.`);
+  }
+  if (tier === 'description_summary' && context.description.text) {
+    bullets.unshift(`The description says: ${limitText(context.description.text, 180)}`);
+  }
+  if (bullets.length === 0) {
+    bullets.push('Only the BVID and basic page context are available.');
+  }
+  return bullets.slice(0, 5);
+}
+
+function buildEvidence(
+  context: CurrentVideoContext,
+  tier: CurrentVideoSummarySourceTier,
+): CurrentVideoSummaryEvidence[] {
+  const evidence: CurrentVideoSummaryEvidence[] = [
+    { source: 'metadata', label: 'BVID', value: context.bvid },
+  ];
+  if (context.title) evidence.push({ source: 'metadata', label: 'Title', value: context.title });
+  if (context.authorName) evidence.push({ source: 'metadata', label: 'Creator', value: context.authorName });
+  if (context.durationSeconds) evidence.push({ source: 'metadata', label: 'Duration', value: formatDuration(context.durationSeconds) });
+  if (context.currentPart.title) evidence.push({ source: 'page', label: 'Current part', value: context.currentPart.title });
+  if (context.parts.length > 0) evidence.push({ source: 'page', label: 'Parts', value: String(context.parts.length) });
+  if (context.chapters.length > 0) {
+    evidence.push({
+      source: 'chapter',
+      label: 'Chapters',
+      value: context.chapters.slice(0, 3).map(chapter => chapter.title).join(', '),
+    });
+  }
+  if (tier === 'description_summary' && context.description.text) {
+    evidence.push({
+      source: 'description',
+      label: 'Description excerpt',
+      value: limitText(context.description.text, DESCRIPTION_EVIDENCE_LIMIT),
+    });
+  }
+  evidence.push({
+    source: 'local_fallback',
+    label: 'Source boundary',
+    value: 'Description and content text are different source tiers; content text remains unavailable.',
+  });
+  return evidence;
+}
+
+function buildMissingSources(context: CurrentVideoContext): string[] {
+  const missing: string[] = [];
+  if (context.sources.description !== 'available') missing.push('description');
+  if (context.sources.transcript !== 'available') missing.push('transcript');
+  if (context.sources.contentText !== 'available') missing.push('content text');
+  if (context.sources.pages !== 'available') missing.push('page labels');
+  if (context.sources.chapters !== 'available') missing.push('chapters');
+  return missing;
+}
+
+function buildLimitations(
+  context: CurrentVideoContext,
+  tier: CurrentVideoSummarySourceTier,
+): string[] {
+  const limitations = [
+    'No transcript is available, so this is not a full video summary and does not claim to understand the complete video body.',
+    'Full content text is unavailable; the description is not treated as body content.',
+  ];
+  if (tier === 'metadata_summary') {
+    limitations.unshift('Only metadata is available, so the summary is low confidence and topic-level.');
+  } else {
+    limitations.unshift('The summary uses the visible description plus metadata, but not transcript or full content text.');
+  }
+  if (context.sources.chapters === 'available') {
+    limitations.push('Chapter labels can describe structure only; they are not expanded into body claims.');
+  }
+  return limitations;
+}
+
+function buildNextQuestions(tier: CurrentVideoSummarySourceTier): string[] {
+  return tier === 'description_summary'
+    ? ['Show only description highlights', 'Find related favorites']
+    : ['Refresh current video metadata', 'Find related favorites'];
+}
+
+function noContextSummary(reason: string): string {
+  if (reason === 'non_video_page') return 'This tab is not a Bilibili video page.';
+  if (reason === 'video_context_unavailable') return 'The current Bilibili video context is still unavailable.';
+  return 'No current video context is available.';
+}
+
+function descriptionLead(text: string | null): string {
+  const normalized = normalizeText(text);
+  if (!normalized) return 'the text visible in the description';
+  const sentence = normalized.split(/(?<=[.!?。！？])\s+/u)[0] ?? normalized;
+  return limitText(sentence, 180);
+}
+
+function localAiNote(status?: CurrentVideoSummaryAiStatus): string {
+  switch (status) {
+    case 'disabled':
+      return 'AI summaries are disabled, so this is a local evidence fallback.';
+    case 'not_configured':
+      return 'AI summaries are enabled but no API key is configured, so this is a local evidence fallback.';
+    case 'failed':
+      return 'AI generation failed; local evidence fallback is shown.';
+    case 'low_confidence':
+      return 'AI returned low confidence; local evidence fallback is shown.';
+    default:
+      return 'Local evidence fallback; AI was not requested.';
+  }
+}
+
+function limitNullableText(value: string | null, maxLength: number): string | null {
+  return value ? limitText(value, maxLength) : null;
+}
+
+function limitText(value: string, maxLength: number): string {
+  const normalized = normalizeText(value);
+  if (normalized.length <= maxLength) return normalized;
+  if (maxLength <= 3) return normalized.slice(0, maxLength);
+  return `${normalized.slice(0, maxLength - 3)}...`;
+}
+
+function normalizeText(value: string | null): string {
+  return (value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function formatDuration(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+  const rest = safe % 60;
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(rest).padStart(2, '0')}`;
+  }
+  return `${minutes}:${String(rest).padStart(2, '0')}`;
+}

--- a/src/shared/types/config.ts
+++ b/src/shared/types/config.ts
@@ -7,6 +7,7 @@ export interface UserConfig {
   showSidebar: boolean;
   theme: 'dark' | 'light';
   ai: AiConfig;
+  assistant: AssistantConfig;
   dynamicBill: DynamicBillConfig;
 }
 
@@ -14,6 +15,10 @@ export interface AiConfig {
   baseURL: string;
   apiKey: string;
   chatModel: string;
+}
+
+export interface AssistantConfig {
+  aiSummariesEnabled: boolean;
 }
 
 export interface DynamicBillConfig {
@@ -32,6 +37,9 @@ export const DEFAULT_CONFIG: UserConfig = {
     baseURL: 'https://api.deepseek.com',
     apiKey: '',
     chatModel: 'deepseek-v4-flash',
+  },
+  assistant: {
+    aiSummariesEnabled: false,
   },
   dynamicBill: {
     aiExplanationsEnabled: false,

--- a/src/shared/types/current-video-summary.ts
+++ b/src/shared/types/current-video-summary.ts
@@ -1,0 +1,42 @@
+export type CurrentVideoSummarySourceTier = 'metadata_summary' | 'description_summary';
+export type CurrentVideoSummaryStatus = 'ready' | 'no_context' | 'loading' | 'cancelled';
+export type CurrentVideoSummaryConfidence = 'low' | 'medium';
+export type CurrentVideoSummaryGenerationMode = 'local_fallback' | 'ai';
+export type CurrentVideoSummaryAiStatus =
+  | 'not_requested'
+  | 'disabled'
+  | 'not_configured'
+  | 'generated'
+  | 'failed'
+  | 'low_confidence';
+
+export interface CurrentVideoSummaryEvidence {
+  source: 'metadata' | 'description' | 'page' | 'chapter' | 'local_fallback';
+  label: string;
+  value: string;
+}
+
+export interface CurrentVideoSummaryAiState {
+  status: CurrentVideoSummaryAiStatus;
+  model: string | null;
+  error: string | null;
+  note: string;
+}
+
+export interface CurrentVideoSummaryResult {
+  status: CurrentVideoSummaryStatus;
+  sourceTier: CurrentVideoSummarySourceTier | null;
+  sourceTierLabel: 'metadata summary' | 'description summary' | null;
+  confidence: CurrentVideoSummaryConfidence;
+  generationMode: CurrentVideoSummaryGenerationMode;
+  title: string;
+  summary: string;
+  bullets: string[];
+  evidence: CurrentVideoSummaryEvidence[];
+  missingSources: string[];
+  warnings: string[];
+  limitations: string[];
+  nextQuestions: string[];
+  ai: CurrentVideoSummaryAiState;
+  generatedAt: number;
+}

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -21,6 +21,7 @@ import type {
 } from './dynamic-bill';
 import type { FavoriteSyncResult, SmartFavoriteOverview, SmartFavoriteResult, SmartFavoriteSearchResponse, SmartIndexResult } from './favorite';
 import type { CurrentVideoContextResult } from './current-video-context';
+import type { CurrentVideoSummaryResult } from './current-video-summary';
 
 // Popup / Dashboard → Service Worker
 export type RequestAction =
@@ -39,6 +40,7 @@ export type RequestAction =
   | 'EXPORT_DATA_PAGE'
   | 'GET_SYNC_STATUS'
   | 'GET_CURRENT_VIDEO_CONTEXT'
+  | 'GET_CURRENT_VIDEO_SUMMARY'
   | 'GET_SMART_FAVORITES'
   | 'GET_SMART_FAVORITES_BY_PATH'
   | 'SYNC_FAVORITES'
@@ -166,6 +168,7 @@ export type SmartFavoriteIndexResponse = BiliVizResponse<SmartIndexResult>;
 export type SmartFavoriteSearchMessageResponse = BiliVizResponse<SmartFavoriteSearchResponse>;
 export type SmartFavoritePathResponse = BiliVizResponse<SmartFavoriteResult[]>;
 export type CurrentVideoContextResponse = BiliVizResponse<CurrentVideoContextResult>;
+export type CurrentVideoSummaryResponse = BiliVizResponse<CurrentVideoSummaryResult>;
 export type DynamicBillOverviewResponse = BiliVizResponse<DynamicBillOverview>;
 export type DynamicSyncResponse = BiliVizResponse<DynamicSyncResult>;
 export type DynamicBillGenerateResponse = BiliVizResponse<DynamicBillGenerateResult>;

--- a/tests/current-video-summary.test.ts
+++ b/tests/current-video-summary.test.ts
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildCurrentVideoSummaryAiPayload,
+  buildLocalCurrentVideoSummary,
+  cancelledCurrentVideoSummary,
+  loadingCurrentVideoSummary,
+} from '../src/shared/current-video-summary.ts';
+import type { CurrentVideoContext } from '../src/shared/types/current-video-context.ts';
+
+test('builds metadata-only summary without treating missing description as content text', () => {
+  const summary = buildLocalCurrentVideoSummary(videoContext({
+    descriptionText: null,
+    descriptionAvailable: false,
+  }));
+
+  assert.equal(summary.status, 'ready');
+  assert.equal(summary.sourceTierLabel, 'metadata summary');
+  assert.equal(summary.confidence, 'low');
+  assert.match(summary.summary, /^Metadata summary:/);
+  assert.ok(summary.missingSources.includes('description'));
+  assert.ok(summary.missingSources.includes('transcript'));
+  assert.ok(summary.missingSources.includes('content text'));
+  assert.ok(summary.limitations.some(item => item.includes('not a full video summary')));
+});
+
+test('builds description summary while keeping contentText unavailable', () => {
+  const context = videoContext({
+    descriptionText: 'This description explains the visible topic, structure, and intended audience for the upload.',
+    descriptionAvailable: true,
+  });
+  const summary = buildLocalCurrentVideoSummary(context);
+
+  assert.equal(summary.sourceTierLabel, 'description summary');
+  assert.equal(summary.confidence, 'medium');
+  assert.ok(summary.evidence.some(item => item.source === 'description'));
+  assert.equal(context.sources.contentText, 'unavailable');
+  assert.ok(summary.limitations.some(item => item.includes('description is not treated as body content')));
+});
+
+test('marks AI disabled fallback without changing source tier', () => {
+  const summary = buildLocalCurrentVideoSummary(videoContext({}), {
+    aiStatus: 'disabled',
+    aiModel: 'test-model',
+  });
+
+  assert.equal(summary.generationMode, 'local_fallback');
+  assert.equal(summary.ai.status, 'disabled');
+  assert.equal(summary.sourceTierLabel, 'description summary');
+});
+
+test('marks AI not configured fallback', () => {
+  const summary = buildLocalCurrentVideoSummary(videoContext({}), {
+    aiStatus: 'not_configured',
+    aiModel: 'test-model',
+  });
+
+  assert.equal(summary.generationMode, 'local_fallback');
+  assert.equal(summary.ai.status, 'not_configured');
+});
+
+test('marks AI failed fallback with error', () => {
+  const summary = buildLocalCurrentVideoSummary(videoContext({}), {
+    aiStatus: 'failed',
+    aiModel: 'test-model',
+    aiError: 'AI_REQUEST_FAILED_TEST',
+  });
+
+  assert.equal(summary.generationMode, 'local_fallback');
+  assert.equal(summary.ai.status, 'failed');
+  assert.equal(summary.ai.error, 'AI_REQUEST_FAILED_TEST');
+});
+
+test('marks low-confidence AI fallback', () => {
+  const summary = buildLocalCurrentVideoSummary(videoContext({}), {
+    aiStatus: 'low_confidence',
+    aiModel: 'test-model',
+  });
+
+  assert.equal(summary.generationMode, 'local_fallback');
+  assert.equal(summary.ai.status, 'low_confidence');
+});
+
+test('builds bounded AI payload without authorMid or local ledgers', () => {
+  const context = videoContext({
+    descriptionText: 'A'.repeat(2000),
+    descriptionAvailable: true,
+  });
+  const payload = buildCurrentVideoSummaryAiPayload(context);
+  const rawPayload = JSON.stringify(payload);
+
+  assert.equal(payload.video.description.text?.length, 1200);
+  assert.equal('authorMid' in payload.video, false);
+  assert.equal(payload.availableSources.contentText, 'unavailable');
+  assert.doesNotMatch(rawPayload, /authorMid|watchHistory|favorites|following|Cookie|Key\.txt|user profile/i);
+});
+
+test('exposes loading and cancelled states without accepting an AI result', () => {
+  const loading = loadingCurrentVideoSummary(100);
+  const cancelled = cancelledCurrentVideoSummary(videoContext({}), 200);
+
+  assert.equal(loading.status, 'loading');
+  assert.equal(cancelled.status, 'cancelled');
+  assert.equal(cancelled.generationMode, 'local_fallback');
+  assert.equal(cancelled.ai.status, 'not_requested');
+});
+
+function videoContext(options: {
+  descriptionText?: string | null;
+  descriptionAvailable?: boolean;
+}): CurrentVideoContext {
+  const descriptionText = options.descriptionText ?? 'A visible description for the current video.';
+  const descriptionAvailable = options.descriptionAvailable ?? true;
+  return {
+    kind: 'video',
+    url: 'https://www.bilibili.com/video/BV1Summary000',
+    collectedAt: 1000,
+    bvid: 'BV1Summary000',
+    cid: 100,
+    title: 'Current Video Title',
+    authorName: 'Current UP',
+    authorMid: 12345,
+    durationSeconds: 600,
+    currentPart: {
+      page: 1,
+      title: 'Main part',
+      total: 1,
+    },
+    parts: [
+      { page: 1, cid: 100, title: 'Main part', durationSeconds: 600 },
+    ],
+    chapters: [],
+    description: {
+      availability: descriptionAvailable ? 'available' : 'unavailable',
+      text: descriptionAvailable ? descriptionText : null,
+      length: descriptionAvailable ? descriptionText?.length ?? null : null,
+    },
+    sources: {
+      metadata: 'available',
+      description: descriptionAvailable ? 'available' : 'unavailable',
+      pages: 'available',
+      chapters: 'unknown',
+      transcript: 'unavailable',
+      contentText: 'unavailable',
+    },
+    warnings: descriptionAvailable
+      ? ['transcript_unavailable']
+      : ['description_unavailable', 'transcript_unavailable'],
+  };
+}


### PR DESCRIPTION
## Scope

Implements current video metadata/description summary v0 for Issue #48.

- Adds a shared current-video summary contract and local evidence fallback builder.
- Adds `GET_CURRENT_VIDEO_SUMMARY` in the background service worker.
- Shows source-tiered summary output in the popup and local evidence summary in the content overlay.
- Adds an `assistant.aiSummariesEnabled` config flag, default off, alongside existing AI endpoint settings.

## Source-tier behavior

- `metadata summary` is used when only title/UP/duration/page/chapter metadata is available.
- `description summary` is used only when the current video description is available.
- `description` and `contentText` remain separate source layers; this PR does not populate `sources.contentText` and does not treat description as body text.
- No transcript support is implemented. UI states explicitly say this is not a full-video summary.

## AI payload boundary

AI wording is optional and only attempted when assistant summaries are enabled and an API key is already configured. The payload is bounded to current video fields: bvid, cid, title, authorName, duration, current part, limited parts/chapters, bounded description text, source availability, and warnings.

The payload intentionally excludes authorMid, full history, favorites, following lists, feedback records, cookies, user profile data, local key paths, and unrelated local database rows.

## Fallback states

Covered states include local metadata-only fallback, description fallback, AI disabled, AI not configured, AI failed, AI low confidence, no transcript/content text, loading, cancel, and no current video context.

## Validation

- `git diff --check` passed.
- `npm run test:current-video-summary` passed: 8 tests.
- `node --test tests/current-video-context.test.ts` passed: 3 tests.
- `npm run typecheck` passed.
- `npm run build` passed. Existing Vite large chunk warning for `chunks/theme-*.js` remains non-blocking.
- Scanned `dashboard`, `popup`, `public`, `src`, and `README.md` for `未消费` / `猜你喜欢`; no matches.

## Blocker / must-fix / follow-up

Blocker: none known.

Must-fix before ready: review source-tier copy and AI toggle placement in the shared AI config card.

Follow-up: transcript extraction, transcript summary, Smart Favorites Q&A, video key nodes, jump/auto-jump, and Bilibili write-back remain out of scope.

Closes #48