### PR TITLE
[codex] Fix popup current-video tab resolution

### DIFF
--- a/src/background/current-video-context-resolver.ts
+++ b/src/background/current-video-context-resolver.ts
@@ -1,0 +1,86 @@
+import type { CurrentVideoContextResult } from '../shared/types/current-video-context';
+
+export interface CurrentVideoTabSnapshot {
+  id: number;
+  url: string | null;
+  active: boolean;
+  lastAccessed: number | null;
+}
+
+export interface ResolvedCurrentVideoTabState {
+  tab: CurrentVideoTabSnapshot | null;
+  context: CurrentVideoContextResult | null;
+}
+
+export const CURRENT_VIDEO_CONTEXT_MAX_AGE_MS = 10 * 60 * 1000;
+
+export function resolveCurrentVideoTabState(
+  tabs: CurrentVideoTabSnapshot[],
+  contexts: ReadonlyMap<number, CurrentVideoContextResult>,
+  now = Date.now(),
+): ResolvedCurrentVideoTabState {
+  const orderedTabs = [...tabs].sort(compareTabsByRecency);
+  const activeTabs = orderedTabs.filter(tab => tab.active);
+  const primaryTab = activeTabs[0] ?? orderedTabs[0] ?? null;
+
+  if (primaryTab?.url) {
+    return {
+      tab: primaryTab,
+      context: resolveFreshMatchingVideoContext(primaryTab, contexts, now),
+    };
+  }
+
+  const fallback = orderedTabs.find(tab => resolveFreshMatchingVideoContext(tab, contexts, now));
+  if (!fallback) {
+    return { tab: primaryTab, context: null };
+  }
+
+  return {
+    tab: fallback,
+    context: resolveFreshMatchingVideoContext(fallback, contexts, now),
+  };
+}
+
+export function resolveFreshMatchingVideoContext(
+  tab: CurrentVideoTabSnapshot,
+  contexts: ReadonlyMap<number, CurrentVideoContextResult>,
+  now = Date.now(),
+): CurrentVideoContextResult | null {
+  if (tab.id <= 0 || !tab.url || !isBilibiliVideoUrl(tab.url)) return null;
+
+  const context = contexts.get(tab.id);
+  if (!context || context.kind !== 'video') return null;
+  if (extractBvidFromUrl(tab.url) !== context.bvid) return null;
+  if (now - context.collectedAt > CURRENT_VIDEO_CONTEXT_MAX_AGE_MS) return null;
+
+  return context;
+}
+
+export function isBilibiliVideoUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname.endsWith('bilibili.com') && parsed.pathname.startsWith('/video/');
+  } catch {
+    return false;
+  }
+}
+
+export function extractBvidFromUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return parsed.pathname.match(/\/video\/(BV[A-Za-z0-9]+)/)?.[1] ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function compareTabsByRecency(a: CurrentVideoTabSnapshot, b: CurrentVideoTabSnapshot): number {
+  const lastAccessedDiff = normalizeLastAccessed(b.lastAccessed) - normalizeLastAccessed(a.lastAccessed);
+  if (lastAccessedDiff !== 0) return lastAccessedDiff;
+  if (a.active !== b.active) return Number(b.active) - Number(a.active);
+  return b.id - a.id;
+}
+
+function normalizeLastAccessed(value: number | null): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : -1;
+}

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -36,6 +36,12 @@ import { generateDynamicBillItems } from '../dynamic-bill/generator';
 import { DYNAMIC_BILL_STRATEGY } from '../dynamic-bill/strategy';
 import { getDynamicOverview, syncDynamicBillUpdates } from '../dynamic-bill/sync';
 import {
+  extractBvidFromUrl,
+  isBilibiliVideoUrl,
+  resolveCurrentVideoTabState,
+  type CurrentVideoTabSnapshot,
+} from '../current-video-context-resolver';
+import {
   getDynamicBillFilterPreference,
   getDynamicBillItems,
   addDynamicBillFeedback,
@@ -75,6 +81,20 @@ export function setupMessageHandlers(): void {
 
   chrome.tabs.onRemoved.addListener((tabId) => {
     currentVideoContexts.delete(tabId);
+  });
+
+  chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+    const nextUrl = changeInfo.url;
+    if (!nextUrl) return;
+    if (!isBilibiliVideoUrl(nextUrl)) {
+      currentVideoContexts.delete(tabId);
+      return;
+    }
+
+    const cached = currentVideoContexts.get(tabId);
+    if (cached?.kind === 'video' && cached.bvid !== extractBvidFromUrl(nextUrl)) {
+      currentVideoContexts.delete(tabId);
+    }
   });
 }
 
@@ -329,14 +349,16 @@ async function requestVideoKnowledgeJump(params: Record<string, unknown> | undef
     };
   }
 
-  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  const tabId = tab?.id ?? 0;
-  if (!tab?.url || tabId <= 0 || !isBilibiliVideoUrl(tab.url)) {
+  const target = await resolveCurrentVideoLookupState();
+  const tabId = target.tab?.id ?? 0;
+  if (!target.tab?.url || tabId <= 0 || !isBilibiliVideoUrl(target.tab.url)) {
     throw new Error('NO_ACTIVE_BILIBILI_VIDEO_TAB');
   }
 
-  const context = await getCurrentVideoContextForActiveTab();
-  const knowledge = buildVideoKnowledgeResult(context);
+  if (target.context?.kind !== 'video') {
+    throw new Error('VIDEO_CONTEXT_UNAVAILABLE');
+  }
+  const knowledge = buildVideoKnowledgeResult(target.context);
   const node = findVideoKnowledgeNode(knowledge, nodeId);
   if (!node || !node.jumpAction) {
     throw new Error('VIDEO_KNOWLEDGE_JUMP_TARGET_UNAVAILABLE');
@@ -346,7 +368,7 @@ async function requestVideoKnowledgeJump(params: Record<string, unknown> | undef
     action: 'VIDEO_KNOWLEDGE_MANUAL_JUMP',
     payload: {
       node,
-      contextBvid: context.kind === 'video' ? context.bvid : null,
+      contextBvid: target.context.bvid,
       confirmed: true,
     },
   });
@@ -360,20 +382,36 @@ async function markConsumedFromPlayerEvent(
 }
 
 async function getCurrentVideoContextForActiveTab(): Promise<CurrentVideoContextResult> {
-  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const { tab, context } = await resolveCurrentVideoLookupState();
   const url = tab?.url ?? null;
-  const tabId = tab?.id ?? 0;
 
   if (!url || !isBilibiliVideoUrl(url)) {
     return buildNoContext(url, 'non_video_page', 'non_video');
   }
 
-  const context = tabId > 0 ? currentVideoContexts.get(tabId) : null;
-  if (context?.kind === 'video' && context.bvid === extractBvidFromUrl(url)) {
+  if (context?.kind === 'video') {
     return context;
   }
 
   return buildNoContext(url, 'video_context_unavailable', 'video');
+}
+
+async function resolveCurrentVideoLookupState(): Promise<{
+  tab: CurrentVideoTabSnapshot | null;
+  context: CurrentVideoContextResult | null;
+}> {
+  const windows = await chrome.windows.getAll({
+    populate: true,
+    windowTypes: ['normal'],
+  });
+  const tabs = windows.flatMap(window => (window.tabs ?? []).map(tab => ({
+    id: tab.id ?? 0,
+    url: tab.url ?? null,
+    active: tab.active ?? false,
+    lastAccessed: typeof tab.lastAccessed === 'number' ? tab.lastAccessed : null,
+  } satisfies CurrentVideoTabSnapshot)));
+
+  return resolveCurrentVideoTabState(tabs, currentVideoContexts);
 }
 
 function buildNoContext(
@@ -388,24 +426,6 @@ function buildNoContext(
     reason,
     pageType,
   };
-}
-
-function isBilibiliVideoUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    return parsed.hostname.endsWith('bilibili.com') && parsed.pathname.startsWith('/video/');
-  } catch {
-    return false;
-  }
-}
-
-function extractBvidFromUrl(url: string): string {
-  try {
-    const parsed = new URL(url);
-    return parsed.pathname.match(/\/video\/(BV[A-Za-z0-9]+)/)?.[1] ?? '';
-  } catch {
-    return '';
-  }
 }
 
 function isEffectivePlayerWatch(payload: PlayerHeartbeatPayload | PlayerActionPayload): boolean {

--- a/tests/current-video-context-resolver.test.ts
+++ b/tests/current-video-context-resolver.test.ts
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  CURRENT_VIDEO_CONTEXT_MAX_AGE_MS,
+  resolveCurrentVideoTabState,
+  type CurrentVideoTabSnapshot,
+} from '../src/background/current-video-context-resolver.ts';
+import type { CurrentVideoContextResult } from '../src/shared/types/current-video-context.ts';
+
+test('prefers the most recently accessed active normal tab context', () => {
+  const tabs: CurrentVideoTabSnapshot[] = [
+    {
+      id: 11,
+      url: 'https://www.bilibili.com/video/BVOlderCtx11',
+      active: true,
+      lastAccessed: 100,
+    },
+    {
+      id: 22,
+      url: 'https://www.bilibili.com/video/BVLatestCtx22?p=2',
+      active: true,
+      lastAccessed: 200,
+    },
+  ];
+  const contexts = new Map<number, CurrentVideoContextResult>([
+    [11, videoContext('https://www.bilibili.com/video/BVOlderCtx11', 'BVOlderCtx11', 1000)],
+    [22, videoContext('https://www.bilibili.com/video/BVLatestCtx22?p=2', 'BVLatestCtx22', 1001)],
+  ]);
+
+  const resolved = resolveCurrentVideoTabState(tabs, contexts, 2000);
+
+  assert.equal(resolved.tab?.id, 22);
+  assert.equal(resolved.context?.kind, 'video');
+  assert.equal(resolved.context?.kind === 'video' ? resolved.context.bvid : null, 'BVLatestCtx22');
+});
+
+test('keeps non-video fallback when the most recent active tab is not a video page', () => {
+  const tabs: CurrentVideoTabSnapshot[] = [
+    {
+      id: 31,
+      url: 'https://www.bilibili.com/',
+      active: true,
+      lastAccessed: 300,
+    },
+    {
+      id: 32,
+      url: 'https://www.bilibili.com/video/BVBackground32',
+      active: false,
+      lastAccessed: 200,
+    },
+  ];
+  const contexts = new Map<number, CurrentVideoContextResult>([
+    [32, videoContext('https://www.bilibili.com/video/BVBackground32', 'BVBackground32', 1000)],
+  ]);
+
+  const resolved = resolveCurrentVideoTabState(tabs, contexts, 2000);
+
+  assert.equal(resolved.tab?.id, 31);
+  assert.equal(resolved.context, null);
+});
+
+test('ignores mismatched or stale contexts for the chosen video tab', () => {
+  const tabs: CurrentVideoTabSnapshot[] = [
+    {
+      id: 41,
+      url: 'https://www.bilibili.com/video/BVTarget41',
+      active: true,
+      lastAccessed: 400,
+    },
+  ];
+
+  const mismatched = resolveCurrentVideoTabState(
+    tabs,
+    new Map<number, CurrentVideoContextResult>([
+      [41, videoContext('https://www.bilibili.com/video/BVOther41', 'BVOther41', 1000)],
+    ]),
+    2000,
+  );
+  assert.equal(mismatched.tab?.id, 41);
+  assert.equal(mismatched.context, null);
+
+  const stale = resolveCurrentVideoTabState(
+    tabs,
+    new Map<number, CurrentVideoContextResult>([
+      [41, videoContext('https://www.bilibili.com/video/BVTarget41', 'BVTarget41', 1000)],
+    ]),
+    1000 + CURRENT_VIDEO_CONTEXT_MAX_AGE_MS + 1,
+  );
+  assert.equal(stale.tab?.id, 41);
+  assert.equal(stale.context, null);
+});
+
+test('falls back to the freshest matching video context when tab urls are unavailable', () => {
+  const tabs: CurrentVideoTabSnapshot[] = [
+    {
+      id: 51,
+      url: null,
+      active: true,
+      lastAccessed: 500,
+    },
+    {
+      id: 52,
+      url: 'https://www.bilibili.com/video/BVFallback52',
+      active: false,
+      lastAccessed: 450,
+    },
+  ];
+  const contexts = new Map<number, CurrentVideoContextResult>([
+    [52, videoContext('https://www.bilibili.com/video/BVFallback52', 'BVFallback52', 1500)],
+  ]);
+
+  const resolved = resolveCurrentVideoTabState(tabs, contexts, 2000);
+
+  assert.equal(resolved.tab?.id, 52);
+  assert.equal(resolved.context?.kind, 'video');
+  assert.equal(resolved.context?.kind === 'video' ? resolved.context.bvid : null, 'BVFallback52');
+});
+
+function videoContext(url: string, bvid: string, collectedAt: number): CurrentVideoContextResult {
+  return {
+    kind: 'video',
+    url,
+    collectedAt,
+    bvid,
+    cid: 100,
+    title: 'Resolver test video',
+    authorName: 'Resolver UP',
+    authorMid: 42,
+    durationSeconds: 600,
+    currentPart: {
+      page: 1,
+      title: 'Main part',
+      total: 1,
+    },
+    parts: [],
+    chapters: [],
+    description: {
+      availability: 'unavailable',
+      text: null,
+      length: null,
+    },
+    sources: {
+      metadata: 'available',
+      description: 'unavailable',
+      pages: 'unavailable',
+      chapters: 'unknown',
+      transcript: 'unavailable',
+      contentText: 'unavailable',
+    },
+    warnings: ['transcript_unavailable'],
+  };
+}


### PR DESCRIPTION
Closes #73

## Scope

- replace popup `currentWindow` tab lookup with a background resolver that inspects active tabs from normal browser windows and selects the freshest eligible Bilibili video tab instead of the popup extension window
- reuse the same resolved tab/context path for `GET_CURRENT_VIDEO_CONTEXT`, current-video summary, Video Knowledge, and manual Video Knowledge jump requests
- clear cached current-video context on tab URL changes when the tab leaves Bilibili video pages or switches to a different BVID, so popup requests do not reuse stale tab context
- add focused resolver coverage for active-tab priority, non-video fallback, stale/mismatched context rejection, and no-URL fallback

## Validation

- `node --test tests/current-video-context-resolver.test.ts`
- `npm run test:current-video-summary`
- `npm run test:video-knowledge`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- `rg -n ^import\\s dist/content/player-monitor.js`
- `rg -n 未消费|猜你喜欢 dashboard popup public src README.md tests`
- clean temporary Edge profile smoke with unpacked `dist/` extension on `https://www.bilibili.com/video/BV1tg411z7n3/`

## Smoke Result

- page overlay still loads on a public Bilibili video page and keeps current-video metadata/description context
- opening the floating popup now keeps resolving the Bilibili video tab instead of the popup extension window
- Popup Current Video Assistant shows the same current-video context (`BV1tg411z7n3`) instead of `no-context`
- Popup Video Knowledge v0 now sees the same current-video context and rendered metadata/description nodes in the clean-profile smoke
- `dist/content/player-monitor.js` still has no top-level ESM `import`
- the existing Vite large chunk warning for `chunks/theme-*.js` remains non-blocking build hygiene

## Blocker

- none in this PR; this should unblock rerunning #63 from latest `main`

## Must-Fix

- rerun #63 clean smoke from latest `main` after this PR merges
- clean PR #70 back to smoke-report-only after the rerun, because it currently documents a blocker flow and should stay draft/open until the rerun passes

## Follow-Up

- if release owners want stronger resilience later, persist or actively re-request current-video context across MV3 service-worker restarts instead of relying only on in-memory context reports
- keep recording the large Vite chunk warning as non-blocking unless a bundle-size issue is opened

## Privacy Boundary

- did not read local key files, Cookie files, browser profile files, or Bilibili login-state files from disk
- used only clean temporary browser profiles for smoke verification
- did not upload full local history, favorites, following, feedback, or database contents
- did not write back to Bilibili