### PR TITLE
[codex] Add 0.10.0-alpha clean smoke report

### DIFF
--- a/docs/release-smoke-0.10.0-alpha.md
+++ b/docs/release-smoke-0.10.0-alpha.md
@@ -8,26 +8,32 @@ Date: 2026-06-11
 
 - Branch under test: `codex/release-0.10-alpha-smoke`
 - Worktree: `C:\Users\LittleNub\Documents\New project 4\BiliBili-DataViz-Plugin-release-0.10-smoke`
-- Retest baseline includes the #71 blocker fix from PR #72:
-  - merged PR: `https://github.com/LittleNuB/BiliBili-DataViz-Plugin/pull/72`
-  - GitHub merge commit: `ee643bcbc9f2eaabdabf9c16f5c6c7f9d6c821e0`
-  - local rebase base used for this retest: `c285cd92651b7fd8322ae6507625e2defa68e755` (`codex/fix-player-monitor-content-script`)
-- Previous smoke report blocker: `player-monitor` classic content script was emitted with a top-level ESM import and failed on public Bilibili video pages.
+- Final retest baseline includes both blocker fixes now merged to `main`:
+  - PR #72 / Issue #71 merge commit: `ee643bcbc9f2eaabdabf9c16f5c6c7f9d6c821e0`
+  - PR #74 / Issue #73 merge commit: `2df9665f5fa19eab28752b7edd592dc4aed69360`
+- Local rebase base used for this final smoke rerun: `7b6c09b87270f4989815b26d97e0e7ebe44fffa6` (`codex/fix-popup-current-video-tab-resolution`), which corresponds to the changes merged by PR #74.
 
 ## Scope
 
-This pass re-ran the clean smoke after the #71 fix:
+This pass is the final clean smoke rerun after #71 and #73 landed:
 
-- keep the PR scope as smoke reporting only
-- re-run focused tests, typecheck, and build
-- verify `dist/content/player-monitor.js` is now emitted as a classic content script without a top-level ESM import
-- re-run clean-profile unpacked-extension smoke for popup, dashboard overview, Smart Favorites Q&A local fallback, Dynamic Bill entry, Current Video Assistant current-context, and Video Knowledge current-context
+- keep PR #70 as a smoke-report-only PR
+- run focused tests, typecheck, and build
+- verify `dist/content/player-monitor.js` still ships as a classic-content-script-safe bundle without a top-level ESM import
+- rerun clean-profile unpacked-extension smoke for:
+  - current-video page overlay
+  - popup open path
+  - dashboard overview path
+  - Smart Favorites Q&A local fallback
+  - Dynamic Bill entry and clean-profile no-crash state
+  - popup Current Video Assistant current-context
+  - popup Video Knowledge current-context
 
-No product feature, version metadata, manifest metadata, tag, release artifact, or GitHub Release change was made in this PR.
+No product feature, version metadata, manifest metadata, release notes, artifact, tag, or GitHub Release change was made in this PR.
 
 ## Version And Manifest Check
 
-Confirmed in this retest:
+Confirmed in this final rerun:
 
 - `public/manifest.json`: `version = 0.10.0`
 - `public/manifest.json`: `version_name = 0.10.0-alpha`
@@ -43,16 +49,16 @@ Confirmed in this retest:
 - Browser: `Microsoft Edge 149.0.4022.52`
 - Browser executable: `C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe`
 - Extension load target: unpacked `dist/`
-- Temporary browser profile used for this retest: `C:\Users\LITTLE~1\AppData\Local\Temp\bilibill-smoke-rerun-h0cv57sv`
+- Temporary browser profile used for this final rerun: `C:\Users\LITTLE~1\AppData\Local\Temp\bilibill-smoke-final-bmwbwq8n`
 - Runtime extension id during smoke: `ognjdpcomghnidghkhbdihlfiojmdanf`
-- Public video URL used for current-context retest: `https://www.bilibili.com/video/BV1TNE965ESB?track_id=`
-- Temporary profile was created only for this retest and was deleted afterward
+- Public video URL used for current-context verification: `https://www.bilibili.com/video/BV1TNE965ESB?track_id=`
+- Temporary profile was created only for this rerun and was deleted afterward
 
 ## Commands And Results
 
 | Command | Result |
 | --- | --- |
-| `git rebase codex/fix-player-monitor-content-script` | Pass. Smoke branch rebased onto the local head that corresponds to merged PR #72. |
+| `git rebase --onto codex/fix-popup-current-video-tab-resolution c285cd92651b7fd8322ae6507625e2defa68e755 codex/release-0.10-alpha-smoke` | Pass. Rebased the smoke-report commits onto the post-#73 fix baseline while keeping the branch diff docs-only. |
 | `npm run test:favorites` | Pass. 15 tests passed. |
 | `npm run test:current-video-summary` | Pass. 9 tests passed. |
 | `npm run test:video-knowledge` | Pass. 5 tests passed. |
@@ -78,54 +84,26 @@ Privacy boundary for this pass:
 
 | Area | Result | Evidence |
 | --- | --- | --- |
-| Current-video page overlay current-context | Pass | On the public Bilibili video page, the injected `Bili-Bill local assistant` overlay loaded and showed `description summary / medium confidence`, `BVID BV1TNE965ESB`, and source availability details. |
+| Current-video page overlay current-context | Pass | On the public Bilibili video page, the injected `Bili-Bill local assistant` overlay loaded and showed a `description summary / medium confidence` result with `BVID BV1TNE965ESB`. |
 | Popup opens | Pass | `chrome-extension://.../popup/index.html` loaded with title `Bili-Bill`. |
-| Popup overview path | Pass | Clicking `打开总览` opened `chrome-extension://.../dashboard/index.html`. |
-| Popup Dynamic Bill path | Pass | Clicking `动态账单入口` opened `chrome-extension://.../dashboard/index.html#dynamic-bill`. |
-| Dashboard overview | Pass | Overview route loaded with export actions and empty/local-only metrics in the clean profile. |
+| Popup overview path | Pass | Clicking the overview entry opened `chrome-extension://.../dashboard/index.html`. |
+| Popup Dynamic Bill path | Pass | Clicking the Dynamic Bill entry opened `chrome-extension://.../dashboard/index.html#dynamic-bill`. |
+| Dashboard overview | Pass | Overview route loaded with export actions and clean-profile local metrics. |
 | Smart Favorites Q&A local fallback | Pass | Clean profile with no synced favorites returned `no_result`, `confidence: low`, `status: no_result`, and `AI: local_fallback`. |
-| Dynamic Bill no-crash state | Pass | Dynamic Bill route loaded, showed clean-profile empty state, and kept the three local columns `久违更新 / 换换口味 / 被淹没的关注`. |
+| Dynamic Bill clean-profile state | Pass | Dynamic Bill route loaded, showed the clean-profile empty state, and kept the three local columns `久违更新 / 换换口味 / 被淹没的关注`. |
+| Popup Current Video Assistant current-context | Pass | Popup resolved the same public video tab and showed the current-video title, `BVID BV1TNE965ESB / CID unknown`, `description summary`, and local fallback source-status copy instead of no-context. |
+| Popup Video Knowledge current-context | Pass | Popup `Video knowledge v0` rendered current-context nodes in the same clean-profile session, including a metadata node and a description helper node, without the previous no-context fallback. |
 
-### Fixed By #71
+### Fix Verification
 
-The previous blocker is fixed in this retest:
+This final smoke rerun confirms both earlier blockers are fixed:
 
-- `dist/content/player-monitor.js` no longer ships with a top-level ESM import
-- public Bilibili video page injection no longer hit `Cannot use import statement outside a module`
-- current-video overlay now renders on the public video page with metadata/description context
-
-### New Remaining Blocker
-
-| Area | Result | Evidence |
-| --- | --- | --- |
-| Popup Current Video Assistant current-context | Blocked | Even with the video page open and overlay active, the popup still rendered `No current video context. Open a Bilibili video page to see metadata and source availability.` |
-| Popup Video Knowledge current-context | Blocked | In the same popup session, `Video knowledge v0` still rendered `No current video context is available for knowledge nodes.` |
-
-### Root Cause Evidence
-
-The remaining blocker is different from the old content-script import failure.
-
-Observed runtime behavior:
-
-- the public video page overlay loaded successfully, proving the `player-monitor` content script executed and produced current-video page context
-- immediately after opening the popup window, Popup and Video Knowledge still resolved to no-context state
-
-Confirmed debug evidence from the extension runtime:
-
-- when the popup window is open, the background tab lookup returns the popup tab itself:
-  - `chrome.tabs.query({ active: true, currentWindow: true })`
-  - returned `chrome-extension://.../popup/index.html`
-- `chrome.tabs.query({ active: true, lastFocusedWindow: true })` returned the same popup tab in this smoke run
-
-Relevant code path:
-
-- `src/background/messages/handlers.ts`
-- `getCurrentVideoContextForActiveTab()` still queries the active tab from the popup window context instead of resolving the last active Bilibili video tab that already published current-video context
-
-Effect:
-
-- #71 fixed current-video page collection
-- Popup / Video Knowledge current-context remains blocked because the lookup path points at the popup extension tab rather than the Bilibili video tab
+- #71 fix verified:
+  - `dist/content/player-monitor.js` no longer ships with a top-level ESM import
+  - public Bilibili video-page injection no longer fails on classic content-script parsing
+- #73 fix verified:
+  - popup current-video requests no longer collapse to the popup extension tab
+  - popup Current Video Assistant and popup Video Knowledge now resolve the active Bilibili video context in the clean popup flow
 
 ## Coverage Limits That Are Not Blockers
 
@@ -152,18 +130,17 @@ Results:
 
 ### Blockers
 
-- #71 fixed the original `player-monitor` content-script build blocker.
-- A new runtime blocker remains: Popup Current Video Assistant and Popup Video Knowledge still do not resolve current-context in the clean popup window flow because active-tab lookup resolves the popup extension page, not the Bilibili video tab.
+None found in this final clean smoke rerun.
 
 ### Must-Fix Before Release Prep
 
-- Update current-video / Video Knowledge tab resolution so popup requests can read the already-collected current-video context from the active Bilibili video tab instead of the popup extension tab, then rerun clean smoke.
+None identified in this smoke slice.
 
 ### Follow-Up
 
 - Keep the Vite large chunk warning on the release checklist as non-blocking build hygiene.
-- After the popup current-context tab-resolution issue is fixed, rerun the clean-profile smoke before package-artifact work.
-- If release owners still want live-data confidence after clean smoke passes, run one explicitly approved logged-in manual pass without reading cookies or profile files from disk.
+- If release owners want additional live-data confidence later, run one explicitly approved logged-in manual pass without reading cookies or profile files from disk.
+- Package-artifact work can proceed separately now that the clean-profile smoke path is clear.
 
 ## Privacy Confirmation
 
@@ -178,6 +155,6 @@ Confirmed for this pass:
 
 ## Conclusion
 
-This clean smoke retest still does not clear 0.10.0-alpha yet.
+This final clean smoke rerun clears 0.10.0-alpha for Issue #63.
 
-Reason: #71 fixed the original content-script import blocker and restored current-video page overlay behavior on a public Bilibili video page, but the popup flow still cannot resolve current-video context or Video Knowledge current-context because it queries the popup extension tab instead of the video tab. The known Vite large chunk warning remains non-blocking.
+Reason: focused tests, typecheck, build, player-monitor output verification, current-video page overlay, popup current-context, Video Knowledge current-context, Dashboard overview, Smart Favorites local fallback, and Dynamic Bill clean-profile entry state all passed. The only remaining build observation is the known non-blocking Vite large chunk warning.

--- a/docs/release-smoke-0.10.0-alpha.md
+++ b/docs/release-smoke-0.10.0-alpha.md
@@ -1,0 +1,162 @@
+# Bili-Bill 0.10.0-alpha Clean Smoke Report
+
+Issue: #63
+
+Date: 2026-06-11
+
+## Baseline
+
+- Branch under test: `codex/release-0.10-alpha-smoke`
+- Worktree: `C:\Users\LittleNub\Documents\New project 4\BiliBili-DataViz-Plugin-release-0.10-smoke`
+- Baseline commit: `8d94e9d356dab4c8510a8a43feac0d821afde58d`
+- Source base check: `origin/main` resolved to `8d94e9d356dab4c8510a8a43feac0d821afde58d`
+
+## Scope
+
+This pass covered the clean smoke verification slice only:
+
+- confirm release metadata on latest main
+- run install, focused tests, typecheck, and build
+- load `dist/` as an unpacked extension in a fresh temporary browser profile
+- smoke Popup, Dashboard overview, Smart Favorites Q&A local fallback, Current Video Assistant, Video Knowledge, and Dynamic Bill entry states
+
+No product feature, version, package metadata, manifest metadata, tag, release artifact, or GitHub Release change was made.
+
+## Version And Manifest Check
+
+Confirmed from latest main before smoke:
+
+- `public/manifest.json`: `version = 0.10.0`
+- `public/manifest.json`: `version_name = 0.10.0-alpha`
+- `dist/manifest.json`: `version = 0.10.0`
+- `dist/manifest.json`: `version_name = 0.10.0-alpha`
+- `package.json`: `version = 0.10.0-alpha`
+
+## Environment
+
+- OS: `Microsoft Windows NT 10.0.26200.0`
+- Node.js: `v24.14.1`
+- npm: `11.11.0`
+- Browser: `Microsoft Edge 149.0.4022.52`
+- Browser executable: `C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe`
+- Extension load target: unpacked `dist/`
+- Temporary browser profile used for smoke: `C:\Users\LITTLE~1\AppData\Local\Temp\bilibill-smoke-rhypgety`
+- Runtime extension id during smoke: `ognjdpcomghnidghkhbdihlfiojmdanf`
+- Public video URL used for current-context attempt: `https://www.bilibili.com/video/BV1TNE965ESB?track_id=`
+- Temporary profile was created only for this smoke run and was deleted afterward
+
+## Commands And Results
+
+| Command | Result |
+| --- | --- |
+| `git fetch origin main` | Pass. `origin/main` updated to `8d94e9d356dab4c8510a8a43feac0d821afde58d`. |
+| `npm install` | Pass. 28 packages installed, 0 vulnerabilities. |
+| `npm run test:favorites` | Pass. 15 tests passed. |
+| `npm run test:current-video-summary` | Pass. 9 tests passed. |
+| `npm run test:video-knowledge` | Pass. 5 tests passed. |
+| `npm run typecheck` | Pass. `tsc --noEmit` completed. |
+| `npm run build` | Pass. Production build completed. |
+
+Build warning:
+
+- Non-blocking known warning remains: Vite reported `dist/chunks/theme-BXY0bwcN.js` above 500 kB after minification.
+
+## Browser / Extension Smoke
+
+Privacy boundary for this pass:
+
+- fresh temporary browser profile only
+- no reuse of local Bilibili cookies
+- no reuse of real browser profile data
+- no reuse of login-state files
+- no read of `C:\Users\LittleNub\Desktop\Key.txt`
+
+### Pass
+
+| Area | Result | Evidence |
+| --- | --- | --- |
+| Popup opens | Pass | `chrome-extension://.../popup/index.html` loaded with title `Bili-Bill`. |
+| Popup overview path | Pass | Clicking `打开总览` opened `chrome-extension://.../dashboard/index.html`. |
+| Popup Dynamic Bill path | Pass | Clicking `动态账单入口` opened `chrome-extension://.../dashboard/index.html#dynamic-bill`. |
+| Dashboard overview | Pass | Overview route loaded with `导出 JSON` / `导出 CSV`, empty weekly/monthly metrics, and empty local-history state. |
+| Smart Favorites Q&A local fallback | Pass | Clean profile with no synced favorites returned `no_result`, `confidence: low`, `status: no_result`, and `AI: local_fallback`. |
+| Current Video Assistant no-context | Pass | Popup showed `No current video context. Open a Bilibili video page to see metadata and source availability.` |
+| Video Knowledge no-context | Pass | Popup showed `Video knowledge v0` and `No current video context is available for knowledge nodes.` |
+| Dynamic Bill no-crash state | Pass | Dynamic Bill route loaded, showed clean-profile empty state, sync/generate controls, and the three local columns `久违更新 / 换换口味 / 被淹没的关注`. |
+
+### Blocked
+
+| Area | Result | Evidence |
+| --- | --- | --- |
+| Current Video Assistant current-context | Blocked | On a public Bilibili video page, popup still stayed in `No current video context` after refresh and after reopening the popup in a fresh extension window. |
+| Video Knowledge current-context | Blocked | On the same public Bilibili video page, popup still showed zero knowledge nodes and the same no-context message. |
+
+### Root Cause Evidence
+
+This is not a login-state limitation. The blocker reproduced on a public video page in a clean profile and points to the current-video content script build output:
+
+- `dist/content/player-monitor.js` starts with an ESM import:
+  - `import { ... } from "../chunks/current-video-summary-BGvYK5Jn.js";`
+- `manifest.json` registers `content/player-monitor.js` as a classic content script under `content_scripts`, not as a module script.
+- On the public video page smoke attempt, the page surfaced:
+  - `Cannot use import statement outside a module`
+- Because `player-monitor` did not execute cleanly on the video page, the background `CURRENT_VIDEO_CONTEXT_UPDATE` path never produced usable runtime current-video context for Popup or Video Knowledge.
+
+Observed related noise:
+
+- homepage/sidebar card smoke also emitted a non-blocking timeout while waiting for homepage sidebar targets
+- those homepage/sidebar observations are secondary; the blocking issue for #63 is the current-video content script load failure
+
+## Coverage Limits That Are Not Blockers
+
+- This pass intentionally did not reuse or inspect any real Bilibili login state.
+- Real logged-in Dynamic Bill sync, followed-creator snapshots, favorite sync against live account data, and real current-user history data were not exercised.
+- Not covering real login-backed three-column generation is expected for this clean-profile smoke and is not a blocker by itself.
+
+## Copy Scan
+
+Scoped scan completed for:
+
+- `dashboard`
+- `popup`
+- `public`
+- `src`
+- `README.md`
+- this smoke report
+
+Results:
+
+- no hit for the AGENTS.md forbidden Dynamic Bill copy patterns
+
+## Findings
+
+### Blockers
+
+- Current-video clean smoke is blocked on the `player-monitor` content script build artifact being emitted as ESM while the manifest injects it as a classic content script. This prevents current-context runtime collection on public Bilibili video pages, which in turn blocks Popup Current Video Assistant current-context and Video Knowledge current-context smoke coverage.
+
+### Must-Fix Before Release Prep
+
+- Fix the `content/player-monitor.js` bundling/loading path so the content script executes on `*://www.bilibili.com/video/*` without `import` parse failure, then rerun the clean smoke for Popup Current Video Assistant and Video Knowledge current-context states.
+
+### Follow-Up
+
+- Keep the Vite large chunk warning on the release checklist as non-blocking build hygiene.
+- After the current-video content script load issue is fixed, rerun this clean-profile smoke before package-artifact work.
+- If release owners still want live-data confidence after clean smoke passes, run one explicitly approved logged-in manual pass without reading cookies or profile files from disk.
+
+## Privacy Confirmation
+
+Confirmed for this pass:
+
+- did not read local key files
+- did not read Cookie files
+- did not read or reuse browser profile files
+- did not read Bilibili login-state files
+- did not upload full history, favorites, following lists, feedback records, or database contents
+- did not write back to Bilibili
+
+## Conclusion
+
+This clean smoke pass does not clear 0.10.0-alpha yet.
+
+Reason: install, focused tests, typecheck, build, Popup entry paths, Dashboard overview, Smart Favorites local fallback, and Dynamic Bill no-crash state all passed, but current-video current-context and Video Knowledge current-context are blocked by the `player-monitor` content script load failure on public Bilibili video pages. The known Vite large chunk warning remains non-blocking.

--- a/docs/release-smoke-0.10.0-alpha.md
+++ b/docs/release-smoke-0.10.0-alpha.md
@@ -8,23 +8,26 @@ Date: 2026-06-11
 
 - Branch under test: `codex/release-0.10-alpha-smoke`
 - Worktree: `C:\Users\LittleNub\Documents\New project 4\BiliBili-DataViz-Plugin-release-0.10-smoke`
-- Baseline commit: `8d94e9d356dab4c8510a8a43feac0d821afde58d`
-- Source base check: `origin/main` resolved to `8d94e9d356dab4c8510a8a43feac0d821afde58d`
+- Retest baseline includes the #71 blocker fix from PR #72:
+  - merged PR: `https://github.com/LittleNuB/BiliBili-DataViz-Plugin/pull/72`
+  - GitHub merge commit: `ee643bcbc9f2eaabdabf9c16f5c6c7f9d6c821e0`
+  - local rebase base used for this retest: `c285cd92651b7fd8322ae6507625e2defa68e755` (`codex/fix-player-monitor-content-script`)
+- Previous smoke report blocker: `player-monitor` classic content script was emitted with a top-level ESM import and failed on public Bilibili video pages.
 
 ## Scope
 
-This pass covered the clean smoke verification slice only:
+This pass re-ran the clean smoke after the #71 fix:
 
-- confirm release metadata on latest main
-- run install, focused tests, typecheck, and build
-- load `dist/` as an unpacked extension in a fresh temporary browser profile
-- smoke Popup, Dashboard overview, Smart Favorites Q&A local fallback, Current Video Assistant, Video Knowledge, and Dynamic Bill entry states
+- keep the PR scope as smoke reporting only
+- re-run focused tests, typecheck, and build
+- verify `dist/content/player-monitor.js` is now emitted as a classic content script without a top-level ESM import
+- re-run clean-profile unpacked-extension smoke for popup, dashboard overview, Smart Favorites Q&A local fallback, Dynamic Bill entry, Current Video Assistant current-context, and Video Knowledge current-context
 
-No product feature, version, package metadata, manifest metadata, tag, release artifact, or GitHub Release change was made.
+No product feature, version metadata, manifest metadata, tag, release artifact, or GitHub Release change was made in this PR.
 
 ## Version And Manifest Check
 
-Confirmed from latest main before smoke:
+Confirmed in this retest:
 
 - `public/manifest.json`: `version = 0.10.0`
 - `public/manifest.json`: `version_name = 0.10.0-alpha`
@@ -40,22 +43,22 @@ Confirmed from latest main before smoke:
 - Browser: `Microsoft Edge 149.0.4022.52`
 - Browser executable: `C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe`
 - Extension load target: unpacked `dist/`
-- Temporary browser profile used for smoke: `C:\Users\LITTLE~1\AppData\Local\Temp\bilibill-smoke-rhypgety`
+- Temporary browser profile used for this retest: `C:\Users\LITTLE~1\AppData\Local\Temp\bilibill-smoke-rerun-h0cv57sv`
 - Runtime extension id during smoke: `ognjdpcomghnidghkhbdihlfiojmdanf`
-- Public video URL used for current-context attempt: `https://www.bilibili.com/video/BV1TNE965ESB?track_id=`
-- Temporary profile was created only for this smoke run and was deleted afterward
+- Public video URL used for current-context retest: `https://www.bilibili.com/video/BV1TNE965ESB?track_id=`
+- Temporary profile was created only for this retest and was deleted afterward
 
 ## Commands And Results
 
 | Command | Result |
 | --- | --- |
-| `git fetch origin main` | Pass. `origin/main` updated to `8d94e9d356dab4c8510a8a43feac0d821afde58d`. |
-| `npm install` | Pass. 28 packages installed, 0 vulnerabilities. |
+| `git rebase codex/fix-player-monitor-content-script` | Pass. Smoke branch rebased onto the local head that corresponds to merged PR #72. |
 | `npm run test:favorites` | Pass. 15 tests passed. |
 | `npm run test:current-video-summary` | Pass. 9 tests passed. |
 | `npm run test:video-knowledge` | Pass. 5 tests passed. |
 | `npm run typecheck` | Pass. `tsc --noEmit` completed. |
-| `npm run build` | Pass. Production build completed. |
+| `npm run build` | Pass. Main Vite build plus dedicated `vite.player-monitor.config.ts` build completed. |
+| `rg -n "^import\\s" dist/content/player-monitor.js` | Pass. No top-level ESM import remained in the emitted classic content script. |
 
 Build warning:
 
@@ -75,43 +78,60 @@ Privacy boundary for this pass:
 
 | Area | Result | Evidence |
 | --- | --- | --- |
+| Current-video page overlay current-context | Pass | On the public Bilibili video page, the injected `Bili-Bill local assistant` overlay loaded and showed `description summary / medium confidence`, `BVID BV1TNE965ESB`, and source availability details. |
 | Popup opens | Pass | `chrome-extension://.../popup/index.html` loaded with title `Bili-Bill`. |
 | Popup overview path | Pass | Clicking `打开总览` opened `chrome-extension://.../dashboard/index.html`. |
 | Popup Dynamic Bill path | Pass | Clicking `动态账单入口` opened `chrome-extension://.../dashboard/index.html#dynamic-bill`. |
-| Dashboard overview | Pass | Overview route loaded with `导出 JSON` / `导出 CSV`, empty weekly/monthly metrics, and empty local-history state. |
+| Dashboard overview | Pass | Overview route loaded with export actions and empty/local-only metrics in the clean profile. |
 | Smart Favorites Q&A local fallback | Pass | Clean profile with no synced favorites returned `no_result`, `confidence: low`, `status: no_result`, and `AI: local_fallback`. |
-| Current Video Assistant no-context | Pass | Popup showed `No current video context. Open a Bilibili video page to see metadata and source availability.` |
-| Video Knowledge no-context | Pass | Popup showed `Video knowledge v0` and `No current video context is available for knowledge nodes.` |
-| Dynamic Bill no-crash state | Pass | Dynamic Bill route loaded, showed clean-profile empty state, sync/generate controls, and the three local columns `久违更新 / 换换口味 / 被淹没的关注`. |
+| Dynamic Bill no-crash state | Pass | Dynamic Bill route loaded, showed clean-profile empty state, and kept the three local columns `久违更新 / 换换口味 / 被淹没的关注`. |
 
-### Blocked
+### Fixed By #71
+
+The previous blocker is fixed in this retest:
+
+- `dist/content/player-monitor.js` no longer ships with a top-level ESM import
+- public Bilibili video page injection no longer hit `Cannot use import statement outside a module`
+- current-video overlay now renders on the public video page with metadata/description context
+
+### New Remaining Blocker
 
 | Area | Result | Evidence |
 | --- | --- | --- |
-| Current Video Assistant current-context | Blocked | On a public Bilibili video page, popup still stayed in `No current video context` after refresh and after reopening the popup in a fresh extension window. |
-| Video Knowledge current-context | Blocked | On the same public Bilibili video page, popup still showed zero knowledge nodes and the same no-context message. |
+| Popup Current Video Assistant current-context | Blocked | Even with the video page open and overlay active, the popup still rendered `No current video context. Open a Bilibili video page to see metadata and source availability.` |
+| Popup Video Knowledge current-context | Blocked | In the same popup session, `Video knowledge v0` still rendered `No current video context is available for knowledge nodes.` |
 
 ### Root Cause Evidence
 
-This is not a login-state limitation. The blocker reproduced on a public video page in a clean profile and points to the current-video content script build output:
+The remaining blocker is different from the old content-script import failure.
 
-- `dist/content/player-monitor.js` starts with an ESM import:
-  - `import { ... } from "../chunks/current-video-summary-BGvYK5Jn.js";`
-- `manifest.json` registers `content/player-monitor.js` as a classic content script under `content_scripts`, not as a module script.
-- On the public video page smoke attempt, the page surfaced:
-  - `Cannot use import statement outside a module`
-- Because `player-monitor` did not execute cleanly on the video page, the background `CURRENT_VIDEO_CONTEXT_UPDATE` path never produced usable runtime current-video context for Popup or Video Knowledge.
+Observed runtime behavior:
 
-Observed related noise:
+- the public video page overlay loaded successfully, proving the `player-monitor` content script executed and produced current-video page context
+- immediately after opening the popup window, Popup and Video Knowledge still resolved to no-context state
 
-- homepage/sidebar card smoke also emitted a non-blocking timeout while waiting for homepage sidebar targets
-- those homepage/sidebar observations are secondary; the blocking issue for #63 is the current-video content script load failure
+Confirmed debug evidence from the extension runtime:
+
+- when the popup window is open, the background tab lookup returns the popup tab itself:
+  - `chrome.tabs.query({ active: true, currentWindow: true })`
+  - returned `chrome-extension://.../popup/index.html`
+- `chrome.tabs.query({ active: true, lastFocusedWindow: true })` returned the same popup tab in this smoke run
+
+Relevant code path:
+
+- `src/background/messages/handlers.ts`
+- `getCurrentVideoContextForActiveTab()` still queries the active tab from the popup window context instead of resolving the last active Bilibili video tab that already published current-video context
+
+Effect:
+
+- #71 fixed current-video page collection
+- Popup / Video Knowledge current-context remains blocked because the lookup path points at the popup extension tab rather than the Bilibili video tab
 
 ## Coverage Limits That Are Not Blockers
 
 - This pass intentionally did not reuse or inspect any real Bilibili login state.
 - Real logged-in Dynamic Bill sync, followed-creator snapshots, favorite sync against live account data, and real current-user history data were not exercised.
-- Not covering real login-backed three-column generation is expected for this clean-profile smoke and is not a blocker by itself.
+- Not covering real login-backed Dynamic Bill generation is expected for this clean-profile smoke and is not a blocker by itself.
 
 ## Copy Scan
 
@@ -132,16 +152,17 @@ Results:
 
 ### Blockers
 
-- Current-video clean smoke is blocked on the `player-monitor` content script build artifact being emitted as ESM while the manifest injects it as a classic content script. This prevents current-context runtime collection on public Bilibili video pages, which in turn blocks Popup Current Video Assistant current-context and Video Knowledge current-context smoke coverage.
+- #71 fixed the original `player-monitor` content-script build blocker.
+- A new runtime blocker remains: Popup Current Video Assistant and Popup Video Knowledge still do not resolve current-context in the clean popup window flow because active-tab lookup resolves the popup extension page, not the Bilibili video tab.
 
 ### Must-Fix Before Release Prep
 
-- Fix the `content/player-monitor.js` bundling/loading path so the content script executes on `*://www.bilibili.com/video/*` without `import` parse failure, then rerun the clean smoke for Popup Current Video Assistant and Video Knowledge current-context states.
+- Update current-video / Video Knowledge tab resolution so popup requests can read the already-collected current-video context from the active Bilibili video tab instead of the popup extension tab, then rerun clean smoke.
 
 ### Follow-Up
 
 - Keep the Vite large chunk warning on the release checklist as non-blocking build hygiene.
-- After the current-video content script load issue is fixed, rerun this clean-profile smoke before package-artifact work.
+- After the popup current-context tab-resolution issue is fixed, rerun the clean-profile smoke before package-artifact work.
 - If release owners still want live-data confidence after clean smoke passes, run one explicitly approved logged-in manual pass without reading cookies or profile files from disk.
 
 ## Privacy Confirmation
@@ -157,6 +178,6 @@ Confirmed for this pass:
 
 ## Conclusion
 
-This clean smoke pass does not clear 0.10.0-alpha yet.
+This clean smoke retest still does not clear 0.10.0-alpha yet.
 
-Reason: install, focused tests, typecheck, build, Popup entry paths, Dashboard overview, Smart Favorites local fallback, and Dynamic Bill no-crash state all passed, but current-video current-context and Video Knowledge current-context are blocked by the `player-monitor` content script load failure on public Bilibili video pages. The known Vite large chunk warning remains non-blocking.
+Reason: #71 fixed the original content-script import blocker and restored current-video page overlay behavior on a public Bilibili video page, but the popup flow still cannot resolve current-video context or Video Knowledge current-context because it queries the popup extension tab instead of the video tab. The known Vite large chunk warning remains non-blocking.


### PR DESCRIPTION
﻿Closes #63

## Scope

Finalize `docs/release-smoke-0.10.0-alpha.md` after rerunning the 0.10.0-alpha clean smoke on top of the merged #71 and #73 fixes.

This PR is now a pure smoke-report PR. It only changes the smoke report document and does not include code, manifest metadata, package metadata, release notes, artifacts, tags, or release publishing changes.

## Validation

- `git rebase --onto codex/fix-popup-current-video-tab-resolution c285cd92651b7fd8322ae6507625e2defa68e755 codex/release-0.10-alpha-smoke`
- `npm run test:favorites`
- `npm run test:current-video-summary`
- `npm run test:video-knowledge`
- `npm run typecheck`
- `npm run build`
- `rg -n "^import\\s" dist/content/player-monitor.js`
- `git diff --check`
- scoped copy scan across `dashboard`, `popup`, `public`, `src`, `README.md`, and the smoke report
- clean-profile Edge unpacked-extension smoke for current-video overlay, popup current-context, Video Knowledge current-context, dashboard overview, Smart Favorites local fallback, and Dynamic Bill entry

## Final Smoke Result

- #71 fix verified: `dist/content/player-monitor.js` no longer emits a top-level ESM import, and the public video-page overlay loads current-video context.
- #73 fix verified: popup current-video requests now resolve the active Bilibili video tab rather than the popup extension tab.
- Current-video page overlay passed on a public Bilibili video page.
- Popup Current Video Assistant current-context passed and showed `BV1TNE965ESB` with a description-summary local fallback.
- Popup Video Knowledge current-context passed and rendered metadata/description nodes in the same clean-profile flow.
- Dashboard overview path passed.
- Smart Favorites Q&A clean-profile local fallback passed.
- Dynamic Bill clean-profile entry/no-crash state passed.

## Blocker

- none found in the final clean smoke rerun for #63
- the existing Vite large chunk warning remains non-blocking build hygiene only

## Must-Fix

- none identified in this smoke-report slice

## Follow-Up

- package-artifact work can proceed separately now that the clean-profile smoke path is clear
- if release owners want additional live-data confidence later, run one explicitly approved logged-in manual pass without reading cookies or profile files from disk

## Privacy Boundary

- used a fresh temporary browser profile only
- did not read or reuse local cookies, browser profile files, login-state files, or `C:\Users\LittleNub\Desktop\Key.txt`
- did not upload full local history, favorites, following, feedback, or database contents
- did not write back to Bilibili
