### PR TITLE
[codex] Add assistant payload privacy audit

### DIFF
--- a/src/shared/assistant-payload-audit.ts
+++ b/src/shared/assistant-payload-audit.ts
@@ -1,0 +1,192 @@
+export interface AssistantPayloadAuditContract {
+  name: string;
+  allowedPaths: readonly string[];
+}
+
+export interface AssistantPayloadAuditViolation {
+  path: string;
+  reason: string;
+  token?: string;
+}
+
+export interface AssistantPayloadAuditResult {
+  passed: boolean;
+  violations: AssistantPayloadAuditViolation[];
+}
+
+const SENSITIVE_KEY_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
+  { pattern: /^(watchHistory|historyItems|fullHistory|watchRecords)$/i, reason: 'Full watch history fields are not allowed.' },
+  { pattern: /^(favorites|favoriteItems|favoriteFolders|fullFavorites|unmatchedFavorites)$/i, reason: 'Full favorites fields are not allowed.' },
+  { pattern: /^(following|followings|followingList|followedCreators|fullFollowing)$/i, reason: 'Full following fields are not allowed.' },
+  { pattern: /^(feedback|feedbackRecords|fullFeedback)$/i, reason: 'Full feedback fields are not allowed.' },
+  { pattern: /cookie/i, reason: 'Cookie fields are not allowed.' },
+  { pattern: /(browserProfile|profilePath|userDataDir|chromeProfile|firefoxProfile)/i, reason: 'Browser profile fields are not allowed.' },
+  { pattern: /(loginState|sessdata|biliJct|dedeUserId)/i, reason: 'Bilibili login-state fields are not allowed.' },
+  { pattern: /(keyPath|apiKeyPath|localKeyPath|keyFile)/i, reason: 'Local key path fields are not allowed.' },
+  { pattern: /^(userMid|mid|uid|userProfile|profile)$/i, reason: 'User profile identifiers are not allowed.' },
+  { pattern: /^authorMid$/i, reason: 'Creator relationship identifier authorMid is not allowed in assistant AI payloads.' },
+];
+
+const SENSITIVE_STRING_PATTERNS: Array<{ pattern: RegExp; token: string; reason: string }> = [
+  {
+    pattern: /C:\\Users\\LittleNub\\Desktop\\Key\.txt/i,
+    token: 'C:\\Users\\LittleNub\\Desktop\\Key.txt',
+    reason: 'Local key file path is not allowed.',
+  },
+  { pattern: /\bKey\.txt\b/i, token: 'Key.txt', reason: 'Local key file path is not allowed.' },
+  { pattern: /\bCookie\b|SESSDATA|bili_jct|DedeUserID/i, token: 'Cookie/login token', reason: 'Cookie or Bilibili login-state token is not allowed.' },
+  { pattern: /Chrome\\User Data|Firefox\\Profiles|browser profile/i, token: 'browser profile', reason: 'Browser profile token is not allowed.' },
+  { pattern: /Bilibili login state|login-state|login state/i, token: 'Bilibili login state', reason: 'Bilibili login-state token is not allowed.' },
+  { pattern: /user profile|userMid|user mid|\bmid\s*[:=]\s*\d+/i, token: 'user profile identifier', reason: 'User profile identifier token is not allowed.' },
+  { pattern: /authorMid|author mid/i, token: 'authorMid', reason: 'Creator relationship identifier token is not allowed.' },
+  { pattern: /watchHistory|full watch history|full history/i, token: 'watch history', reason: 'Full watch history token is not allowed.' },
+  { pattern: /favoriteItems|full favorites|full favorite/i, token: 'favorites', reason: 'Full favorites token is not allowed.' },
+  { pattern: /followingList|full following/i, token: 'following', reason: 'Full following token is not allowed.' },
+  { pattern: /feedbackRecords|full feedback/i, token: 'feedback', reason: 'Full feedback token is not allowed.' },
+];
+
+export const currentVideoSummaryPayloadContract: AssistantPayloadAuditContract = {
+  name: 'current-video-summary-v0',
+  allowedPaths: [
+    '$',
+    '$.intent',
+    '$.video',
+    '$.video.bvid',
+    '$.video.cid',
+    '$.video.title',
+    '$.video.authorName',
+    '$.video.durationSeconds',
+    '$.video.currentPart',
+    '$.video.currentPart.page',
+    '$.video.currentPart.title',
+    '$.video.currentPart.total',
+    '$.video.parts',
+    '$.video.parts[]',
+    '$.video.parts[].page',
+    '$.video.parts[].cid',
+    '$.video.parts[].title',
+    '$.video.parts[].durationSeconds',
+    '$.video.chapters',
+    '$.video.chapters[]',
+    '$.video.chapters[].title',
+    '$.video.chapters[].startSeconds',
+    '$.video.description',
+    '$.video.description.availability',
+    '$.video.description.text',
+    '$.video.description.length',
+    '$.availableSources',
+    '$.availableSources.metadata',
+    '$.availableSources.description',
+    '$.availableSources.pages',
+    '$.availableSources.chapters',
+    '$.availableSources.transcript',
+    '$.availableSources.contentText',
+    '$.sourceTier',
+    '$.warnings',
+    '$.warnings[]',
+    '$.safetyRules',
+    '$.safetyRules[]',
+  ],
+};
+
+export function auditAssistantPayload(
+  payload: unknown,
+  contract: AssistantPayloadAuditContract,
+): AssistantPayloadAuditResult {
+  const allowed = new Set(contract.allowedPaths);
+  const violations: AssistantPayloadAuditViolation[] = [];
+  visitPayload(payload, {
+    path: '$',
+    normalizedPath: '$',
+    allowed,
+    violations,
+  });
+  return {
+    passed: violations.length === 0,
+    violations,
+  };
+}
+
+export function assertAssistantPayloadAudit(
+  payload: unknown,
+  contract: AssistantPayloadAuditContract,
+): void {
+  const result = auditAssistantPayload(payload, contract);
+  if (result.passed) return;
+
+  throw new Error([
+    `Assistant payload privacy audit failed for ${contract.name}:`,
+    ...result.violations.map(violation => {
+      const token = violation.token ? ` token=${violation.token}` : '';
+      return `- ${violation.path}: ${violation.reason}${token}`;
+    }),
+  ].join('\n'));
+}
+
+interface VisitState {
+  path: string;
+  normalizedPath: string;
+  allowed: Set<string>;
+  violations: AssistantPayloadAuditViolation[];
+}
+
+function visitPayload(value: unknown, state: VisitState): void {
+  if (!state.allowed.has(state.normalizedPath)) {
+    state.violations.push({
+      path: state.path,
+      reason: 'Field path is not approved for this assistant AI payload contract.',
+    });
+  }
+
+  if (typeof value === 'string') {
+    checkSensitiveString(value, state.path, state.violations);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      visitPayload(item, {
+        ...state,
+        path: `${state.path}[${index}]`,
+        normalizedPath: `${state.normalizedPath}[]`,
+      });
+    });
+    return;
+  }
+
+  if (!value || typeof value !== 'object') return;
+
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = `${state.path}.${key}`;
+    checkSensitiveKey(key, childPath, state.violations);
+    visitPayload(child, {
+      ...state,
+      path: childPath,
+      normalizedPath: `${state.normalizedPath}.${key}`,
+    });
+  }
+}
+
+function checkSensitiveKey(
+  key: string,
+  path: string,
+  violations: AssistantPayloadAuditViolation[],
+): void {
+  for (const { pattern, reason } of SENSITIVE_KEY_PATTERNS) {
+    if (pattern.test(key)) {
+      violations.push({ path, reason, token: key });
+    }
+  }
+}
+
+function checkSensitiveString(
+  value: string,
+  path: string,
+  violations: AssistantPayloadAuditViolation[],
+): void {
+  for (const { pattern, token, reason } of SENSITIVE_STRING_PATTERNS) {
+    if (pattern.test(value)) {
+      violations.push({ path, reason, token });
+    }
+  }
+}

--- a/tests/current-video-summary.test.ts
+++ b/tests/current-video-summary.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  assertAssistantPayloadAudit,
+  auditAssistantPayload,
+  currentVideoSummaryPayloadContract,
+} from '../src/shared/assistant-payload-audit.ts';
+import {
   buildCurrentVideoSummaryAiPayload,
   buildLocalCurrentVideoSummary,
   cancelledCurrentVideoSummary,
@@ -87,12 +92,47 @@ test('builds bounded AI payload without authorMid or local ledgers', () => {
     descriptionAvailable: true,
   });
   const payload = buildCurrentVideoSummaryAiPayload(context);
+  const audit = auditAssistantPayload(payload, currentVideoSummaryPayloadContract);
   const rawPayload = JSON.stringify(payload);
 
   assert.equal(payload.video.description.text?.length, 1200);
   assert.equal('authorMid' in payload.video, false);
   assert.equal(payload.availableSources.contentText, 'unavailable');
   assert.doesNotMatch(rawPayload, /authorMid|watchHistory|favorites|following|Cookie|Key\.txt|user profile/i);
+  assert.equal(audit.passed, true, JSON.stringify(audit.violations));
+  assertAssistantPayloadAudit(payload, currentVideoSummaryPayloadContract);
+});
+
+test('current video AI payload audit reports sensitive fields and tokens', () => {
+  const payload = buildCurrentVideoSummaryAiPayload(videoContext({}));
+  const badPayload = {
+    ...payload,
+    watchHistory: [{ bvid: 'BVHistoryLeak', watchedAt: 1000 }],
+    localContext: {
+      userMid: 42,
+    },
+    video: {
+      ...payload.video,
+      authorMid: 12345,
+    },
+    safetyRules: [
+      ...payload.safetyRules,
+      'Never send Cookie: SESSDATA=abc or C:\\Users\\LittleNub\\Desktop\\Key.txt.',
+    ],
+  };
+  const audit = auditAssistantPayload(badPayload, currentVideoSummaryPayloadContract);
+  const report = audit.violations.map(violation => `${violation.path} ${violation.token ?? ''}`).join('\n');
+
+  assert.equal(audit.passed, false);
+  assert.match(report, /\$\.watchHistory/);
+  assert.match(report, /\$\.localContext\.userMid/);
+  assert.match(report, /\$\.video\.authorMid/);
+  assert.match(report, /Cookie\/login token/);
+  assert.match(report, /C:\\Users\\LittleNub\\Desktop\\Key\.txt/);
+  assert.throws(
+    () => assertAssistantPayloadAudit(badPayload, currentVideoSummaryPayloadContract),
+    /\$\.video\.authorMid/,
+  );
 });
 
 test('exposes loading and cancelled states without accepting an AI result', () => {


### PR DESCRIPTION
Closes #49

## Scope
- Added a reusable assistant payload privacy audit helper in `src/shared/assistant-payload-audit.ts`.
- Added the current-video summary v0 payload allowlist contract.
- Updated current-video summary focused tests to audit the valid #48 payload and a mock payload containing sensitive fields/tokens.

## Audit contract
- Current-video summary payload allows only the approved minimal fields: intent, bvid/cid/title/authorName/duration, currentPart, parts, chapters, description availability/text/length, source availability, source tier, warnings, and safety rules.
- The shared scanner rejects unapproved paths and reports the concrete payload path.
- The shared scanner also flags full ledger/relationship fields and sensitive keys/tokens including watch history, favorites, following, feedback, Cookie/login state, browser profile, local key paths, user profile identifiers, user mid, and authorMid.

## Validation
- `npm run test:current-video-summary` passed.
- `npm run typecheck` passed.
- `npm run build` passed; existing Vite large chunk warning for `chunks/theme-*.js` remains non-blocking.
- `git diff --check` passed; PowerShell reported LF/CRLF working-copy conversion warnings only.
- Scanned `dashboard`, `popup`, `public`, `src`, `README.md`, and `tests` for `未消费` / `猜你喜欢`; no matches.

## Privacy boundary
- Did not read local key files, Cookie files, browser profiles, Bilibili login-state files, or personal profile files.
- Did not add product features, new AI requests, transcript extraction, video key nodes, or Bilibili write-back behavior.
- Tests use mock payload data only.

## Blocker / must-fix / follow-up
- Blocker: none.
- Must-fix: none known.
- Follow-up: add dedicated contracts for future Smart Favorites Q&A and Video Knowledge Base AI payloads when those payload builders land.