### PR TITLE
[codex] Implement Smart Favorites local Q&A

### DIFF
--- a/dashboard/modules/favorites/SmartFavoritesPage.tsx
+++ b/dashboard/modules/favorites/SmartFavoritesPage.tsx
@@ -6,6 +6,8 @@ import type {
   FavoriteFolderSyncDiagnostic,
   FavoriteSyncResult,
   SmartFavoriteOverview,
+  SmartFavoriteQaCitedVideo,
+  SmartFavoriteQaResponse,
   SmartFavoriteResult,
   SmartFavoriteSearchResponse,
   SmartFavoriteTreeNode,
@@ -25,7 +27,9 @@ export function SmartFavoritesPage() {
   const [config, setConfig] = useState<AiConfig>({ baseURL: 'https://api.deepseek.com', apiKey: '', chatModel: 'deepseek-v4-flash' });
   const [assistantConfig, setAssistantConfig] = useState<AssistantConfig>({ aiSummariesEnabled: false });
   const [query, setQuery] = useState('');
+  const [question, setQuestion] = useState('');
   const [search, setSearch] = useState<SmartFavoriteSearchResponse | null>(null);
+  const [qa, setQa] = useState<SmartFavoriteQaResponse | null>(null);
   const [selectedPath, setSelectedPath] = useState<string[]>([]);
   const [pathResults, setPathResults] = useState<SmartFavoriteResult[]>([]);
   const [expandedTree, setExpandedTree] = useState<Set<string>>(() => new Set());
@@ -146,6 +150,24 @@ export function SmartFavoritesPage() {
     setError(null);
     try {
       setSearch(await requestSW<SmartFavoriteSearchResponse>('SEARCH_SMART_FAVORITES', { query: q, limit: 30 }));
+      setQa(null);
+      setSelectedPath([]);
+      setPathResults([]);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy('');
+    }
+  }
+
+  async function askFavorites() {
+    const q = question.trim();
+    if (!q) return;
+    setBusy('qa');
+    setError(null);
+    try {
+      setQa(await requestSW<SmartFavoriteQaResponse>('ASK_SMART_FAVORITES', { query: q, limit: 8 }));
+      setSearch(null);
       setSelectedPath([]);
       setPathResults([]);
     } catch (e) {
@@ -174,6 +196,7 @@ export function SmartFavoritesPage() {
     try {
       setSelectedPath(path);
       setSearch(null);
+      setQa(null);
       setPathResults(await requestSW<SmartFavoriteResult[]>('GET_SMART_FAVORITES_BY_PATH', { path, limit: 200 }));
     } catch (e) {
       setError((e as Error).message);
@@ -254,6 +277,15 @@ export function SmartFavoritesPage() {
         )}
       </section>
 
+      <section style={CARD}>
+        <div style={{ color: '#FFFFFF', fontSize: '13px', fontWeight: 600, marginBottom: '8px' }}>Smart Favorites Q&A</div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: '8px' }}>
+          <TextInput value={question} onInput={setQuestion} placeholder="Ask about locally synced favorites" onEnter={askFavorites} />
+          <ActionButton label={busy === 'qa' ? 'Answering...' : 'Ask'} onClick={askFavorites} disabled={!!busy || !question.trim()} />
+        </div>
+        {qa && <QaAnswerPanel qa={qa} />}
+      </section>
+
       <div style={{ display: 'grid', gridTemplateColumns: '240px 1fr', gap: '12px', alignItems: 'start' }}>
         <section style={CARD}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '8px', marginBottom: '8px' }}>
@@ -286,6 +318,7 @@ export function SmartFavoritesPage() {
 
         <section style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
           <ResultSection
+            qa={qa}
             search={search}
             selectedPath={selectedPath}
             pathResults={pathResults}
@@ -305,16 +338,31 @@ function mergeIndexResult(total: SmartIndexResult, batch: SmartIndexResult): voi
 }
 
 function ResultSection({
+  qa,
   search,
   selectedPath,
   pathResults,
   busy,
 }: {
+  qa: SmartFavoriteQaResponse | null;
   search: SmartFavoriteSearchResponse | null;
   selectedPath: string[];
   pathResults: SmartFavoriteResult[];
   busy: string;
 }) {
+  if (qa) {
+    return (
+      <>
+        <ResultHeader title="Q&A cited results" count={qa.citedVideos.length} />
+        {qa.citedVideos.length === 0 ? (
+          <EmptyPanel text={qa.answer} />
+        ) : (
+          qa.citedVideos.map(video => <QaCitationCard key={video.bvid || String(video.avid)} video={video} />)
+        )}
+      </>
+    );
+  }
+
   if (search) {
     return (
       <>
@@ -369,6 +417,105 @@ function EmptyPanel({ text }: { text: string }) {
       {text}
     </div>
   );
+}
+
+function QaAnswerPanel({ qa }: { qa: SmartFavoriteQaResponse }) {
+  const statusTone = getQaStatusTone(qa.status.kind);
+  return (
+    <div style={{ marginTop: '10px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+        <Badge text={qa.answerType} color={statusTone} />
+        <Badge text={`confidence: ${qa.confidence}`} color={qa.confidence === 'high' ? '#00D4AA' : qa.confidence === 'medium' ? BILI_BLUE : '#FFB347'} />
+        <Badge text={`status: ${qa.status.kind}`} color={statusTone} />
+      </div>
+      <div style={{ color: '#FFFFFF', fontSize: '13px', lineHeight: 1.5 }}>{qa.answer}</div>
+      <div style={{ color: '#A0A0B0', fontSize: '12px', lineHeight: 1.5 }}>{qa.evidenceSummary}</div>
+      {qa.status.notes.length > 0 && (
+        <div style={{ color: '#FFB347', fontSize: '12px', lineHeight: 1.5 }}>
+          {qa.status.notes.join(' ')}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function QaCitationCard({ video }: { video: SmartFavoriteQaCitedVideo }) {
+  return (
+    <a
+      href={video.link || undefined}
+      target="_blank"
+      rel="noreferrer"
+      onClick={event => {
+        if (!video.link) event.preventDefault();
+      }}
+      style={{ ...CARD, display: 'flex', flexDirection: 'column', gap: '8px', textDecoration: 'none' }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', alignItems: 'start' }}>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ color: '#FFFFFF', fontSize: '13px', fontWeight: 600, lineHeight: 1.4 }}>{video.title}</div>
+          <div style={{ color: '#9090A0', fontSize: '11px', marginTop: '4px' }}>
+            {video.bvid || `av${video.avid}`} · {video.authorName || 'Unknown UP'} · {video.folderTitle || 'Unknown folder'}
+          </div>
+        </div>
+        <Badge text={video.confidence} color={video.confidence === 'high' ? '#00D4AA' : video.confidence === 'medium' ? BILI_BLUE : '#FFB347'} />
+      </div>
+      {video.smartPath.length > 0 && (
+        <div style={{ color: BILI_BLUE, fontSize: '11px' }}>{video.smartPath.join(' / ')}</div>
+      )}
+      <div style={{ color: '#D8D8E8', fontSize: '12px', lineHeight: 1.5 }}>{video.evidence}</div>
+      <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+        {video.matchReasons.map(reason => <Badge key={reason} text={reason} color="#6666AA" />)}
+      </div>
+      <div style={{ color: '#9090A0', fontSize: '11px', lineHeight: 1.5 }}>
+        Source fields: {video.sourceFields.join(', ') || 'local metadata'} · Score {video.score}
+      </div>
+      {video.evidenceHits.length > 0 && (
+        <div style={{ display: 'grid', gap: '4px' }}>
+          {video.evidenceHits.slice(0, 4).map(hit => (
+            <div key={`${hit.field}:${hit.terms.join('|')}`} style={{ color: '#A0A0B0', fontSize: '11px', lineHeight: 1.45 }}>
+              {hit.label}: {hit.terms.join(', ')}
+            </div>
+          ))}
+        </div>
+      )}
+      <div style={{ color: video.link ? BILI_PINK : '#666', fontSize: '11px' }}>{video.link ? 'Open video' : 'No usable link'}</div>
+    </a>
+  );
+}
+
+function Badge({ text, color }: { text: string; color: string }) {
+  return (
+    <span
+      style={{
+        border: `1px solid ${color}`,
+        borderRadius: '999px',
+        color,
+        fontSize: '11px',
+        lineHeight: 1,
+        padding: '4px 7px',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {text}
+    </span>
+  );
+}
+
+function getQaStatusTone(kind: SmartFavoriteQaResponse['status']['kind']): string {
+  switch (kind) {
+    case 'ok':
+      return '#00D4AA';
+    case 'low_confidence':
+    case 'stale_index':
+    case 'index_missing':
+      return '#FFB347';
+    case 'incomplete_sync':
+    case 'insufficient_evidence':
+    case 'no_result':
+      return '#FF6B6B';
+    default:
+      return '#9090A0';
+  }
 }
 
 function Metric({ label, value }: { label: string; value: number }) {

--- a/src/background/favorites/qa-core.ts
+++ b/src/background/favorites/qa-core.ts
@@ -1,0 +1,492 @@
+import type {
+  FavoriteFolder,
+  FavoriteFolderSyncDiagnostic,
+  FavoriteItem,
+  SmartFavoriteIndex,
+  SmartFavoriteQaCitedVideo,
+  SmartFavoriteQaConfidence,
+  SmartFavoriteQaEvidenceHit,
+  SmartFavoriteQaIndexCoverage,
+  SmartFavoriteQaResponse,
+  SmartFavoriteQaStatus,
+  SmartFavoriteQaStatusKind,
+  SmartFavoriteQaSyncCoverage,
+} from '../../shared/types/favorite';
+
+const DEFAULT_QA_LIMIT = 8;
+const MEDIUM_SCORE = 28;
+const HIGH_SCORE = 56;
+const LOW_RESULT_SCORE = 10;
+const QUERY_STOP_TERMS = new Set([
+  'find',
+  'search',
+  'video',
+  'videos',
+  'favorite',
+  'favorites',
+  'bilibili',
+  'about',
+  'related',
+  'similar',
+  'that',
+  'this',
+  'have',
+  'did',
+  'does',
+  'with',
+  'from',
+  'what',
+  'which',
+  'please',
+  'help',
+  'me',
+  'my',
+  '我',
+  '你',
+  '的',
+  '了',
+  '吗',
+  '呢',
+  '有没有',
+  '是否',
+  '帮我',
+  '找',
+  '查',
+  '搜索',
+  '收藏',
+  '视频',
+  '那个',
+  '一个',
+  '一些',
+  '相关',
+  '类似',
+  '当前',
+  '内容',
+]);
+const CONTENT_QA_PATTERNS = [
+  'transcript',
+  'subtitle',
+  'caption',
+  'comment',
+  'danmaku',
+  'full content',
+  '字幕',
+  '台词',
+  '弹幕',
+  '评论',
+  '正文',
+  '全文',
+  '完整内容',
+  '视频里说',
+];
+
+interface SmartFavoriteQaInput {
+  query: string;
+  items: FavoriteItem[];
+  indexes: Map<string, SmartFavoriteIndex>;
+  folders: FavoriteFolder[];
+  limit?: number;
+  now?: number;
+}
+
+interface SearchableField {
+  field: string;
+  label: string;
+  value: string;
+  weight: number;
+  reason: string;
+}
+
+interface ScoredVideo {
+  item: FavoriteItem;
+  smart?: SmartFavoriteIndex;
+  score: number;
+  evidenceHits: SmartFavoriteQaEvidenceHit[];
+  sourceFields: string[];
+  matchReasons: string[];
+  confidence: SmartFavoriteQaConfidence;
+}
+
+export function buildSmartFavoriteQaResponse(input: SmartFavoriteQaInput): SmartFavoriteQaResponse {
+  const query = input.query.trim();
+  const limit = Math.max(1, Math.min(Math.floor(input.limit ?? DEFAULT_QA_LIMIT), 20));
+  const diagnostics = input.folders
+    .map(folder => folder.lastSyncDiagnostic)
+    .filter((diagnostic): diagnostic is FavoriteFolderSyncDiagnostic => diagnostic !== undefined);
+  const syncCoverage = buildSyncCoverage(diagnostics);
+  const indexCoverage = buildIndexCoverage(input.items, input.indexes);
+  const notes = buildCoverageNotes(syncCoverage, indexCoverage);
+
+  if (!query) {
+    const status = buildStatus('no_result', notes, syncCoverage, indexCoverage);
+    return {
+      answerType: 'no_result',
+      query,
+      answer: 'Enter a question to search locally synced favorites.',
+      confidence: 'low',
+      evidenceSummary: 'No query was provided.',
+      status,
+      citedVideos: [],
+    };
+  }
+
+  const terms = buildLocalQueryTerms(query);
+  const scored = input.items
+    .map(item => scoreFavoriteForQuestion(item, input.indexes.get(item.itemKey), terms, query))
+    .filter((result): result is ScoredVideo => result !== null)
+    .sort((a, b) => b.score - a.score || b.item.favTime - a.item.favTime);
+  const citedVideos = scored.slice(0, limit).map(toCitedVideo);
+  const asksForUnsupportedContent = CONTENT_QA_PATTERNS.some(pattern => normalizeForSearch(query).includes(normalizeForSearch(pattern)));
+
+  if (citedVideos.length === 0) {
+    const status = buildStatus('no_result', notes, syncCoverage, indexCoverage);
+    return {
+      answerType: asksForUnsupportedContent ? 'insufficient_evidence' : 'no_result',
+      query,
+      answer: syncCoverage.complete
+        ? 'No matching favorite was found in the locally synced data.'
+        : 'No matching favorite was found in the currently synced data.',
+      confidence: 'low',
+      evidenceSummary: asksForUnsupportedContent
+        ? 'This local slice can only use favorite metadata and Smart Favorites index fields; transcript, comments, and video body text are not available.'
+        : 'No local metadata or Smart Favorites index field matched the question.',
+      status: asksForUnsupportedContent
+        ? buildStatus('insufficient_evidence', [
+          ...notes,
+          'Transcript, comments, danmaku, and full video body evidence are not available for Smart Favorites Q&A.',
+        ], syncCoverage, indexCoverage)
+        : status,
+      citedVideos: [],
+    };
+  }
+
+  const top = citedVideos[0];
+  const confidence = top.confidence;
+  const answerType = confidence === 'low' || top.score < MEDIUM_SCORE ? 'candidate_list' : 'retrieval_answer';
+  const statusKind = pickStatusKind({
+    answerType,
+    confidence,
+    syncCoverage,
+    indexCoverage,
+    asksForUnsupportedContent,
+  });
+  const scopedPrefix = syncCoverage.complete ? 'In locally synced favorites' : 'In the currently synced favorite data';
+  const answer = answerType === 'candidate_list'
+    ? `${scopedPrefix}, there is not enough evidence for a firm answer. The closest cited candidates are listed below.`
+    : `${scopedPrefix}, the strongest cited matches are listed below.`;
+  const evidenceSummary = summarizeEvidence(citedVideos, indexCoverage);
+
+  return {
+    answerType: asksForUnsupportedContent ? 'insufficient_evidence' : answerType,
+    query,
+    answer: asksForUnsupportedContent
+      ? `${scopedPrefix}, these are only metadata/index candidates. This slice cannot answer transcript or full-video content questions.`
+      : answer,
+    confidence,
+    evidenceSummary,
+    status: buildStatus(statusKind, asksForUnsupportedContent
+      ? [
+        ...notes,
+        'Only favorite metadata, folder/path, UP, category/tags, aliases, keywords, summaries, and path fields were used.',
+      ]
+      : notes, syncCoverage, indexCoverage),
+    citedVideos,
+  };
+}
+
+function scoreFavoriteForQuestion(
+  item: FavoriteItem,
+  smart: SmartFavoriteIndex | undefined,
+  terms: string[],
+  rawQuery: string,
+): ScoredVideo | null {
+  const fields = buildSearchableFields(item, smart);
+  const raw = normalizeForSearch(rawQuery);
+  const hits: SmartFavoriteQaEvidenceHit[] = [];
+  let score = 0;
+
+  for (const field of fields) {
+    const normalizedValue = normalizeForSearch(field.value);
+    if (!normalizedValue) continue;
+
+    const matchedTerms = new Set<string>();
+    if (raw && field.field === 'title' && normalizedValue.includes(raw)) {
+      matchedTerms.add(rawQuery.trim());
+      score += field.weight + 18;
+    }
+
+    for (const term of terms) {
+      const normalizedTerm = normalizeForSearch(term);
+      if (normalizedTerm && normalizedValue.includes(normalizedTerm)) {
+        matchedTerms.add(term);
+        score += field.weight;
+      }
+    }
+
+    if (matchedTerms.size > 0) {
+      hits.push({
+        field: field.field,
+        label: field.label,
+        terms: Array.from(matchedTerms).slice(0, 6),
+        weight: field.weight,
+        snippet: clipSnippet(field.value),
+      });
+    }
+  }
+
+  if (score < LOW_RESULT_SCORE || hits.length === 0) return null;
+
+  const sourceFields = uniqueStrings(hits.map(hit => hit.field));
+  const matchReasons = uniqueStrings(hits.map(hit => reasonForField(hit.field))).slice(0, 4);
+  const confidence = score >= HIGH_SCORE || sourceFields.length >= 4
+    ? 'high'
+    : score >= MEDIUM_SCORE || sourceFields.length >= 2
+      ? 'medium'
+      : 'low';
+
+  return {
+    item,
+    ...(smart ? { smart } : {}),
+    score,
+    evidenceHits: hits,
+    sourceFields,
+    matchReasons,
+    confidence,
+  };
+}
+
+function buildSearchableFields(item: FavoriteItem, smart: SmartFavoriteIndex | undefined): SearchableField[] {
+  return [
+    { field: 'bvid', label: 'BVID', value: item.bvid, weight: 60, reason: 'BVID match' },
+    { field: 'title', label: 'Title', value: item.title, weight: 28, reason: 'Title match' },
+    { field: 'authorName', label: 'UP', value: item.authorName, weight: 22, reason: 'UP match' },
+    { field: 'smart.path', label: 'Smart path', value: (smart?.path ?? []).join(' / '), weight: 20, reason: 'Smart path match' },
+    { field: 'smart.keywords', label: 'Smart keywords', value: (smart?.keywords ?? []).join(' '), weight: 18, reason: 'Smart keyword match' },
+    { field: 'smart.aliases', label: 'Smart aliases', value: (smart?.aliases ?? []).join(' '), weight: 18, reason: 'Smart alias match' },
+    { field: 'smart.summary', label: 'Smart summary', value: smart?.summary ?? '', weight: 14, reason: 'Smart summary match' },
+    { field: 'folderTitle', label: 'Favorite folder', value: item.folderTitle, weight: 12, reason: 'Folder match' },
+    { field: 'tagName', label: 'Category', value: item.tagName, weight: 10, reason: 'Category match' },
+    { field: 'tags', label: 'Tags', value: (item.tags ?? []).join(' '), weight: 10, reason: 'Tag match' },
+    { field: 'intro', label: 'Intro', value: item.intro, weight: 8, reason: 'Intro match' },
+  ];
+}
+
+function toCitedVideo(result: ScoredVideo): SmartFavoriteQaCitedVideo {
+  const link = getVideoUrl(result.item);
+  return {
+    bvid: result.item.bvid,
+    avid: result.item.avid,
+    title: result.item.title,
+    authorName: result.item.authorName,
+    folderTitle: result.item.folderTitle,
+    smartPath: result.smart?.path ?? [],
+    link,
+    matchReasons: result.matchReasons,
+    sourceFields: result.sourceFields,
+    confidence: result.confidence,
+    evidence: buildEvidenceSentence(result),
+    evidenceHits: result.evidenceHits,
+    score: Math.round(result.score),
+    ...(result.smart?.indexedAt ? { indexedAt: result.smart.indexedAt } : {}),
+    syncedAt: result.item.syncedAt,
+  };
+}
+
+function buildEvidenceSentence(result: ScoredVideo): string {
+  const labels = uniqueStrings(result.evidenceHits.map(hit => hit.label)).slice(0, 3);
+  const terms = uniqueStrings(result.evidenceHits.flatMap(hit => hit.terms)).slice(0, 5);
+  return `Matched ${labels.join(', ')} with local term evidence: ${terms.join(', ')}.`;
+}
+
+function buildSyncCoverage(diagnostics: FavoriteFolderSyncDiagnostic[]): SmartFavoriteQaSyncCoverage {
+  const problemDiagnostics = diagnostics.filter(hasDiagnosticIssue);
+  const problemFolders = diagnostics.filter(hasDiagnosticIssue).length;
+  return {
+    complete: problemDiagnostics.length === 0,
+    diagnosticsCount: diagnostics.length,
+    problemFolders,
+    ...(problemDiagnostics.length > 0 ? { note: buildIncompleteSyncNote(problemDiagnostics) } : {}),
+  };
+}
+
+function buildIndexCoverage(items: FavoriteItem[], indexes: Map<string, SmartFavoriteIndex>): SmartFavoriteQaIndexCoverage {
+  const indexedItems = Array.from(indexes.values()).filter(index => index.status === 'indexed').length;
+  const failedItems = Array.from(indexes.values()).filter(index => index.status === 'failed').length;
+  const pendingItems = items.filter(item => !indexes.has(item.itemKey)).length;
+  const staleItems = items.filter(item => {
+    const index = indexes.get(item.itemKey);
+    return index !== undefined && item.syncedAt > index.indexedAt;
+  }).length;
+  const indexMissing = items.length > 0 && indexedItems === 0;
+  const staleIndex = staleItems > 0 || pendingItems > 0 || failedItems > 0;
+
+  return {
+    indexedItems,
+    failedItems,
+    pendingItems,
+    staleItems,
+    indexMissing,
+    staleIndex,
+  };
+}
+
+function buildCoverageNotes(syncCoverage: SmartFavoriteQaSyncCoverage, indexCoverage: SmartFavoriteQaIndexCoverage): string[] {
+  const notes: string[] = [];
+  if (!syncCoverage.complete) {
+    notes.push('Favorite sync is incomplete; answers are scoped to the currently synced data.');
+  }
+  if (indexCoverage.indexMissing) {
+    notes.push('Smart Favorites index is missing; only favorite metadata was used.');
+  } else if (indexCoverage.staleIndex) {
+    notes.push('Smart Favorites index may be stale or partial; metadata evidence is still used.');
+  }
+  return notes;
+}
+
+function pickStatusKind(input: {
+  answerType: 'retrieval_answer' | 'candidate_list';
+  confidence: SmartFavoriteQaConfidence;
+  syncCoverage: SmartFavoriteQaSyncCoverage;
+  indexCoverage: SmartFavoriteQaIndexCoverage;
+  asksForUnsupportedContent: boolean;
+}): SmartFavoriteQaStatusKind {
+  if (input.asksForUnsupportedContent) return 'insufficient_evidence';
+  if (!input.syncCoverage.complete) return 'incomplete_sync';
+  if (input.indexCoverage.indexMissing) return 'index_missing';
+  if (input.indexCoverage.staleIndex) return 'stale_index';
+  if (input.answerType === 'candidate_list' || input.confidence === 'low') return 'low_confidence';
+  return 'ok';
+}
+
+function buildStatus(
+  kind: SmartFavoriteQaStatusKind,
+  notes: string[],
+  syncCoverage: SmartFavoriteQaSyncCoverage,
+  indexCoverage: SmartFavoriteQaIndexCoverage,
+): SmartFavoriteQaStatus {
+  return {
+    kind,
+    notes,
+    syncCoverage,
+    indexCoverage,
+  };
+}
+
+function summarizeEvidence(citedVideos: SmartFavoriteQaCitedVideo[], indexCoverage: SmartFavoriteQaIndexCoverage): string {
+  const fields = uniqueStrings(citedVideos.flatMap(video => video.sourceFields));
+  const indexNote = indexCoverage.indexMissing
+    ? ' Smart index fields were unavailable.'
+    : indexCoverage.staleIndex
+      ? ' Some index fields may be stale or partial.'
+      : '';
+  return `Matched ${citedVideos.length} cited video(s) using ${fields.join(', ') || 'local metadata'}.${indexNote}`;
+}
+
+function buildLocalQueryTerms(query: string): string[] {
+  const compact = normalizeForSearch(query);
+  const withoutChineseStopWords = compact
+    .replace(/有没有|帮我|收藏过|收藏|视频|那个|一个|一些|相关|类似|当前|查找|搜索|请问|请/g, ' ');
+  const directTerms = query
+    .split(/[\s,.;:!?，。；：！？、|/\\()[\]{}"'`~]+/)
+    .map(term => term.trim())
+    .filter(isUsefulTerm);
+  const compactTerms = withoutChineseStopWords
+    .split(/\s+/)
+    .map(term => term.trim())
+    .filter(isUsefulTerm);
+  const cjkTerms = getCjkNgrams(withoutChineseStopWords);
+  return uniqueStrings([query.trim(), ...directTerms, ...compactTerms, ...cjkTerms])
+    .filter(isUsefulTerm)
+    .slice(0, 32);
+}
+
+function getCjkNgrams(value: string): string[] {
+  const cjkRuns = value.match(/[\u3400-\u9fff]{2,}/g) ?? [];
+  const terms: string[] = [];
+  for (const run of cjkRuns) {
+    if (run.length <= 6) {
+      terms.push(run);
+      continue;
+    }
+    for (const size of [4, 3, 2]) {
+      for (let index = 0; index <= run.length - size; index++) {
+        terms.push(run.slice(index, index + size));
+      }
+    }
+  }
+  return terms;
+}
+
+function isUsefulTerm(term: string): boolean {
+  const normalized = normalizeForSearch(term);
+  if (normalized.length < 2) return false;
+  return !QUERY_STOP_TERMS.has(normalized);
+}
+
+function reasonForField(field: string): string {
+  switch (field) {
+    case 'bvid':
+      return 'BVID matched';
+    case 'title':
+      return 'Title matched';
+    case 'authorName':
+      return 'UP matched';
+    case 'smart.path':
+      return 'Smart path matched';
+    case 'smart.keywords':
+      return 'Smart keyword matched';
+    case 'smart.aliases':
+      return 'Smart alias matched';
+    case 'smart.summary':
+      return 'Smart summary matched';
+    case 'folderTitle':
+      return 'Favorite folder matched';
+    case 'tagName':
+      return 'Category matched';
+    case 'tags':
+      return 'Tag matched';
+    case 'intro':
+      return 'Intro matched';
+    default:
+      return 'Local metadata matched';
+  }
+}
+
+function hasDiagnosticIssue(diagnostic: FavoriteFolderSyncDiagnostic): boolean {
+  return diagnostic.errors.length > 0
+    || diagnostic.hasMoreAfterStop
+    || diagnostic.stoppedByMaxPages
+    || diagnostic.unexplainedDelta > 0;
+}
+
+function buildIncompleteSyncNote(diagnostics: FavoriteFolderSyncDiagnostic[]): string {
+  const samples = diagnostics.slice(0, 3).map(diagnostic => {
+    const issues = [
+      diagnostic.errors.length > 0 ? `${diagnostic.errors.length} error(s)` : '',
+      diagnostic.unexplainedDelta > 0 ? `delta ${diagnostic.unexplainedDelta}` : '',
+      diagnostic.hasMoreAfterStop ? 'has_more after stop' : '',
+      diagnostic.stoppedByMaxPages ? 'max pages reached' : '',
+    ].filter(Boolean).join(', ');
+    return `${diagnostic.title || diagnostic.mediaId}(${diagnostic.mediaId}): ${issues}`;
+  });
+  return `FAVORITE_SYNC_INCOMPLETE: ${samples.join('; ')}`;
+}
+
+function getVideoUrl(item: FavoriteItem): string {
+  if (item.bvid) return `https://www.bilibili.com/video/${encodeURIComponent(item.bvid)}`;
+  if (item.avid) return `https://www.bilibili.com/video/av${encodeURIComponent(String(item.avid))}`;
+  return '';
+}
+
+function clipSnippet(value: string): string {
+  const trimmed = value.trim().replace(/\s+/g, ' ');
+  return trimmed.length <= 120 ? trimmed : `${trimmed.slice(0, 117)}...`;
+}
+
+function normalizeForSearch(value: string): string {
+  return value.toLocaleLowerCase().replace(/\s+/g, '');
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean)));
+}

--- a/src/background/favorites/qa.ts
+++ b/src/background/favorites/qa.ts
@@ -1,0 +1,13 @@
+import type { SmartFavoriteQaResponse } from '../../shared/types/favorite';
+import { getFavoriteFolders, getFavoriteItems, getSmartFavoriteIndexMap } from '../storage/favorite-repo';
+import { buildSmartFavoriteQaResponse } from './qa-core';
+
+export async function answerSmartFavoriteQuestion(query: string, limit = 8): Promise<SmartFavoriteQaResponse> {
+  const [folders, items, indexes] = await Promise.all([
+    getFavoriteFolders(),
+    getFavoriteItems(),
+    getSmartFavoriteIndexMap(),
+  ]);
+
+  return buildSmartFavoriteQaResponse({ query, items, indexes, folders, limit });
+}

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -28,6 +28,7 @@ import { getDeviceData } from '../analytics/device';
 import { abortCurrentHistorySync, hasActiveHistorySyncAbortScope } from '../sync/sync-control';
 import { syncFavorites } from '../favorites/sync';
 import { buildSmartFavoriteIndex, getSmartFavoriteOverview, getSmartFavoritesByPath, searchSmartFavorites } from '../favorites/smart';
+import { answerSmartFavoriteQuestion } from '../favorites/qa';
 import { buildDynamicBillExplanations } from '../dynamic-bill/ai';
 import { generateDynamicBillItems } from '../dynamic-bill/generator';
 import { DYNAMIC_BILL_STRATEGY } from '../dynamic-bill/strategy';
@@ -253,6 +254,14 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
       return {
         success: true,
         data: await searchSmartFavorites(query, Number.isFinite(limit) ? limit : undefined) as T,
+      };
+    }
+    case 'ASK_SMART_FAVORITES': {
+      const query = String(request.params?.query ?? '');
+      const limit = Number(request.params?.limit);
+      return {
+        success: true,
+        data: await answerSmartFavoriteQuestion(query, Number.isFinite(limit) ? limit : undefined) as T,
       };
     }
     case 'GET_DYNAMIC_BILL_OVERVIEW':

--- a/src/shared/types/favorite.ts
+++ b/src/shared/types/favorite.ts
@@ -114,3 +114,79 @@ export interface SmartFavoriteSearchResponse {
   rewrittenTerms: string[];
   results: SmartFavoriteResult[];
 }
+
+export type SmartFavoriteQaAnswerType =
+  | 'retrieval_answer'
+  | 'candidate_list'
+  | 'no_result'
+  | 'insufficient_evidence';
+
+export type SmartFavoriteQaConfidence = 'high' | 'medium' | 'low';
+
+export type SmartFavoriteQaStatusKind =
+  | 'ok'
+  | 'no_result'
+  | 'low_confidence'
+  | 'stale_index'
+  | 'incomplete_sync'
+  | 'index_missing'
+  | 'insufficient_evidence';
+
+export interface SmartFavoriteQaEvidenceHit {
+  field: string;
+  label: string;
+  terms: string[];
+  weight: number;
+  snippet: string;
+}
+
+export interface SmartFavoriteQaCitedVideo {
+  bvid: string;
+  avid: number;
+  title: string;
+  authorName: string;
+  folderTitle: string;
+  smartPath: string[];
+  link: string;
+  matchReasons: string[];
+  sourceFields: string[];
+  confidence: SmartFavoriteQaConfidence;
+  evidence: string;
+  evidenceHits: SmartFavoriteQaEvidenceHit[];
+  score: number;
+  indexedAt?: number;
+  syncedAt: number;
+}
+
+export interface SmartFavoriteQaSyncCoverage {
+  complete: boolean;
+  diagnosticsCount: number;
+  problemFolders: number;
+  note?: string;
+}
+
+export interface SmartFavoriteQaIndexCoverage {
+  indexedItems: number;
+  failedItems: number;
+  pendingItems: number;
+  staleItems: number;
+  indexMissing: boolean;
+  staleIndex: boolean;
+}
+
+export interface SmartFavoriteQaStatus {
+  kind: SmartFavoriteQaStatusKind;
+  notes: string[];
+  syncCoverage: SmartFavoriteQaSyncCoverage;
+  indexCoverage: SmartFavoriteQaIndexCoverage;
+}
+
+export interface SmartFavoriteQaResponse {
+  answerType: SmartFavoriteQaAnswerType;
+  query: string;
+  answer: string;
+  confidence: SmartFavoriteQaConfidence;
+  evidenceSummary: string;
+  status: SmartFavoriteQaStatus;
+  citedVideos: SmartFavoriteQaCitedVideo[];
+}

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -19,7 +19,14 @@ import type {
   DynamicBillOverview,
   DynamicSyncResult,
 } from './dynamic-bill';
-import type { FavoriteSyncResult, SmartFavoriteOverview, SmartFavoriteResult, SmartFavoriteSearchResponse, SmartIndexResult } from './favorite';
+import type {
+  FavoriteSyncResult,
+  SmartFavoriteOverview,
+  SmartFavoriteQaResponse,
+  SmartFavoriteResult,
+  SmartFavoriteSearchResponse,
+  SmartIndexResult,
+} from './favorite';
 import type { CurrentVideoContextResult } from './current-video-context';
 import type { CurrentVideoSummaryResult } from './current-video-summary';
 
@@ -46,6 +53,7 @@ export type RequestAction =
   | 'SYNC_FAVORITES'
   | 'BUILD_SMART_FAVORITE_INDEX'
   | 'SEARCH_SMART_FAVORITES'
+  | 'ASK_SMART_FAVORITES'
   | 'GET_DYNAMIC_BILL_OVERVIEW'
   | 'SYNC_DYNAMIC_UPDATES'
   | 'GENERATE_DYNAMIC_BILL'
@@ -166,6 +174,7 @@ export type SmartFavoritesResponse = BiliVizResponse<SmartFavoriteOverview>;
 export type FavoriteSyncResponse = BiliVizResponse<FavoriteSyncResult>;
 export type SmartFavoriteIndexResponse = BiliVizResponse<SmartIndexResult>;
 export type SmartFavoriteSearchMessageResponse = BiliVizResponse<SmartFavoriteSearchResponse>;
+export type SmartFavoriteQaMessageResponse = BiliVizResponse<SmartFavoriteQaResponse>;
 export type SmartFavoritePathResponse = BiliVizResponse<SmartFavoriteResult[]>;
 export type CurrentVideoContextResponse = BiliVizResponse<CurrentVideoContextResult>;
 export type CurrentVideoSummaryResponse = BiliVizResponse<CurrentVideoSummaryResult>;

--- a/tests/smart-favorites-qa.test.ts
+++ b/tests/smart-favorites-qa.test.ts
@@ -1,0 +1,176 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { FavoriteFolder, FavoriteFolderSyncDiagnostic, FavoriteItem, SmartFavoriteIndex } from '../src/shared/types/favorite.ts';
+import { buildSmartFavoriteQaResponse } from '../src/background/favorites/qa-core.ts';
+
+test('returns cited videos with source fields and evidence for local matches', () => {
+  const item = makeFavoriteItem(1, {
+    title: 'Kursk tank battle documentary',
+    folderTitle: 'History',
+    authorName: 'Archive UP',
+    tagName: 'History',
+  });
+  const index = makeIndex(item, {
+    path: ['Knowledge', 'History', 'WWII', 'Kursk'],
+    keywords: ['Kursk', 'Eastern Front'],
+    summary: 'A local metadata summary about the Battle of Kursk.',
+  });
+
+  const response = buildSmartFavoriteQaResponse({
+    query: 'Kursk WWII',
+    items: [item],
+    indexes: new Map([[item.itemKey, index]]),
+    folders: [makeFolder()],
+  });
+
+  assert.equal(response.answerType, 'retrieval_answer');
+  assert.equal(response.citedVideos.length, 1);
+  assert.equal(response.citedVideos[0].bvid, item.bvid);
+  assert.equal(response.citedVideos[0].link, `https://www.bilibili.com/video/${item.bvid}`);
+  assert.ok(response.citedVideos[0].sourceFields.includes('title'));
+  assert.ok(response.citedVideos[0].sourceFields.includes('smart.keywords'));
+  assert.match(response.citedVideos[0].evidence, /Matched/);
+});
+
+test('returns no_result without inventing citations', () => {
+  const item = makeFavoriteItem(1, { title: 'Linear algebra notes' });
+
+  const response = buildSmartFavoriteQaResponse({
+    query: 'sourdough starter',
+    items: [item],
+    indexes: new Map(),
+    folders: [makeFolder()],
+  });
+
+  assert.equal(response.answerType, 'no_result');
+  assert.equal(response.status.kind, 'no_result');
+  assert.equal(response.citedVideos.length, 0);
+  assert.match(response.evidenceSummary, /No local metadata/);
+});
+
+test('returns low-confidence candidates when evidence is weak', () => {
+  const item = makeFavoriteItem(1, { tagName: 'Physics' });
+
+  const response = buildSmartFavoriteQaResponse({
+    query: 'physics',
+    items: [item],
+    indexes: new Map(),
+    folders: [makeFolder()],
+  });
+
+  assert.equal(response.answerType, 'candidate_list');
+  assert.equal(response.confidence, 'low');
+  assert.equal(response.citedVideos[0].confidence, 'low');
+  assert.equal(response.citedVideos[0].sourceFields[0], 'tagName');
+});
+
+test('marks answers when the Smart Favorites index is stale', () => {
+  const item = makeFavoriteItem(1, {
+    title: 'Time management system',
+    syncedAt: 2_000,
+  });
+  const index = makeIndex(item, {
+    indexedAt: 1_000,
+    keywords: ['time management'],
+    path: ['Productivity'],
+  });
+
+  const response = buildSmartFavoriteQaResponse({
+    query: 'time management',
+    items: [item],
+    indexes: new Map([[item.itemKey, index]]),
+    folders: [makeFolder()],
+  });
+
+  assert.equal(response.status.kind, 'stale_index');
+  assert.equal(response.status.indexCoverage.staleItems, 1);
+  assert.match(response.status.notes.join(' '), /stale or partial/);
+});
+
+test('scopes answers to currently synced data when sync diagnostics are incomplete', () => {
+  const item = makeFavoriteItem(1, { title: 'Creator workflow automation' });
+  const folder = makeFolder({ lastSyncDiagnostic: makeIncompleteDiagnostic() });
+
+  const response = buildSmartFavoriteQaResponse({
+    query: 'creator workflow',
+    items: [item],
+    indexes: new Map(),
+    folders: [folder],
+  });
+
+  assert.equal(response.status.kind, 'incomplete_sync');
+  assert.equal(response.status.syncCoverage.complete, false);
+  assert.equal(response.status.syncCoverage.problemFolders, 1);
+  assert.match(response.answer, /currently synced/);
+});
+
+function makeFolder(overrides: Partial<FavoriteFolder> = {}): FavoriteFolder {
+  return {
+    mediaId: 100,
+    title: 'Default',
+    cover: '',
+    intro: '',
+    mediaCount: 1,
+    createdAt: 0,
+    updatedAt: 0,
+    syncedAt: 1_000,
+    ...overrides,
+  };
+}
+
+function makeFavoriteItem(id: number, overrides: Partial<FavoriteItem> = {}): FavoriteItem {
+  return {
+    itemKey: `100:BV${id}`,
+    mediaId: 100,
+    folderTitle: 'Default',
+    avid: id,
+    bvid: `BV${id}`,
+    title: `Video ${id}`,
+    intro: '',
+    authorName: `UP ${id}`,
+    authorMid: id,
+    tagName: '',
+    tags: [],
+    cover: '',
+    duration: 0,
+    pubtime: 0,
+    favTime: id,
+    syncedAt: 1_000,
+    ...overrides,
+  };
+}
+
+function makeIndex(item: FavoriteItem, overrides: Partial<SmartFavoriteIndex> = {}): SmartFavoriteIndex {
+  return {
+    itemKey: item.itemKey,
+    path: [],
+    summary: '',
+    keywords: [],
+    aliases: [],
+    searchableText: '',
+    contentHash: 'hash',
+    model: 'local-test',
+    status: 'indexed',
+    indexedAt: 1_000,
+    ...overrides,
+  };
+}
+
+function makeIncompleteDiagnostic(): FavoriteFolderSyncDiagnostic {
+  return {
+    mediaId: 100,
+    title: 'Default',
+    reportedMediaCount: 20,
+    pagesFetched: 1,
+    rawResourcesSeen: 10,
+    storedVideoItems: 10,
+    filteredUnavailableItems: 0,
+    filteredMissingIdItems: 0,
+    filteredNonVideoItems: 0,
+    filteredItems: 0,
+    hasMoreAfterStop: true,
+    stoppedByMaxPages: false,
+    unexplainedDelta: 10,
+    errors: [],
+  };
+}


### PR DESCRIPTION
﻿## Scope
- Adds a local-only Smart Favorites Q&A retrieval contract and service worker action.
- Adds Dashboard Q&A entry and cited video cards with bvid/title/UP/folder/path/link, reasons, source fields, confidence, and evidence.
- Adds focused mock tests for cited results, no result, low confidence, stale index, and incomplete sync.

## Retrieval contract
- Uses locally synced favorite metadata plus existing Smart Favorites index fields: folder/path, UP, category/tags, summary, keywords, aliases, and path.
- Does not call AI and does not synthesize unsupported claims.
- Returns `retrieval_answer`, `candidate_list`, `no_result`, or `insufficient_evidence` with `citedVideos` and structured evidence hits.

## Coverage and incomplete sync behavior
- Surfaces no-result, low-confidence, stale-index/index-missing, and incomplete-sync states.
- When favorite sync diagnostics are incomplete, answers are scoped to the currently synced data rather than claiming full coverage.

## Privacy boundary
- No Cookie, browser profile, Bilibili login-state, API key file, local key path, full favorites upload, or write-back behavior was added.
- This PR does not implement #51 AI synthesis or #39 transcript/video knowledge.

## Validation
- `git diff --check` passed; CRLF warnings only.
- `node --test tests/smart-favorites-qa.test.ts` passed.
- `npm run test:favorites` passed.
- `npm run typecheck` passed.
- `npm run build` passed; existing Vite large chunk warning remains non-blocking.
- Browser smoke on `http://127.0.0.1:5173/dashboard/index.html`: Smart Favorites Q&A renders and input/Ask interaction is reachable; ordinary browser shows expected missing extension runtime `sendMessage` error.
- Scan of `dashboard`, `popup`, `public`, `src`, `README.md`, and new tests found no `未消费` or `猜你喜欢` copy.

## Blocker / must-fix / follow-up
- Blocker: none for this local retrieval slice.
- Must-fix: none known.
- Follow-up: #51 can add optional AI synthesis from the cited top-N payload only; #39 remains responsible for transcript/content QA.

Closes #50
