### PR TITLE
[codex] Implement video knowledge v0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
     "test:favorites": "node --test tests/favorite-sync-audit.test.ts",
-    "test:current-video-summary": "node --test tests/current-video-summary.test.ts"
+    "test:current-video-summary": "node --test tests/current-video-summary.test.ts",
+    "test:video-knowledge": "node --test tests/video-knowledge.test.ts"
   },
   "dependencies": {
     "preact": "^10.24.0",

--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -5,6 +5,7 @@ import type { QuickStats } from '../src/shared/types/analytics';
 import type { SyncNowResult, SyncProgress } from '../src/shared/types/messages';
 import type { CurrentVideoContextResult } from '../src/shared/types/current-video-context';
 import type { CurrentVideoSummaryResult } from '../src/shared/types/current-video-summary';
+import type { VideoKnowledgeJumpResponse, VideoKnowledgeNode, VideoKnowledgeResult } from '../src/shared/types/video-knowledge';
 import { cancelledCurrentVideoSummary, loadingCurrentVideoSummary } from '../src/shared/current-video-summary';
 import { ProgressRing } from './components/ProgressRing';
 import { QuickStats as QuickStatsPanel } from './components/QuickStats';
@@ -19,6 +20,9 @@ interface SyncStatus {
 export function App() {
   const [currentVideoContext, setCurrentVideoContext] = useState<CurrentVideoContextResult | null>(null);
   const [currentVideoSummary, setCurrentVideoSummary] = useState<CurrentVideoSummaryResult | null>(null);
+  const [videoKnowledge, setVideoKnowledge] = useState<VideoKnowledgeResult | null>(null);
+  const [jumpPreviewNodeId, setJumpPreviewNodeId] = useState<string | null>(null);
+  const [jumpStatus, setJumpStatus] = useState<string | null>(null);
   const [summaryLoading, setSummaryLoading] = useState(false);
   const summaryRequestRef = useRef(0);
 
@@ -26,6 +30,7 @@ export function App() {
     fetchStats(false);
     fetchCurrentVideoContext();
     fetchCurrentVideoSummary();
+    fetchVideoKnowledge();
     const timer = window.setInterval(refreshSyncStatus, 1500);
     return () => window.clearInterval(timer);
   }, []);
@@ -74,6 +79,46 @@ export function App() {
       });
     } finally {
       if (summaryRequestRef.current === requestId) setSummaryLoading(false);
+    }
+  }
+
+  async function fetchVideoKnowledge() {
+    try {
+      const result = await requestSW<VideoKnowledgeResult>('GET_VIDEO_KNOWLEDGE');
+      setVideoKnowledge(result);
+      setJumpPreviewNodeId(null);
+      setJumpStatus(null);
+    } catch (e) {
+      setVideoKnowledge({
+        status: 'no_context',
+        title: 'Video knowledge unavailable',
+        generatedAt: Date.now(),
+        sourceState: {
+          metadata: false,
+          description: false,
+          pages: false,
+          chapters: false,
+          transcript: false,
+          contentText: false,
+        },
+        nodes: [],
+        warnings: ['video_knowledge_request_failed'],
+        limitations: [(e as Error).message],
+      });
+    }
+  }
+
+  async function confirmVideoKnowledgeJump(node: VideoKnowledgeNode) {
+    if (!node.jumpAction) return;
+    setJumpStatus('Confirming manual jump...');
+    try {
+      const result = await requestSW<VideoKnowledgeJumpResponse>('REQUEST_VIDEO_KNOWLEDGE_JUMP', {
+        nodeId: node.id,
+        confirmed: true,
+      });
+      setJumpStatus(result.message);
+    } catch (e) {
+      setJumpStatus((e as Error).message);
     }
   }
 
@@ -215,9 +260,15 @@ export function App() {
       <CurrentVideoAssistantStatus
         context={currentVideoContext}
         summary={currentVideoSummary}
+        knowledge={videoKnowledge}
+        previewNodeId={jumpPreviewNodeId}
+        jumpStatus={jumpStatus}
         loading={summaryLoading}
         onRefresh={fetchCurrentVideoSummary}
         onCancel={cancelCurrentVideoSummary}
+        onRefreshKnowledge={fetchVideoKnowledge}
+        onPreviewNode={setJumpPreviewNodeId}
+        onConfirmJump={confirmVideoKnowledgeJump}
       />
 
       {loading.value && (
@@ -390,17 +441,30 @@ export function App() {
 function CurrentVideoAssistantStatus({
   context,
   summary,
+  knowledge,
+  previewNodeId,
+  jumpStatus,
   loading,
   onRefresh,
   onCancel,
+  onRefreshKnowledge,
+  onPreviewNode,
+  onConfirmJump,
 }: {
   context: CurrentVideoContextResult | null;
   summary: CurrentVideoSummaryResult | null;
+  knowledge: VideoKnowledgeResult | null;
+  previewNodeId: string | null;
+  jumpStatus: string | null;
   loading: boolean;
   onRefresh: () => void;
   onCancel: () => void;
+  onRefreshKnowledge: () => void;
+  onPreviewNode: (nodeId: string | null) => void;
+  onConfirmJump: (node: VideoKnowledgeNode) => void;
 }) {
   const isVideo = context?.kind === 'video';
+  const previewNode = knowledge?.nodes.find(node => node.id === previewNodeId) ?? null;
 
   return (
     <section style={{
@@ -480,6 +544,14 @@ function CurrentVideoAssistantStatus({
           }}>
             No transcript is available. This assistant does not claim a full-video summary.
           </div>
+          <VideoKnowledgePanel
+            knowledge={knowledge}
+            previewNode={previewNode}
+            jumpStatus={jumpStatus}
+            onRefresh={onRefreshKnowledge}
+            onPreview={onPreviewNode}
+            onConfirm={onConfirmJump}
+          />
           <div style={{ display: 'flex', gap: '6px', marginTop: '8px' }}>
             <button
               onClick={onRefresh}
@@ -519,8 +591,172 @@ function CurrentVideoAssistantStatus({
       ) : (
         <div style={{ color: '#A0A0B0', fontSize: '11px', lineHeight: 1.45 }}>
           No current video context. Open a Bilibili video page to see metadata and source availability.
+          <VideoKnowledgePanel
+            knowledge={knowledge}
+            previewNode={previewNode}
+            jumpStatus={jumpStatus}
+            onRefresh={onRefreshKnowledge}
+            onPreview={onPreviewNode}
+            onConfirm={onConfirmJump}
+          />
         </div>
       )}
     </section>
   );
+}
+
+function VideoKnowledgePanel({
+  knowledge,
+  previewNode,
+  jumpStatus,
+  onRefresh,
+  onPreview,
+  onConfirm,
+}: {
+  knowledge: VideoKnowledgeResult | null;
+  previewNode: VideoKnowledgeNode | null;
+  jumpStatus: string | null;
+  onRefresh: () => void;
+  onPreview: (nodeId: string | null) => void;
+  onConfirm: (node: VideoKnowledgeNode) => void;
+}) {
+  const nodes = knowledge?.nodes ?? [];
+  return (
+    <div style={{
+      marginTop: '8px',
+      padding: '8px',
+      border: '1px solid rgba(255,255,255,0.12)',
+      borderRadius: '6px',
+      background: 'rgba(0,0,0,0.10)',
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '8px', alignItems: 'center' }}>
+        <span style={{ color: '#FFD6E2', fontSize: '10px', fontWeight: 700 }}>
+          Video knowledge v0
+        </span>
+        <button
+          onClick={onRefresh}
+          style={{
+            background: 'transparent',
+            color: '#A0A0B0',
+            border: '1px solid rgba(255,255,255,0.14)',
+            borderRadius: '6px',
+            cursor: 'pointer',
+            fontSize: '10px',
+            padding: '3px 6px',
+          }}
+        >
+          Refresh
+        </button>
+      </div>
+      <div style={{ color: '#FFCF8A', fontSize: '10px', lineHeight: 1.45, marginTop: '6px' }}>
+        No transcript. Nodes use only metadata, description, pages, or chapters; no inferred timestamps.
+      </div>
+      {nodes.length === 0 ? (
+        <div style={{ color: '#A0A0B0', fontSize: '10px', lineHeight: 1.45, marginTop: '6px' }}>
+          {knowledge?.status === 'no_context'
+            ? 'No current video context is available for knowledge nodes.'
+            : 'No safe key-node candidates are available.'}
+        </div>
+      ) : (
+        nodes.slice(0, 5).map(node => (
+          <div key={node.id} style={{
+            marginTop: '6px',
+            paddingTop: '6px',
+            borderTop: '1px solid rgba(255,255,255,0.08)',
+          }}>
+            <div style={{ color: '#E8E8F2', fontSize: '10px', lineHeight: 1.35, fontWeight: 650 }}>
+              {node.title}
+            </div>
+            <div style={{ color: '#A0A0B0', fontSize: '9px', lineHeight: 1.45, marginTop: '2px' }}>
+              source {node.sourceLabel} / confidence {Math.round(node.confidence * 100)}%
+              {node.timestamp === null ? ' / no timestamp' : ` / ${formatPopupDuration(node.timestamp)}`}
+            </div>
+            <div style={{ color: '#C8C8D8', fontSize: '9px', lineHeight: 1.4, marginTop: '2px' }}>
+              {node.reason}
+            </div>
+            {node.jumpAction && (
+              <button
+                onClick={() => onPreview(node.id)}
+                style={{
+                  marginTop: '5px',
+                  background: 'rgba(251, 114, 153, 0.18)',
+                  color: '#FFD6E2',
+                  border: '1px solid rgba(251, 114, 153, 0.32)',
+                  borderRadius: '6px',
+                  cursor: 'pointer',
+                  fontSize: '10px',
+                  padding: '4px 7px',
+                }}
+              >
+                Preview jump
+              </button>
+            )}
+          </div>
+        ))
+      )}
+      {previewNode?.jumpAction && (
+        <div style={{
+          marginTop: '8px',
+          padding: '8px',
+          border: '1px solid rgba(255,179,71,0.28)',
+          borderRadius: '6px',
+          background: 'rgba(255,179,71,0.08)',
+        }}>
+          <div style={{ color: '#FFCF8A', fontSize: '10px', lineHeight: 1.45, fontWeight: 700 }}>
+            Manual jump preview
+          </div>
+          <div style={{ color: '#E8E8F2', fontSize: '10px', lineHeight: 1.45, marginTop: '4px' }}>
+            {previewNode.jumpAction.previewLabel}
+          </div>
+          <div style={{ color: '#A0A0B0', fontSize: '9px', lineHeight: 1.45, marginTop: '2px' }}>
+            Source {previewNode.sourceLabel}. Confirmation is required; auto-jump is disabled.
+          </div>
+          <div style={{ display: 'flex', gap: '6px', marginTop: '6px' }}>
+            <button
+              onClick={() => onConfirm(previewNode)}
+              style={{
+                flex: 1,
+                background: '#FFB347',
+                color: '#1A1A2E',
+                border: 'none',
+                borderRadius: '6px',
+                cursor: 'pointer',
+                fontSize: '10px',
+                fontWeight: 700,
+                padding: '5px 7px',
+              }}
+            >
+              Confirm jump
+            </button>
+            <button
+              onClick={() => onPreview(null)}
+              style={{
+                background: 'transparent',
+                color: '#C8C8D8',
+                border: '1px solid rgba(255,255,255,0.14)',
+                borderRadius: '6px',
+                cursor: 'pointer',
+                fontSize: '10px',
+                padding: '5px 7px',
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+      {jumpStatus && (
+        <div style={{ color: '#A0E7A0', fontSize: '10px', lineHeight: 1.45, marginTop: '6px' }}>
+          {jumpStatus}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatPopupDuration(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(safe / 60);
+  const rest = safe % 60;
+  return `${minutes}:${String(rest).padStart(2, '0')}`;
 }

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -1,5 +1,6 @@
 import type { BiliVizRequest, BiliVizContentMessage, BiliVizResponse, PlayerActionPayload, PlayerHeartbeatPayload, SyncNowResult } from '../../shared/types/messages';
 import type { CurrentVideoContextResult, CurrentVideoNoContext } from '../../shared/types/current-video-context';
+import type { VideoKnowledgeJumpResponse } from '../../shared/types/video-knowledge';
 import type { DynamicBillFeedbackScope, DynamicBillStatusFilter } from '../../shared/types/dynamic-bill';
 import { runInitialBackfill } from '../sync/initial-backfill';
 import {
@@ -15,6 +16,7 @@ import {
 import { db } from '../storage/db';
 import type { UserConfig } from '../../shared/types/config';
 import { generateCurrentVideoSummary } from '../current-video-summary';
+import { buildVideoKnowledgeResult, findVideoKnowledgeNode } from '../../shared/video-knowledge';
 import {
   getQuickStats,
   getDashboardOverview,
@@ -221,6 +223,10 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
       return { success: true, data: await getCurrentVideoContextForActiveTab() as T };
     case 'GET_CURRENT_VIDEO_SUMMARY':
       return { success: true, data: await generateCurrentVideoSummary(await getCurrentVideoContextForActiveTab()) as T };
+    case 'GET_VIDEO_KNOWLEDGE':
+      return { success: true, data: buildVideoKnowledgeResult(await getCurrentVideoContextForActiveTab()) as T };
+    case 'REQUEST_VIDEO_KNOWLEDGE_JUMP':
+      return { success: true, data: await requestVideoKnowledgeJump(request.params) as T };
     case 'GET_SMART_FAVORITES':
       return { success: true, data: await getSmartFavoriteOverview() as T };
     case 'GET_SMART_FAVORITES_BY_PATH': {
@@ -307,6 +313,43 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
     default:
       return { success: false, error: `Unknown action: ${request.action}` };
   }
+}
+
+async function requestVideoKnowledgeJump(params: Record<string, unknown> | undefined): Promise<VideoKnowledgeJumpResponse> {
+  const nodeId = requireStringParam(params?.nodeId, 'nodeId');
+  const confirmed = params?.confirmed === true;
+  if (!confirmed) {
+    return {
+      ok: false,
+      message: 'CONFIRMATION_REQUIRED',
+      nodeId,
+      previousPositionSeconds: null,
+      targetSeconds: null,
+      targetPage: null,
+    };
+  }
+
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const tabId = tab?.id ?? 0;
+  if (!tab?.url || tabId <= 0 || !isBilibiliVideoUrl(tab.url)) {
+    throw new Error('NO_ACTIVE_BILIBILI_VIDEO_TAB');
+  }
+
+  const context = await getCurrentVideoContextForActiveTab();
+  const knowledge = buildVideoKnowledgeResult(context);
+  const node = findVideoKnowledgeNode(knowledge, nodeId);
+  if (!node || !node.jumpAction) {
+    throw new Error('VIDEO_KNOWLEDGE_JUMP_TARGET_UNAVAILABLE');
+  }
+
+  return await chrome.tabs.sendMessage(tabId, {
+    action: 'VIDEO_KNOWLEDGE_MANUAL_JUMP',
+    payload: {
+      node,
+      contextBvid: context.kind === 'video' ? context.bvid : null,
+      confirmed: true,
+    },
+  });
 }
 
 async function markConsumedFromPlayerEvent(

--- a/src/content/player-monitor/index.ts
+++ b/src/content/player-monitor/index.ts
@@ -5,10 +5,15 @@ import { startHeartbeat } from './heartbeat';
 import { detectVideo } from './video-detector';
 import type { BiliVizContentMessage } from '../../shared/types/messages';
 import type { CurrentVideoContextResult } from '../../shared/types/current-video-context';
+import type { VideoKnowledgeJumpResponse, VideoKnowledgeNode } from '../../shared/types/video-knowledge';
 
 let cleanup: (() => void) | null = null;
 let lastContextKey = '';
 let retryTimer: number | null = null;
+let latestContext: CurrentVideoContextResult | null = null;
+
+const RETURN_TOAST_ID = 'bdc-video-knowledge-return';
+const PAGE_RETURN_KEY = 'bdc-video-knowledge-return-point';
 
 function scheduleInitialize(delay = 0): void {
   if (retryTimer !== null) {
@@ -24,6 +29,7 @@ function scheduleInitialize(delay = 0): void {
 
 async function initializeMonitor(): Promise<void> {
   const context = collectCurrentVideoContext();
+  latestContext = context;
   renderCurrentVideoAssistant(context);
   sendCurrentVideoContext(context);
 
@@ -46,8 +52,10 @@ async function initializeMonitor(): Promise<void> {
   try {
     const video = await detectVideo();
     const contextWithDuration = withVideoElementDuration(context, video);
+    latestContext = contextWithDuration;
     renderCurrentVideoAssistant(contextWithDuration);
     sendCurrentVideoContext(contextWithDuration);
+    showStoredPageReturnIfAvailable(contextWithDuration);
     lastContextKey = contextKey;
     console.log(
       `[BiliViz] Monitoring: ${contextWithDuration.title} (${contextWithDuration.bvid}, cid=${contextWithDuration.cid || 'unknown'}, p=${contextWithDuration.currentPart.page})`,
@@ -79,6 +87,179 @@ async function initializeMonitor(): Promise<void> {
   } catch (e) {
     console.error('[BiliViz] Failed to initialize player monitor:', e);
   }
+}
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message?.action !== 'VIDEO_KNOWLEDGE_MANUAL_JUMP') return false;
+
+  handleVideoKnowledgeManualJump(message.payload).then(sendResponse).catch((error) => {
+    sendResponse({
+      ok: false,
+      message: error instanceof Error ? error.message : String(error),
+      nodeId: String(message.payload?.node?.id ?? ''),
+      previousPositionSeconds: null,
+      targetSeconds: null,
+      targetPage: null,
+    } satisfies VideoKnowledgeJumpResponse);
+  });
+  return true;
+});
+
+async function handleVideoKnowledgeManualJump(payload: {
+  node?: VideoKnowledgeNode;
+  contextBvid?: string | null;
+  confirmed?: boolean;
+}): Promise<VideoKnowledgeJumpResponse> {
+  const node = payload.node;
+  if (!payload.confirmed || !node?.jumpAction?.requiresConfirmation) {
+    throw new Error('CONFIRMATION_REQUIRED');
+  }
+  if (!node.jumpAction) {
+    throw new Error('JUMP_TARGET_UNAVAILABLE');
+  }
+  if (latestContext?.kind !== 'video' || latestContext.bvid !== payload.contextBvid || node.bvid !== latestContext.bvid) {
+    throw new Error('VIDEO_CONTEXT_CHANGED');
+  }
+
+  const targetPage = node.jumpAction.targetPage;
+  const targetSeconds = node.jumpAction.targetSeconds;
+  if (node.jumpAction.type === 'page' && targetPage && targetPage !== latestContext.currentPart.page) {
+    const previousPositionSeconds = currentVideoElement()?.currentTime ?? null;
+    storePageReturn(latestContext.url, previousPositionSeconds);
+    window.setTimeout(() => {
+      location.assign(urlForPage(targetPage));
+    }, 0);
+    return {
+      ok: true,
+      message: `Opening ${node.jumpAction.previewLabel}`,
+      nodeId: node.id,
+      previousPositionSeconds,
+      targetSeconds,
+      targetPage,
+    };
+  }
+
+  if (typeof targetSeconds !== 'number' || !Number.isFinite(targetSeconds) || targetSeconds < 0) {
+    throw new Error('INVALID_SEEK_TARGET');
+  }
+
+  const video = await detectVideo();
+  const previousPositionSeconds = video.currentTime;
+  video.currentTime = Math.min(targetSeconds, Number.isFinite(video.duration) ? video.duration : targetSeconds);
+  showReturnToast(previousPositionSeconds);
+  return {
+    ok: true,
+    message: `Jumped to ${node.jumpAction.previewLabel}`,
+    nodeId: node.id,
+    previousPositionSeconds,
+    targetSeconds,
+    targetPage,
+  };
+}
+
+function currentVideoElement(): HTMLVideoElement | null {
+  return document.querySelector('video');
+}
+
+function urlForPage(page: number): string {
+  const url = new URL(location.href);
+  url.searchParams.set('p', String(page));
+  return url.toString();
+}
+
+function storePageReturn(url: string, seconds: number | null): void {
+  try {
+    sessionStorage.setItem(PAGE_RETURN_KEY, JSON.stringify({ url, seconds, savedAt: Date.now() }));
+  } catch {
+    // Session storage can be unavailable in some embedded player contexts.
+  }
+}
+
+function showStoredPageReturnIfAvailable(context: CurrentVideoContextResult): void {
+  if (context.kind !== 'video') return;
+  try {
+    const raw = sessionStorage.getItem(PAGE_RETURN_KEY);
+    if (!raw) return;
+    const parsed = JSON.parse(raw) as { url?: unknown; seconds?: unknown; savedAt?: unknown };
+    if (typeof parsed.url !== 'string' || Date.now() - Number(parsed.savedAt ?? 0) > 10 * 60 * 1000) {
+      sessionStorage.removeItem(PAGE_RETURN_KEY);
+      return;
+    }
+    showReturnToast(
+      typeof parsed.seconds === 'number' && Number.isFinite(parsed.seconds) ? parsed.seconds : null,
+      parsed.url,
+    );
+    sessionStorage.removeItem(PAGE_RETURN_KEY);
+  } catch {
+    sessionStorage.removeItem(PAGE_RETURN_KEY);
+  }
+}
+
+function showReturnToast(seconds: number | null, url?: string): void {
+  const existing = document.getElementById(RETURN_TOAST_ID);
+  existing?.remove();
+
+  const toast = document.createElement('div');
+  toast.id = RETURN_TOAST_ID;
+  toast.style.cssText = [
+    'position:fixed',
+    'right:18px',
+    'bottom:150px',
+    'z-index:2147483647',
+    'box-sizing:border-box',
+    'max-width:min(300px,calc(100vw - 36px))',
+    'padding:10px',
+    'border:1px solid rgba(255,179,71,0.36)',
+    'border-radius:8px',
+    'background:rgba(26,26,46,0.97)',
+    'color:#f2f2f6',
+    'box-shadow:0 8px 28px rgba(0,0,0,0.28)',
+    'font:12px/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif',
+  ].join(';');
+
+  const label = document.createElement('div');
+  label.textContent = seconds === null
+    ? 'Manual jump complete. You can return to the previous page.'
+    : `Manual jump complete. Previous position: ${formatDuration(seconds)}.`;
+  toast.appendChild(label);
+
+  const actions = document.createElement('div');
+  actions.style.cssText = 'display:flex;gap:6px;margin-top:8px';
+  const back = document.createElement('button');
+  back.type = 'button';
+  back.textContent = 'Return';
+  back.style.cssText = 'flex:1;border:0;border-radius:6px;background:#ffb347;color:#1a1a2e;font-weight:700;font-size:12px;padding:6px 8px;cursor:pointer';
+  back.addEventListener('click', async () => {
+    if (url) {
+      location.assign(url);
+      return;
+    }
+    if (seconds !== null) {
+      const video = await detectVideo();
+      video.currentTime = Math.max(0, seconds);
+    }
+    toast.remove();
+  });
+
+  const dismiss = document.createElement('button');
+  dismiss.type = 'button';
+  dismiss.textContent = 'Dismiss';
+  dismiss.style.cssText = 'border:1px solid rgba(255,255,255,0.16);border-radius:6px;background:transparent;color:#c8c8d8;font-size:12px;padding:6px 8px;cursor:pointer';
+  dismiss.addEventListener('click', () => toast.remove());
+  actions.append(back, dismiss);
+  toast.appendChild(actions);
+  document.body.appendChild(toast);
+}
+
+function formatDuration(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+  const rest = safe % 60;
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(rest).padStart(2, '0')}`;
+  }
+  return `${minutes}:${String(rest).padStart(2, '0')}`;
 }
 
 function cleanupMonitor(): void {

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -29,6 +29,7 @@ import type {
 } from './favorite';
 import type { CurrentVideoContextResult } from './current-video-context';
 import type { CurrentVideoSummaryResult } from './current-video-summary';
+import type { VideoKnowledgeJumpResponse, VideoKnowledgeResult } from './video-knowledge';
 
 // Popup / Dashboard → Service Worker
 export type RequestAction =
@@ -48,6 +49,8 @@ export type RequestAction =
   | 'GET_SYNC_STATUS'
   | 'GET_CURRENT_VIDEO_CONTEXT'
   | 'GET_CURRENT_VIDEO_SUMMARY'
+  | 'GET_VIDEO_KNOWLEDGE'
+  | 'REQUEST_VIDEO_KNOWLEDGE_JUMP'
   | 'GET_SMART_FAVORITES'
   | 'GET_SMART_FAVORITES_BY_PATH'
   | 'SYNC_FAVORITES'
@@ -178,6 +181,8 @@ export type SmartFavoriteQaMessageResponse = BiliVizResponse<SmartFavoriteQaResp
 export type SmartFavoritePathResponse = BiliVizResponse<SmartFavoriteResult[]>;
 export type CurrentVideoContextResponse = BiliVizResponse<CurrentVideoContextResult>;
 export type CurrentVideoSummaryResponse = BiliVizResponse<CurrentVideoSummaryResult>;
+export type VideoKnowledgeResponse = BiliVizResponse<VideoKnowledgeResult>;
+export type VideoKnowledgeJumpMessageResponse = BiliVizResponse<VideoKnowledgeJumpResponse>;
 export type DynamicBillOverviewResponse = BiliVizResponse<DynamicBillOverview>;
 export type DynamicSyncResponse = BiliVizResponse<DynamicSyncResult>;
 export type DynamicBillGenerateResponse = BiliVizResponse<DynamicBillGenerateResult>;

--- a/src/shared/types/video-knowledge.ts
+++ b/src/shared/types/video-knowledge.ts
@@ -1,0 +1,92 @@
+export type VideoKnowledgeSource =
+  | 'metadata'
+  | 'description'
+  | 'page'
+  | 'chapter'
+  | 'transcript'
+  | 'user_bookmark'
+  | 'user_note'
+  | 'local_watch_event'
+  | 'local_fallback';
+
+export type VideoKnowledgeStatus = 'ready' | 'no_context';
+
+export type VideoKnowledgeSafetyFlag =
+  | 'metadata_only'
+  | 'description_only'
+  | 'page_bound'
+  | 'chapter_bound'
+  | 'manual_confirm_required'
+  | 'auto_jump_disabled'
+  | 'no_transcript'
+  | 'low_confidence';
+
+export interface VideoKnowledgeEvidence {
+  textSpan: string | null;
+  startChar: number | null;
+  endChar: number | null;
+  language: string | null;
+  sourceId: string;
+}
+
+export interface VideoKnowledgeJumpAction {
+  type: 'seek' | 'page';
+  targetSeconds: number | null;
+  targetPage: number | null;
+  targetCid: number | null;
+  previewLabel: string;
+  requiresConfirmation: true;
+  returnPointSeconds: number | null;
+}
+
+export interface VideoKnowledgeNode {
+  id: string;
+  bvid: string;
+  cid: number | null;
+  page: number;
+  timestamp: number | null;
+  endTimestamp: number | null;
+  title: string;
+  reason: string;
+  source: VideoKnowledgeSource;
+  sourceLabel: string;
+  confidence: number;
+  evidence: VideoKnowledgeEvidence | null;
+  jumpAction: VideoKnowledgeJumpAction | null;
+  safetyFlags: VideoKnowledgeSafetyFlag[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface VideoKnowledgeSourceState {
+  metadata: boolean;
+  description: boolean;
+  pages: boolean;
+  chapters: boolean;
+  transcript: boolean;
+  contentText: boolean;
+}
+
+export interface VideoKnowledgeResult {
+  status: VideoKnowledgeStatus;
+  title: string;
+  generatedAt: number;
+  sourceState: VideoKnowledgeSourceState;
+  nodes: VideoKnowledgeNode[];
+  warnings: string[];
+  limitations: string[];
+}
+
+export interface VideoKnowledgeJumpRequest {
+  nodeId: string;
+  confirmed: boolean;
+}
+
+export interface VideoKnowledgeJumpResponse {
+  ok: boolean;
+  message: string;
+  nodeId: string;
+  previousPositionSeconds: number | null;
+  targetSeconds: number | null;
+  targetPage: number | null;
+}

--- a/src/shared/video-knowledge.ts
+++ b/src/shared/video-knowledge.ts
@@ -1,0 +1,257 @@
+import type { CurrentVideoContext, CurrentVideoContextResult, CurrentVideoPart } from './types/current-video-context';
+import type {
+  VideoKnowledgeEvidence,
+  VideoKnowledgeJumpAction,
+  VideoKnowledgeNode,
+  VideoKnowledgeResult,
+  VideoKnowledgeSafetyFlag,
+  VideoKnowledgeSource,
+} from './types/video-knowledge';
+
+const DESCRIPTION_EVIDENCE_LIMIT = 280;
+const NODE_LIMIT = 16;
+
+export function buildVideoKnowledgeResult(
+  context: CurrentVideoContextResult,
+  now = Date.now(),
+): VideoKnowledgeResult {
+  if (context.kind !== 'video') {
+    return {
+      status: 'no_context',
+      title: 'No current video context',
+      generatedAt: now,
+      sourceState: {
+        metadata: false,
+        description: false,
+        pages: false,
+        chapters: false,
+        transcript: false,
+        contentText: false,
+      },
+      nodes: [],
+      warnings: ['no_current_video_context'],
+      limitations: ['Open a Bilibili video page before generating video knowledge nodes.'],
+    };
+  }
+
+  const nodes: VideoKnowledgeNode[] = [
+    buildMetadataNode(context, now),
+    ...buildDescriptionNodes(context, now),
+    ...buildPageNodes(context, now),
+    ...buildChapterNodes(context, now),
+  ].slice(0, NODE_LIMIT);
+
+  return {
+    status: 'ready',
+    title: context.title ?? context.bvid,
+    generatedAt: now,
+    sourceState: {
+      metadata: context.sources.metadata === 'available',
+      description: context.sources.description === 'available',
+      pages: context.sources.pages === 'available',
+      chapters: context.sources.chapters === 'available',
+      transcript: false,
+      contentText: false,
+    },
+    nodes,
+    warnings: Array.from(new Set([...context.warnings, 'transcript_unavailable'])),
+    limitations: [
+      'No transcript is available, so metadata and description nodes do not represent full-video understanding.',
+      'Metadata and description nodes never include generated timestamps.',
+      'Jump actions are manual preview actions and require explicit confirmation before changing playback.',
+    ],
+  };
+}
+
+export function findVideoKnowledgeNode(
+  result: VideoKnowledgeResult,
+  nodeId: string,
+): VideoKnowledgeNode | null {
+  return result.nodes.find(node => node.id === nodeId) ?? null;
+}
+
+function buildMetadataNode(context: CurrentVideoContext, now: number): VideoKnowledgeNode {
+  const partsLabel = context.currentPart.total && context.currentPart.total > 1
+    ? `Part ${context.currentPart.page} of ${context.currentPart.total}`
+    : 'Single visible video page';
+  const duration = context.durationSeconds ? `, duration ${formatDuration(context.durationSeconds)}` : '';
+  const creator = context.authorName ? `, creator ${context.authorName}` : '';
+  return node({
+    id: `node:${context.bvid}:metadata`,
+    context,
+    page: context.currentPart.page,
+    title: context.title ? `Metadata: ${context.title}` : 'Metadata helper',
+    reason: `Built only from visible metadata (${partsLabel}${creator}${duration}).`,
+    source: 'metadata',
+    confidence: 0.34,
+    evidence: evidence('metadata:visible', context.title ?? context.bvid),
+    jumpAction: null,
+    safetyFlags: ['metadata_only', 'no_transcript', 'low_confidence', 'auto_jump_disabled'],
+    now,
+  });
+}
+
+function buildDescriptionNodes(context: CurrentVideoContext, now: number): VideoKnowledgeNode[] {
+  const text = normalizeText(context.description.text);
+  if (context.sources.description !== 'available' || !text) return [];
+
+  const excerpt = limitText(text, DESCRIPTION_EVIDENCE_LIMIT);
+  return [
+    node({
+      id: `node:${context.bvid}:description`,
+      context,
+      page: context.currentPart.page,
+      title: 'Description helper',
+      reason: 'Built from the visible video description only; it is not transcript or body-content evidence.',
+      source: 'description',
+      confidence: text.length >= 80 ? 0.54 : 0.46,
+      evidence: {
+        textSpan: excerpt,
+        startChar: 0,
+        endChar: excerpt.length,
+        language: null,
+        sourceId: 'description:visible',
+      },
+      jumpAction: null,
+      safetyFlags: ['description_only', 'no_transcript', 'auto_jump_disabled'],
+      now,
+    }),
+  ];
+}
+
+function buildPageNodes(context: CurrentVideoContext, now: number): VideoKnowledgeNode[] {
+  if (context.parts.length === 0) return [];
+
+  return context.parts.map((part, index) => {
+    const page = normalizePage(part, index);
+    return node({
+      id: `node:${context.bvid}:page:${page}`,
+      context,
+      page,
+      cid: part.cid,
+      timestamp: 0,
+      title: part.title ? `P${page}: ${part.title}` : `P${page}`,
+      reason: 'Built from the Bilibili page/part list. The timestamp is only the start of that part.',
+      source: 'page',
+      confidence: 0.74,
+      evidence: evidence(`page:${page}`, part.title ?? `P${page}`),
+      jumpAction: {
+        type: 'page',
+        targetSeconds: 0,
+        targetPage: page,
+        targetCid: part.cid,
+        previewLabel: `Jump to P${page}${part.title ? `: ${part.title}` : ''}`,
+        requiresConfirmation: true,
+        returnPointSeconds: null,
+      },
+      safetyFlags: ['page_bound', 'manual_confirm_required', 'auto_jump_disabled', 'no_transcript'],
+      now,
+    });
+  });
+}
+
+function buildChapterNodes(context: CurrentVideoContext, now: number): VideoKnowledgeNode[] {
+  return context.chapters
+    .filter(chapter => Number.isFinite(chapter.startSeconds) && (chapter.startSeconds ?? -1) >= 0)
+    .map((chapter, index) => {
+      const startSeconds = Math.max(0, Math.floor(chapter.startSeconds ?? 0));
+      return node({
+        id: `node:${context.bvid}:chapter:${index}:${startSeconds}`,
+        context,
+        page: context.currentPart.page,
+        timestamp: startSeconds,
+        title: `Chapter: ${chapter.title}`,
+        reason: 'Built from a visible chapter start time. It does not infer content beyond the chapter label.',
+        source: 'chapter',
+        confidence: 0.82,
+        evidence: evidence(`chapter:${index}:${startSeconds}`, chapter.title),
+        jumpAction: {
+          type: 'seek',
+          targetSeconds: startSeconds,
+          targetPage: context.currentPart.page,
+          targetCid: context.cid,
+          previewLabel: `Jump to ${formatDuration(startSeconds)}: ${chapter.title}`,
+          requiresConfirmation: true,
+          returnPointSeconds: null,
+        },
+        safetyFlags: ['chapter_bound', 'manual_confirm_required', 'auto_jump_disabled', 'no_transcript'],
+        now,
+      });
+    });
+}
+
+function node(input: {
+  id: string;
+  context: CurrentVideoContext;
+  page: number;
+  cid?: number | null;
+  timestamp?: number | null;
+  title: string;
+  reason: string;
+  source: VideoKnowledgeSource;
+  confidence: number;
+  evidence: VideoKnowledgeEvidence | null;
+  jumpAction: VideoKnowledgeJumpAction | null;
+  safetyFlags: VideoKnowledgeSafetyFlag[];
+  now: number;
+}): VideoKnowledgeNode {
+  return {
+    id: input.id,
+    bvid: input.context.bvid,
+    cid: input.cid ?? input.context.cid,
+    page: input.page,
+    timestamp: input.timestamp ?? null,
+    endTimestamp: null,
+    title: limitText(input.title, 140),
+    reason: limitText(input.reason, 260),
+    source: input.source,
+    sourceLabel: input.source,
+    confidence: Math.round(Math.max(0, Math.min(1, input.confidence)) * 100) / 100,
+    evidence: input.evidence,
+    jumpAction: input.jumpAction,
+    safetyFlags: input.safetyFlags,
+    createdAt: input.now,
+    updatedAt: input.now,
+  };
+}
+
+function evidence(sourceId: string, text: string): VideoKnowledgeEvidence {
+  const value = limitText(text, DESCRIPTION_EVIDENCE_LIMIT);
+  return {
+    textSpan: value,
+    startChar: 0,
+    endChar: value.length,
+    language: null,
+    sourceId,
+  };
+}
+
+function normalizePage(part: CurrentVideoPart, index: number): number {
+  return Number.isFinite(part.page) && part.page > 0 ? Math.floor(part.page) : index + 1;
+}
+
+function normalizeText(value: string | null): string {
+  return (value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function limitText(value: string, maxLength: number): string {
+  const normalized = normalizeText(value);
+  if (normalized.length <= maxLength) return normalized;
+  if (maxLength <= 3) return normalized.slice(0, maxLength);
+  return `${normalized.slice(0, maxLength - 3)}...`;
+}
+
+export function formatVideoKnowledgeTime(seconds: number): string {
+  return formatDuration(seconds);
+}
+
+function formatDuration(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+  const rest = safe % 60;
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(rest).padStart(2, '0')}`;
+  }
+  return `${minutes}:${String(rest).padStart(2, '0')}`;
+}

--- a/tests/video-knowledge.test.ts
+++ b/tests/video-knowledge.test.ts
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildVideoKnowledgeResult } from '../src/shared/video-knowledge.ts';
+import type { CurrentVideoContext, CurrentVideoContextResult } from '../src/shared/types/current-video-context.ts';
+
+test('builds metadata-only node without transcript or fabricated timestamp', () => {
+  const result = buildVideoKnowledgeResult(videoContext({
+    descriptionText: null,
+    parts: [],
+    chapters: [],
+  }), 1000);
+
+  assert.equal(result.status, 'ready');
+  assert.equal(result.sourceState.transcript, false);
+  assert.equal(result.nodes.length, 1);
+  assert.equal(result.nodes[0].source, 'metadata');
+  assert.equal(result.nodes[0].sourceLabel, 'metadata');
+  assert.equal(result.nodes[0].timestamp, null);
+  assert.equal(result.nodes[0].jumpAction, null);
+  assert.ok(result.nodes[0].confidence > 0);
+  assert.ok(result.limitations.some(item => item.includes('do not represent full-video understanding')));
+});
+
+test('builds description helper without jump target', () => {
+  const result = buildVideoKnowledgeResult(videoContext({
+    descriptionText: 'This visible description lists the topic, scope, and audience without being transcript evidence.',
+    parts: [],
+    chapters: [],
+  }), 1000);
+
+  const description = result.nodes.find(node => node.source === 'description');
+  assert.ok(description);
+  assert.equal(description.timestamp, null);
+  assert.equal(description.jumpAction, null);
+  assert.equal(description.sourceLabel, 'description');
+  assert.ok(description.safetyFlags.includes('description_only'));
+  assert.ok(description.evidence?.textSpan?.includes('visible description'));
+});
+
+test('builds page and chapter nodes with confirmed manual jump previews', () => {
+  const result = buildVideoKnowledgeResult(videoContext({
+    descriptionText: null,
+    parts: [
+      { page: 1, cid: 101, title: 'Intro', durationSeconds: 120 },
+      { page: 2, cid: 102, title: 'Demo', durationSeconds: 300 },
+    ],
+    chapters: [
+      { title: 'Setup', startSeconds: 45 },
+      { title: 'Result', startSeconds: 180 },
+    ],
+  }), 1000);
+
+  const pageNode = result.nodes.find(node => node.id.endsWith(':page:2'));
+  const chapterNode = result.nodes.find(node => node.source === 'chapter' && node.timestamp === 45);
+
+  assert.ok(pageNode);
+  assert.equal(pageNode.sourceLabel, 'page');
+  assert.equal(pageNode.timestamp, 0);
+  assert.equal(pageNode.jumpAction?.type, 'page');
+  assert.equal(pageNode.jumpAction?.requiresConfirmation, true);
+  assert.ok(pageNode.safetyFlags.includes('manual_confirm_required'));
+
+  assert.ok(chapterNode);
+  assert.equal(chapterNode.sourceLabel, 'chapter');
+  assert.equal(chapterNode.jumpAction?.type, 'seek');
+  assert.equal(chapterNode.jumpAction?.targetSeconds, 45);
+  assert.equal(chapterNode.jumpAction?.requiresConfirmation, true);
+  assert.ok(chapterNode.safetyFlags.includes('auto_jump_disabled'));
+});
+
+test('ignores chapters without real start seconds', () => {
+  const result = buildVideoKnowledgeResult(videoContext({
+    descriptionText: null,
+    parts: [],
+    chapters: [
+      { title: 'No time', startSeconds: null },
+    ],
+  }), 1000);
+
+  assert.equal(result.nodes.some(node => node.source === 'chapter'), false);
+});
+
+test('returns no-context fallback with no nodes', () => {
+  const context: CurrentVideoContextResult = {
+    kind: 'no_context',
+    url: 'https://www.bilibili.com/',
+    collectedAt: 1000,
+    reason: 'non_video_page',
+    pageType: 'non_video',
+  };
+  const result = buildVideoKnowledgeResult(context, 1000);
+
+  assert.equal(result.status, 'no_context');
+  assert.equal(result.nodes.length, 0);
+  assert.equal(result.sourceState.metadata, false);
+  assert.ok(result.limitations.some(item => item.includes('Open a Bilibili video page')));
+});
+
+function videoContext(options: {
+  descriptionText: string | null;
+  parts: CurrentVideoContext['parts'];
+  chapters: CurrentVideoContext['chapters'];
+}): CurrentVideoContext {
+  return {
+    kind: 'video',
+    url: 'https://www.bilibili.com/video/BV1Knowledge00',
+    collectedAt: 1000,
+    bvid: 'BV1Knowledge00',
+    cid: 101,
+    title: 'Knowledge source video',
+    authorName: 'Mock UP',
+    authorMid: 42,
+    durationSeconds: 600,
+    currentPart: {
+      page: 1,
+      title: options.parts[0]?.title ?? null,
+      total: options.parts.length || null,
+    },
+    parts: options.parts,
+    chapters: options.chapters,
+    description: {
+      availability: options.descriptionText ? 'available' : 'unavailable',
+      text: options.descriptionText,
+      length: options.descriptionText?.length ?? null,
+    },
+    sources: {
+      metadata: 'available',
+      description: options.descriptionText ? 'available' : 'unavailable',
+      pages: options.parts.length > 0 ? 'available' : 'unavailable',
+      chapters: options.chapters.length > 0 ? 'available' : 'unknown',
+      transcript: 'unavailable',
+      contentText: 'unavailable',
+    },
+    warnings: ['transcript_unavailable'],
+  };
+}


### PR DESCRIPTION
Closes #52

## Scope
- Adds a shared Video Knowledge v0 contract and local builder for metadata, description, page/part, and chapter key-node candidates.
- Surfaces visible helper/key-node candidates in the popup current-video assistant with source labels, confidence, and no-transcript limitations.
- Adds manual jump preview and confirmation flow for real page/chapter targets, routed through the active Bilibili video content script.
- Adds a return path after confirmed seeks/page jumps when the player/page context allows it.

## Node Source Rules
- Metadata and description nodes have no timestamp and no jump action.
- Page nodes use only the real part start (`0`) and page/cid from the current video context.
- Chapter nodes use only visible chapter `startSeconds`.
- v0 always treats transcript/content text as unavailable and does not create transcript-bound nodes.

## Manual Jump Safety
- No auto-jump setting or behavior is introduced.
- Popup first shows a manual preview; background requires `confirmed: true`; content script rechecks confirmation and current BVID before seek/navigation.
- Seek/page jump happens only inside the Bilibili video page content script.
- Content script records the previous playback position where possible and displays a return action.

## Validation
- `npm run test:video-knowledge` passed.
- `npm run test:current-video-summary` passed.
- `npm run typecheck` passed.
- `npm run build` passed; Vite reported the existing large `chunks/theme-*.js` warning as non-blocking.
- `git diff --check` passed.
- Static scan passed for `未消费` and `猜你喜欢` in `dashboard`, `popup`, `public`, `src`, `README.md`, and `tests`.

## Blocker / Must-fix / Follow-up
- Blockers: none.
- Must-fix: none known.
- Follow-up: browser smoke on a real Bilibili page can verify actual player seek/page navigation behavior across Bilibili player variants; this PR validates preview/confirm rules with focused mock tests and type/build checks.

## Privacy Boundary
- Did not read local key files, Cookie files, browser profiles, Bilibili login-state files, or user profile files.
- Does not write back to Bilibili.
- Does not add transcript extraction, AI key-node extraction, Smart Favorites Q&A, transcript summary, or auto-jump.