### PR TITLE
[codex] Fix player-monitor content script loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite build --watch --mode development",
-    "build": "tsc --noEmit && vite build",
+    "build": "tsc --noEmit && vite build && vite build --config vite.player-monitor.config.ts",
     "typecheck": "tsc --noEmit",
     "test:favorites": "node --test tests/favorite-sync-audit.test.ts tests/smart-favorites-qa.test.ts",
     "test:current-video-summary": "node --test tests/current-video-summary.test.ts",

--- a/vite.player-monitor.config.ts
+++ b/vite.player-monitor.config.ts
@@ -9,6 +9,7 @@ const resolveRoot = (...segments: string[]) => path.resolve(__dirname, ...segmen
 
 export default defineConfig({
   root: __dirname,
+  publicDir: false,
   esbuild: {
     jsx: 'automatic',
     jsxImportSource: 'preact',
@@ -22,18 +23,16 @@ export default defineConfig({
   build: {
     target: 'es2022',
     outDir: 'dist',
-    emptyOutDir: true,
+    emptyOutDir: false,
     rollupOptions: {
       input: {
-        background: 'src/background/index.ts',
-        'content/sidebar-card': 'src/content/sidebar-card/index.ts',
-        popup: 'popup/index.html',
-        dashboard: 'dashboard/index.html',
+        'content/player-monitor': 'src/content/player-monitor/index.ts',
       },
       output: {
         entryFileNames: '[name].js',
         chunkFileNames: 'chunks/[name]-[hash].js',
         assetFileNames: 'assets/[name]-[hash].[ext]',
+        inlineDynamicImports: true,
       },
     },
   },


### PR DESCRIPTION
Closes #71

## Scope

- remove `content/player-monitor` from the main multi-entry Vite build
- add a dedicated `vite.player-monitor.config.ts` pass so `dist/content/player-monitor.js` is emitted as a self-contained classic MV3 content script
- keep popup, dashboard, background, and sidebar-card build behavior unchanged

## Validation

- `npm.cmd run test:current-video-summary`
- `npm.cmd run test:video-knowledge`
- `npm.cmd run typecheck`
- `npm.cmd run build`
- `git diff --check`
- `rg ^import\\s dist/content/player-monitor.js` returned no matches
- clean-profile Edge unpacked-extension smoke on public video `https://www.bilibili.com/video/BV1TNE965ESB?track_id=`
  - page overlay loaded and showed current-video metadata/description context
  - popup reloaded with the video tab active left no-context state and showed current-video context plus Video Knowledge metadata/description nodes

## Blocker

- none in this PR
- #63 clean smoke still needs to be rerun after this PR is merged

## Must-Fix

- none identified in this scope

## Follow-Up

- rerun #63 clean-profile smoke after merge to clear the release blocker path
- keep the known Vite large chunk warning for `dist/chunks/theme-*.js` as non-blocking build hygiene

## Privacy Boundary

- used a fresh temporary browser profile only
- did not read local key files, Cookie files, browser profile files, or Bilibili login-state files from disk
- did not upload full local history, favorites, following, feedback, or database contents
- did not write back to Bilibili