### PR TITLE
[codex] Fix Smart Favorites sync and index coverage

### DIFF
--- a/dashboard/modules/favorites/SmartFavoritesPage.tsx
+++ b/dashboard/modules/favorites/SmartFavoritesPage.tsx
@@ -87,9 +87,9 @@ export function SmartFavoritesPage() {
       const result = await requestSW<FavoriteSyncResult>('SYNC_FAVORITES');
       if (result.status === 'blocked') {
         setError(result.blockedReason ?? 'Favorite sync incomplete; available data was kept.');
-        setNotice(`Sync incomplete: kept/updated ${result.insertedOrUpdated} usable videos, deleted nothing. Reported ${result.reportedItems}, fetched ${result.items}, filtered ${result.filteredItems}; see audit below.`);
+        setNotice(`Sync incomplete: kept/updated ${result.insertedOrUpdated} usable videos, deleted nothing. Bilibili reported ${result.reportedItems}, newly stored ${result.items}, filtered ${result.filteredItems}; see audit below.`);
       } else {
-        setNotice(`Sync complete: ${result.folders} folders, ${result.items} videos, ${result.filteredItems} filtered resources.`);
+        setNotice(`Sync complete: ${result.folders} folders, ${result.items} locally stored videos, ${result.filteredItems} filtered resources.`);
       }
       setOverview(await requestSW<SmartFavoriteOverview>('GET_SMART_FAVORITES'));
     } catch (e) {
@@ -225,11 +225,17 @@ export function SmartFavoritesPage() {
 
       <section style={CARD}>
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: '8px', marginBottom: '12px' }}>
-          <Metric label="收藏夹" value={overview?.folders.length ?? 0} />
-          <Metric label="收藏视频" value={overview?.totalItems ?? 0} />
-          <Metric label="索引成功" value={overview?.indexedItems ?? 0} />
-          <Metric label="索引失败" value={overview?.failedItems ?? 0} />
-          <Metric label="待索引" value={overview?.pendingItems ?? 0} />
+          <Metric label="Folders" value={overview?.folders.length ?? 0} />
+          <Metric label="Bilibili reported" value={overview?.reportedItems ?? 0} />
+          <Metric label="Locally stored" value={overview?.storedItems ?? 0} />
+          <Metric label="Indexed" value={overview?.indexedItems ?? 0} />
+          <Metric label="Failed" value={overview?.failedItems ?? 0} />
+          <Metric label="Pending" value={overview?.pendingItems ?? 0} />
+        </div>
+        <div style={{ color: overview?.lastSyncDiagnostics.length && overview?.syncComplete === false ? '#FFB347' : '#9090A0', fontSize: '12px', lineHeight: 1.5, marginBottom: '12px' }}>
+          {overview?.lastSyncDiagnostics.length && overview?.syncComplete === false
+            ? `Favorite sync is incomplete in ${overview.incompleteFolders} folder(s). Smart index coverage is scoped to the current local snapshot: Bilibili reported ${overview.reportedItems}, locally stored ${overview.storedItems}, indexed ${overview.indexedItems}, failed ${overview.failedItems}, pending ${overview.pendingItems}.`
+            : `Smart index coverage only applies to locally stored favorites: Bilibili reported ${overview?.reportedItems ?? 0}, locally stored ${overview?.storedItems ?? 0}, indexed ${overview?.indexedItems ?? 0}, failed ${overview?.failedItems ?? 0}, pending ${overview?.pendingItems ?? 0}.`}
         </div>
         <SyncDiagnostics diagnostics={overview?.lastSyncDiagnostics ?? []} />
         <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
@@ -605,19 +611,23 @@ function SyncDiagnostics({ diagnostics }: { diagnostics: FavoriteFolderSyncDiagn
 
   const totals = diagnostics.reduce((sum, diagnostic) => ({
     reported: sum.reported + diagnostic.reportedMediaCount,
+    requestedPages: sum.requestedPages + diagnostic.requestedPages,
+    fetchedPages: sum.fetchedPages + diagnostic.pagesFetched,
     stored: sum.stored + diagnostic.storedVideoItems,
     filtered: sum.filtered + diagnostic.filteredItems,
     delta: sum.delta + diagnostic.unexplainedDelta,
-    errors: sum.errors + diagnostic.errors.length,
-  }), { reported: 0, stored: 0, filtered: 0, delta: 0, errors: 0 });
+    errors: sum.errors + diagnostic.pageErrors,
+    incomplete: sum.incomplete + (diagnostic.completenessState === 'incomplete' ? 1 : 0),
+  }), { reported: 0, requestedPages: 0, fetchedPages: 0, stored: 0, filtered: 0, delta: 0, errors: 0, incomplete: 0 });
+  const overallState = totals.incomplete > 0 ? 'incomplete' : 'complete';
 
   return (
     <div style={{ marginBottom: '12px', overflowX: 'auto' }}>
       <div style={{ color: '#FFFFFF', fontSize: '13px', fontWeight: 600, marginBottom: '6px' }}>
-        Sync audit: reported {totals.reported}, stored {totals.stored}, filtered {totals.filtered}, delta {totals.delta}, errors {totals.errors}
+        Sync audit: state {overallState}, reported {totals.reported}, requested/fetched pages {totals.requestedPages}/{totals.fetchedPages}, stored {totals.stored}, filtered {totals.filtered}, delta {totals.delta}, page errors {totals.errors}
       </div>
-      <div style={{ minWidth: '720px', display: 'grid', gridTemplateColumns: '1.5fr repeat(6, 72px) 1.8fr', gap: '1px', background: '#333355', border: '1px solid #333355', borderRadius: '6px', overflow: 'hidden' }}>
-        {['Folder', 'Reported', 'Pages', 'Raw', 'Stored', 'Filtered', 'Delta', 'Errors'].map(label => (
+      <div style={{ minWidth: '1080px', display: 'grid', gridTemplateColumns: '1.5fr 88px 88px 92px 72px 72px 180px 72px 2fr', gap: '1px', background: '#333355', border: '1px solid #333355', borderRadius: '6px', overflow: 'hidden' }}>
+        {['Folder', 'State', 'Reported', 'Req/Fetched', 'Raw', 'Stored', 'Filtered (u/mid/nv)', 'Delta', 'Page issues'].map(label => (
           <AuditCell key={label} header text={label} />
         ))}
         {diagnostics.map(diagnostic => (
@@ -629,16 +639,19 @@ function SyncDiagnostics({ diagnostics }: { diagnostics: FavoriteFolderSyncDiagn
 }
 
 function SyncDiagnosticRow({ diagnostic }: { diagnostic: FavoriteFolderSyncDiagnostic }) {
+  const filteredBreakdown = `${diagnostic.filteredItems} (${diagnostic.filteredUnavailableItems}/${diagnostic.filteredMissingIdItems}/${diagnostic.filteredNonVideoItems})`;
+  const pageIssues = diagnostic.pageErrors > 0 ? `${diagnostic.pageErrors}: ${diagnostic.errors.join(' | ')}` : '-';
   return (
     <>
       <AuditCell text={`${diagnostic.title || 'Untitled'} #${diagnostic.mediaId}`} />
+      <AuditCell text={diagnostic.completenessState} tone={diagnostic.completenessState === 'incomplete' ? 'error' : undefined} />
       <AuditCell text={String(diagnostic.reportedMediaCount)} tone={diagnostic.unexplainedDelta > 0 ? 'warn' : undefined} />
-      <AuditCell text={String(diagnostic.pagesFetched)} />
+      <AuditCell text={`${diagnostic.requestedPages}/${diagnostic.pagesFetched}`} tone={diagnostic.requestedPages > diagnostic.pagesFetched ? 'warn' : undefined} />
       <AuditCell text={String(diagnostic.rawResourcesSeen)} />
       <AuditCell text={String(diagnostic.storedVideoItems)} />
-      <AuditCell text={String(diagnostic.filteredItems)} />
+      <AuditCell text={filteredBreakdown} />
       <AuditCell text={String(diagnostic.unexplainedDelta)} tone={diagnostic.unexplainedDelta > 0 ? 'warn' : undefined} />
-      <AuditCell text={diagnostic.errors.join('; ') || '-'} tone={diagnostic.errors.length > 0 ? 'error' : undefined} />
+      <AuditCell text={pageIssues} tone={diagnostic.pageErrors > 0 ? 'error' : undefined} />
     </>
   );
 }

--- a/src/background/favorites/favorite-fetch-loop.ts
+++ b/src/background/favorites/favorite-fetch-loop.ts
@@ -1,3 +1,4 @@
+import { FAVORITE_SHORT_PAGE_RETRY_LIMIT } from '../../shared/constants.ts';
 import type { FavoriteFolder, FavoriteFolderSyncDiagnostic, FavoriteItem } from '../../shared/types/favorite';
 
 export interface FavoriteResourceApiItem {
@@ -50,6 +51,7 @@ export async function fetchFavoriteItemsWithPageFetcher(
     mediaId: folder.mediaId,
     title: folder.title,
     reportedMediaCount: Math.max(0, Number(folder.mediaCount ?? 0)),
+    requestedPages: 0,
     pagesFetched: 0,
     rawResourcesSeen: 0,
     storedVideoItems: 0,
@@ -57,26 +59,30 @@ export async function fetchFavoriteItemsWithPageFetcher(
     filteredMissingIdItems: 0,
     filteredNonVideoItems: 0,
     filteredItems: 0,
+    pageErrors: 0,
     hasMoreAfterStop: false,
     stoppedByMaxPages: false,
     unexplainedDelta: 0,
+    completenessState: 'complete',
     errors: [],
   };
 
   for (let pn = 1; pn <= maxPages; pn++) {
-    let data: FavoriteResourcesData;
-    try {
-      data = await fetchPage(pn, signal);
-    } catch (error) {
-      diagnostic.errors.push(`page ${pn}: ${error instanceof Error ? error.message : String(error)}`);
-      diagnostic.hasMoreAfterStop = true;
-      break;
-    }
+    const page = await fetchFavoritePageWithRetries(pn, fetchPage, signal, pageSize, diagnostic);
+    if (!page) break;
 
-    const medias = data.medias ?? [];
+    const medias = page.medias ?? [];
     diagnostic.pagesFetched++;
     diagnostic.rawResourcesSeen += medias.length;
-    if (medias.length === 0) break;
+    if (medias.length === 0) {
+      if (page.has_more === true) {
+        markDiagnosticIncomplete(
+          diagnostic,
+          `page ${pn}: has_more=true but returned 0/${pageSize} resources after ${page.attempts} attempt(s)`,
+        );
+      }
+      break;
+    }
 
     for (const media of medias) {
       const parsed = toFavoriteItem(media, folder, syncedAt);
@@ -89,29 +95,79 @@ export async function fetchFavoriteItemsWithPageFetcher(
       }
     }
 
-    if (data.has_more === false) break;
-    if (medias.length < pageSize) {
-      if (data.has_more === true) {
-        diagnostic.hasMoreAfterStop = true;
-        diagnostic.errors.push(`page ${pn}: has_more=true but returned ${medias.length}/${pageSize} resources`);
-      }
-      break;
+    if (page.has_more === false) break;
+    if (medias.length < pageSize && page.has_more === true) {
+      markDiagnosticIncomplete(
+        diagnostic,
+        `page ${pn}: has_more=true but returned ${medias.length}/${pageSize} resources after ${page.attempts} attempt(s)`,
+      );
     }
-    if (pn === maxPages && data.has_more === true) {
+    if (pn === maxPages && page.has_more === true) {
       diagnostic.hasMoreAfterStop = true;
       diagnostic.stoppedByMaxPages = true;
-      diagnostic.errors.push(`reached max page limit ${maxPages} while has_more=true`);
+      markDiagnosticIncomplete(diagnostic, `reached max page limit ${maxPages} while has_more=true`);
     }
   }
 
   diagnostic.storedVideoItems = result.length;
   diagnostic.filteredItems = diagnostic.filteredUnavailableItems + diagnostic.filteredMissingIdItems + diagnostic.filteredNonVideoItems;
+  diagnostic.pageErrors = diagnostic.errors.length;
   diagnostic.unexplainedDelta = Math.max(
     0,
     diagnostic.reportedMediaCount - diagnostic.storedVideoItems - diagnostic.filteredItems,
   );
+  if (diagnostic.pageErrors > 0 || diagnostic.hasMoreAfterStop || diagnostic.stoppedByMaxPages || diagnostic.unexplainedDelta > 0) {
+    diagnostic.completenessState = 'incomplete';
+  }
 
   return { items: result, diagnostic };
+}
+
+async function fetchFavoritePageWithRetries(
+  pageNumber: number,
+  fetchPage: FavoriteResourcePageFetcher,
+  signal: AbortSignal | undefined,
+  pageSize: number,
+  diagnostic: FavoriteFolderSyncDiagnostic,
+): Promise<(FavoriteResourcesData & { attempts: number }) | null> {
+  let attempts = 0;
+  let bestPage: FavoriteResourcesData | null = null;
+
+  while (attempts <= FAVORITE_SHORT_PAGE_RETRY_LIMIT) {
+    attempts++;
+    diagnostic.requestedPages++;
+
+    let data: FavoriteResourcesData;
+    try {
+      data = await fetchPage(pageNumber, signal);
+    } catch (error) {
+      markDiagnosticIncomplete(
+        diagnostic,
+        `page ${pageNumber}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      diagnostic.hasMoreAfterStop = true;
+      return bestPage ? { ...bestPage, attempts } : null;
+    }
+
+    const medias = data.medias ?? [];
+    if (!bestPage || medias.length > (bestPage.medias ?? []).length || data.has_more === false) {
+      bestPage = data;
+    }
+
+    if (data.has_more !== true) {
+      return { ...data, attempts };
+    }
+    if (medias.length === pageSize) {
+      return { ...data, attempts };
+    }
+  }
+
+  return bestPage ? { ...bestPage, attempts } : null;
+}
+
+function markDiagnosticIncomplete(diagnostic: FavoriteFolderSyncDiagnostic, message: string): void {
+  diagnostic.completenessState = 'incomplete';
+  diagnostic.errors.push(message);
 }
 
 function toFavoriteItem(

--- a/src/background/favorites/qa-core.ts
+++ b/src/background/favorites/qa-core.ts
@@ -12,6 +12,8 @@ import type {
   SmartFavoriteQaStatusKind,
   SmartFavoriteQaSyncCoverage,
 } from '../../shared/types/favorite';
+import { normalizeFavoriteFolderSyncDiagnostic } from '../../shared/favorite-sync-diagnostics.ts';
+import { summarizeSmartFavoriteIndexCoverage } from '../../shared/smart-favorite-coverage.ts';
 
 const DEFAULT_QA_LIMIT = 8;
 const MEDIUM_SCORE = 28;
@@ -111,10 +113,10 @@ export function buildSmartFavoriteQaResponse(input: SmartFavoriteQaInput): Smart
   const query = input.query.trim();
   const limit = Math.max(1, Math.min(Math.floor(input.limit ?? DEFAULT_QA_LIMIT), 20));
   const diagnostics = input.folders
-    .map(folder => folder.lastSyncDiagnostic)
+    .map(folder => folder.lastSyncDiagnostic ? normalizeFavoriteFolderSyncDiagnostic(folder.lastSyncDiagnostic) : undefined)
     .filter((diagnostic): diagnostic is FavoriteFolderSyncDiagnostic => diagnostic !== undefined);
   const syncCoverage = buildSyncCoverage(diagnostics);
-  const indexCoverage = buildIndexCoverage(input.items, input.indexes);
+  const indexCoverage = buildIndexCoverage(input.folders, input.items, input.indexes);
   const notes = buildCoverageNotes(syncCoverage, indexCoverage);
 
   if (!query) {
@@ -144,8 +146,8 @@ export function buildSmartFavoriteQaResponse(input: SmartFavoriteQaInput): Smart
       answerType: asksForUnsupportedContent ? 'insufficient_evidence' : 'no_result',
       query,
       answer: syncCoverage.complete
-        ? 'No matching favorite was found in the locally synced data.'
-        : 'No matching favorite was found in the currently synced data.',
+        ? 'No matching favorite was found in the locally synced favorites.'
+        : '当前已同步收藏中，未找到匹配的收藏。',
       confidence: 'low',
       evidenceSummary: asksForUnsupportedContent
         ? 'This local slice can only use favorite metadata and Smart Favorites index fields; transcript, comments, and video body text are not available.'
@@ -170,7 +172,7 @@ export function buildSmartFavoriteQaResponse(input: SmartFavoriteQaInput): Smart
     indexCoverage,
     asksForUnsupportedContent,
   });
-  const scopedPrefix = syncCoverage.complete ? 'In locally synced favorites' : 'In the currently synced favorite data';
+  const scopedPrefix = syncCoverage.complete ? 'In locally synced favorites' : '当前已同步收藏中';
   const answer = answerType === 'candidate_list'
     ? `${scopedPrefix}, there is not enough evidence for a firm answer. The closest cited candidates are listed below.`
     : `${scopedPrefix}, the strongest cited matches are listed below.`;
@@ -309,31 +311,20 @@ function buildSyncCoverage(diagnostics: FavoriteFolderSyncDiagnostic[]): SmartFa
   };
 }
 
-function buildIndexCoverage(items: FavoriteItem[], indexes: Map<string, SmartFavoriteIndex>): SmartFavoriteQaIndexCoverage {
-  const indexedItems = Array.from(indexes.values()).filter(index => index.status === 'indexed').length;
-  const failedItems = Array.from(indexes.values()).filter(index => index.status === 'failed').length;
-  const pendingItems = items.filter(item => !indexes.has(item.itemKey)).length;
-  const staleItems = items.filter(item => {
-    const index = indexes.get(item.itemKey);
-    return index !== undefined && item.syncedAt > index.indexedAt;
-  }).length;
-  const indexMissing = items.length > 0 && indexedItems === 0;
-  const staleIndex = staleItems > 0 || pendingItems > 0 || failedItems > 0;
-
-  return {
-    indexedItems,
-    failedItems,
-    pendingItems,
-    staleItems,
-    indexMissing,
-    staleIndex,
-  };
+function buildIndexCoverage(
+  folders: FavoriteFolder[],
+  items: FavoriteItem[],
+  indexes: Map<string, SmartFavoriteIndex>,
+): SmartFavoriteQaIndexCoverage {
+  return summarizeSmartFavoriteIndexCoverage(folders, items, indexes);
 }
 
 function buildCoverageNotes(syncCoverage: SmartFavoriteQaSyncCoverage, indexCoverage: SmartFavoriteQaIndexCoverage): string[] {
-  const notes: string[] = [];
+  const notes: string[] = [
+    `Index coverage: Bilibili reported ${indexCoverage.bilibiliReportedItems}, locally stored ${indexCoverage.storedItems}, indexed ${indexCoverage.indexedItems}, failed ${indexCoverage.failedItems}, pending ${indexCoverage.pendingItems}.`,
+  ];
   if (!syncCoverage.complete) {
-    notes.push('Favorite sync is incomplete; answers are scoped to the currently synced data.');
+    notes.push('Favorite sync is incomplete; answers are scoped to the currently synced favorites only.');
   }
   if (indexCoverage.indexMissing) {
     notes.push('Smart Favorites index is missing; only favorite metadata was used.');
@@ -453,16 +444,14 @@ function reasonForField(field: string): string {
 }
 
 function hasDiagnosticIssue(diagnostic: FavoriteFolderSyncDiagnostic): boolean {
-  return diagnostic.errors.length > 0
-    || diagnostic.hasMoreAfterStop
-    || diagnostic.stoppedByMaxPages
-    || diagnostic.unexplainedDelta > 0;
+  return diagnostic.completenessState === 'incomplete';
 }
 
 function buildIncompleteSyncNote(diagnostics: FavoriteFolderSyncDiagnostic[]): string {
   const samples = diagnostics.slice(0, 3).map(diagnostic => {
     const issues = [
-      diagnostic.errors.length > 0 ? `${diagnostic.errors.length} error(s)` : '',
+      diagnostic.pageErrors > 0 ? `${diagnostic.pageErrors} page error(s)` : '',
+      `requested/fetched ${diagnostic.requestedPages}/${diagnostic.pagesFetched}`,
       diagnostic.unexplainedDelta > 0 ? `delta ${diagnostic.unexplainedDelta}` : '',
       diagnostic.hasMoreAfterStop ? 'has_more after stop' : '',
       diagnostic.stoppedByMaxPages ? 'max pages reached' : '',

--- a/src/background/favorites/smart.ts
+++ b/src/background/favorites/smart.ts
@@ -7,9 +7,10 @@ import type {
   SmartFavoriteTreeNode,
   SmartIndexResult,
 } from '../../shared/types/favorite';
+import { normalizeFavoriteFoldersWithDiagnostics } from '../../shared/favorite-sync-diagnostics.ts';
+import { summarizeSmartFavoriteIndexCoverage } from '../../shared/smart-favorite-coverage.ts';
 import { loadConfig } from '../storage/config-store';
 import {
-  countIndexedFavorites,
   getFavoriteFolders,
   getFavoriteItems,
   getSmartFavoriteIndexMap,
@@ -122,25 +123,29 @@ function shouldProcessCandidate(
 }
 
 export async function getSmartFavoriteOverview(): Promise<SmartFavoriteOverview> {
-  const [folders, items, indexedItems, indexMap] = await Promise.all([
+  const [storedFolders, items, indexMap] = await Promise.all([
     getFavoriteFolders(),
     getFavoriteItems(),
-    countIndexedFavorites(),
     getSmartFavoriteIndexMap(),
   ]);
-  const failedItems = Array.from(indexMap.values()).filter(index => index.status === 'failed').length;
-  const pendingItems = Math.max(0, items.length - indexedItems - failedItems);
+  const folders = normalizeFavoriteFoldersWithDiagnostics(storedFolders);
+  const coverage = summarizeSmartFavoriteIndexCoverage(folders, items, indexMap);
+  const diagnostics = folders
+    .map(folder => folder.lastSyncDiagnostic)
+    .filter(diagnostic => diagnostic !== undefined);
 
   return {
     folders,
+    reportedItems: coverage.bilibiliReportedItems,
+    storedItems: coverage.storedItems,
     totalItems: items.length,
-    indexedItems,
-    failedItems,
-    pendingItems,
+    indexedItems: coverage.indexedItems,
+    failedItems: coverage.failedItems,
+    pendingItems: coverage.pendingItems,
+    incompleteFolders: diagnostics.filter(diagnostic => diagnostic.completenessState === 'incomplete').length,
+    syncComplete: diagnostics.length > 0 && diagnostics.every(diagnostic => diagnostic.completenessState === 'complete'),
     lastSyncedAt: Math.max(0, ...folders.map(folder => folder.syncedAt), ...items.map(item => item.syncedAt)),
-    lastSyncDiagnostics: folders
-      .map(folder => folder.lastSyncDiagnostic)
-      .filter(diagnostic => diagnostic !== undefined),
+    lastSyncDiagnostics: diagnostics,
     tree: buildTree(items, indexMap),
   };
 }

--- a/src/background/favorites/sync-audit.ts
+++ b/src/background/favorites/sync-audit.ts
@@ -8,18 +8,14 @@ export interface FavoriteSyncCompletenessAssessment {
 export function assessFavoriteSyncCompleteness(
   diagnostics: FavoriteFolderSyncDiagnostic[],
 ): FavoriteSyncCompletenessAssessment {
-  const failedFolders = diagnostics.filter(diagnostic =>
-    diagnostic.errors.length > 0
-    || diagnostic.hasMoreAfterStop
-    || diagnostic.stoppedByMaxPages
-    || diagnostic.unexplainedDelta > 0,
-  );
+  const failedFolders = diagnostics.filter(diagnostic => diagnostic.completenessState === 'incomplete');
 
   if (failedFolders.length === 0) return { complete: true };
 
   const samples = failedFolders.slice(0, 3).map(diagnostic => {
     const issues = [
-      diagnostic.errors.length > 0 ? `${diagnostic.errors.length} error(s)` : '',
+      diagnostic.pageErrors > 0 ? `${diagnostic.pageErrors} page error(s)` : '',
+      `requested/fetched ${diagnostic.requestedPages}/${diagnostic.pagesFetched}`,
       diagnostic.unexplainedDelta > 0 ? `delta ${diagnostic.unexplainedDelta}` : '',
       diagnostic.hasMoreAfterStop ? 'has_more after stop' : '',
       diagnostic.stoppedByMaxPages ? 'max pages reached' : '',

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -11,6 +11,7 @@ export const HISTORY_PAGE_SIZE = 30;
 export const MAX_BACKFILL_PAGES = 300;
 export const FAVORITE_PAGE_SIZE = 20;
 export const MAX_FAVORITE_SYNC_PAGES = 500;
+export const FAVORITE_SHORT_PAGE_RETRY_LIMIT = 2;
 export const DYNAMIC_UPDATE_WINDOW_DAYS = 7;
 export const DYNAMIC_FEED_MAX_PAGES = 80;
 export const FOLLOWING_PAGE_SIZE = 50;

--- a/src/shared/favorite-sync-diagnostics.ts
+++ b/src/shared/favorite-sync-diagnostics.ts
@@ -1,0 +1,66 @@
+import type { FavoriteFolder, FavoriteFolderSyncCompletenessState, FavoriteFolderSyncDiagnostic } from './types/favorite.ts';
+
+export function normalizeFavoriteFolderSyncDiagnostic(diagnostic: FavoriteFolderSyncDiagnostic): FavoriteFolderSyncDiagnostic {
+  const filteredItems = Number.isFinite(diagnostic.filteredItems)
+    ? diagnostic.filteredItems
+    : Math.max(
+      0,
+      Number(diagnostic.filteredUnavailableItems ?? 0)
+      + Number(diagnostic.filteredMissingIdItems ?? 0)
+      + Number(diagnostic.filteredNonVideoItems ?? 0),
+    );
+  const pageErrors = Number.isFinite(diagnostic.pageErrors)
+    ? diagnostic.pageErrors
+    : Array.isArray(diagnostic.errors) ? diagnostic.errors.length : 0;
+  const requestedPages = Number.isFinite(diagnostic.requestedPages)
+    ? diagnostic.requestedPages
+    : Math.max(0, Number(diagnostic.pagesFetched ?? 0));
+  const completenessState = diagnostic.completenessState ?? deriveFavoriteFolderSyncCompletenessState({
+    pageErrors,
+    errors: diagnostic.errors,
+    hasMoreAfterStop: diagnostic.hasMoreAfterStop,
+    stoppedByMaxPages: diagnostic.stoppedByMaxPages,
+    unexplainedDelta: diagnostic.unexplainedDelta,
+  });
+
+  return {
+    ...diagnostic,
+    filteredItems,
+    pageErrors,
+    requestedPages,
+    completenessState,
+  };
+}
+
+export function normalizeFavoriteFoldersWithDiagnostics(folders: FavoriteFolder[]): FavoriteFolder[] {
+  return folders.map(folder => {
+    if (!folder.lastSyncDiagnostic) return folder;
+    return {
+      ...folder,
+      lastSyncDiagnostic: normalizeFavoriteFolderSyncDiagnostic(folder.lastSyncDiagnostic),
+    };
+  });
+}
+
+export function deriveFavoriteFolderSyncCompletenessState(
+  diagnostic: Pick<
+    FavoriteFolderSyncDiagnostic,
+    'pageErrors' | 'errors' | 'hasMoreAfterStop' | 'stoppedByMaxPages' | 'unexplainedDelta'
+  >,
+): FavoriteFolderSyncCompletenessState {
+  return getFavoriteFolderSyncIssueCount(diagnostic) > 0 ? 'incomplete' : 'complete';
+}
+
+export function getFavoriteFolderSyncIssueCount(
+  diagnostic: Pick<
+    FavoriteFolderSyncDiagnostic,
+    'pageErrors' | 'errors' | 'hasMoreAfterStop' | 'stoppedByMaxPages' | 'unexplainedDelta'
+  >,
+): number {
+  return [
+    Math.max(0, Number(diagnostic.pageErrors ?? (diagnostic.errors?.length ?? 0))),
+    diagnostic.hasMoreAfterStop ? 1 : 0,
+    diagnostic.stoppedByMaxPages ? 1 : 0,
+    Math.max(0, Number(diagnostic.unexplainedDelta ?? 0)) > 0 ? 1 : 0,
+  ].reduce((sum, count) => sum + count, 0);
+}

--- a/src/shared/smart-favorite-coverage.ts
+++ b/src/shared/smart-favorite-coverage.ts
@@ -1,0 +1,57 @@
+import type { FavoriteFolder, FavoriteItem, SmartFavoriteIndex } from './types/favorite.ts';
+
+export interface SmartFavoriteIndexCoverageSummary {
+  bilibiliReportedItems: number;
+  storedItems: number;
+  indexedItems: number;
+  failedItems: number;
+  pendingItems: number;
+  staleItems: number;
+  indexMissing: boolean;
+  staleIndex: boolean;
+}
+
+export function summarizeSmartFavoriteIndexCoverage(
+  folders: FavoriteFolder[],
+  items: FavoriteItem[],
+  indexes: Map<string, SmartFavoriteIndex>,
+): SmartFavoriteIndexCoverageSummary {
+  let indexedItems = 0;
+  let failedItems = 0;
+  let pendingItems = 0;
+  let staleItems = 0;
+
+  for (const item of items) {
+    const index = indexes.get(item.itemKey);
+    if (!index) {
+      pendingItems++;
+      continue;
+    }
+
+    if (index.status === 'indexed') {
+      indexedItems++;
+    } else {
+      failedItems++;
+    }
+
+    if (item.syncedAt > index.indexedAt) {
+      staleItems++;
+    }
+  }
+
+  const storedItems = items.length;
+  const bilibiliReportedItems = folders.reduce((sum, folder) => sum + Math.max(0, Number(folder.mediaCount ?? 0)), 0);
+  const indexMissing = storedItems > 0 && indexedItems === 0;
+  const staleIndex = staleItems > 0 || pendingItems > 0 || failedItems > 0;
+
+  return {
+    bilibiliReportedItems,
+    storedItems,
+    indexedItems,
+    failedItems,
+    pendingItems,
+    staleItems,
+    indexMissing,
+    staleIndex,
+  };
+}

--- a/src/shared/smart-favorites-qa-synthesis.ts
+++ b/src/shared/smart-favorites-qa-synthesis.ts
@@ -21,7 +21,7 @@ export interface SmartFavoriteQaAiPayload {
   intent: 'smart_favorites_qa_synthesis';
   question: string;
   syncCoverage: SmartFavoriteQaAiSyncCoverage;
-  indexCoverage: SmartFavoriteQaResponse['status']['indexCoverage'];
+  indexCoverage: SmartFavoriteQaAiIndexCoverage;
   availableSources: {
     favoriteMetadata: true;
     smartIndex: boolean;
@@ -37,6 +37,15 @@ export interface SmartFavoriteQaAiSyncCoverage {
   diagnosticsCount: number;
   problemFolders: number;
   coverageStatus: 'complete' | 'incomplete';
+}
+
+export interface SmartFavoriteQaAiIndexCoverage {
+  indexedItems: number;
+  failedItems: number;
+  pendingItems: number;
+  staleItems: number;
+  indexMissing: boolean;
+  staleIndex: boolean;
 }
 
 export interface SmartFavoriteQaAiPayloadVideo {
@@ -95,7 +104,7 @@ export function buildSmartFavoriteQaAiPayload(
     intent: 'smart_favorites_qa_synthesis',
     question: limitText(response.query, MAX_TEXT.question),
     syncCoverage: toAiSyncCoverage(response.status.syncCoverage),
-    indexCoverage: response.status.indexCoverage,
+    indexCoverage: toAiIndexCoverage(response.status.indexCoverage),
     availableSources: {
       favoriteMetadata: true,
       smartIndex: response.status.indexCoverage.indexedItems > 0,
@@ -122,6 +131,19 @@ function toAiSyncCoverage(
     diagnosticsCount: coverage.diagnosticsCount,
     problemFolders: coverage.problemFolders,
     coverageStatus: coverage.complete ? 'complete' : 'incomplete',
+  };
+}
+
+function toAiIndexCoverage(
+  coverage: SmartFavoriteQaResponse['status']['indexCoverage'],
+): SmartFavoriteQaAiIndexCoverage {
+  return {
+    indexedItems: coverage.indexedItems,
+    failedItems: coverage.failedItems,
+    pendingItems: coverage.pendingItems,
+    staleItems: coverage.staleItems,
+    indexMissing: coverage.indexMissing,
+    staleIndex: coverage.staleIndex,
   };
 }
 

--- a/src/shared/types/favorite.ts
+++ b/src/shared/types/favorite.ts
@@ -62,14 +62,20 @@ export interface SmartFavoriteResult {
 
 export interface SmartFavoriteOverview {
   folders: FavoriteFolder[];
+  reportedItems: number;
+  storedItems: number;
   totalItems: number;
   indexedItems: number;
   failedItems: number;
   pendingItems: number;
+  incompleteFolders: number;
+  syncComplete: boolean;
   lastSyncedAt: number;
   lastSyncDiagnostics: FavoriteFolderSyncDiagnostic[];
   tree: SmartFavoriteTreeNode[];
 }
+
+export type FavoriteFolderSyncCompletenessState = 'complete' | 'incomplete';
 
 export type FavoriteSyncStatus = 'complete' | 'blocked';
 
@@ -77,6 +83,7 @@ export interface FavoriteFolderSyncDiagnostic {
   mediaId: number;
   title: string;
   reportedMediaCount: number;
+  requestedPages: number;
   pagesFetched: number;
   rawResourcesSeen: number;
   storedVideoItems: number;
@@ -84,9 +91,11 @@ export interface FavoriteFolderSyncDiagnostic {
   filteredMissingIdItems: number;
   filteredNonVideoItems: number;
   filteredItems: number;
+  pageErrors: number;
   hasMoreAfterStop: boolean;
   stoppedByMaxPages: boolean;
   unexplainedDelta: number;
+  completenessState: FavoriteFolderSyncCompletenessState;
   errors: string[];
 }
 
@@ -166,6 +175,8 @@ export interface SmartFavoriteQaSyncCoverage {
 }
 
 export interface SmartFavoriteQaIndexCoverage {
+  bilibiliReportedItems: number;
+  storedItems: number;
   indexedItems: number;
   failedItems: number;
   pendingItems: number;

--- a/tests/favorite-sync-audit.test.ts
+++ b/tests/favorite-sync-audit.test.ts
@@ -36,10 +36,43 @@ test('fetches all favorite resource pages until has_more is false', async () => 
   );
 
   assert.equal(result.items.length, 25);
+  assert.equal(result.diagnostic.requestedPages, 2);
   assert.equal(result.diagnostic.pagesFetched, 2);
   assert.equal(result.diagnostic.rawResourcesSeen, 25);
+  assert.equal(result.diagnostic.pageErrors, 0);
+  assert.equal(result.diagnostic.completenessState, 'complete');
   assert.equal(result.diagnostic.unexplainedDelta, 0);
   assert.deepEqual(result.diagnostic.errors, []);
+});
+
+test('retries short pages with has_more=true, continues, and still marks the folder incomplete', async () => {
+  const pageOneAttempts = [
+    { medias: makeVideos(18, 0), has_more: true },
+    { medias: makeVideos(18, 0), has_more: true },
+    { medias: makeVideos(18, 0), has_more: true },
+  ];
+  const pageTwo = { medias: makeVideos(2, 18), has_more: false };
+
+  const result = await fetchFavoriteItemsWithPageFetcher(
+    { ...folder, mediaCount: 20 },
+    async pageNumber => {
+      if (pageNumber === 1) {
+        return pageOneAttempts.shift() ?? { medias: [], has_more: false };
+      }
+      return pageTwo;
+    },
+    undefined,
+    500,
+    FAVORITE_PAGE_SIZE,
+  );
+
+  assert.equal(result.items.length, 20);
+  assert.equal(result.diagnostic.requestedPages, 4);
+  assert.equal(result.diagnostic.pagesFetched, 2);
+  assert.equal(result.diagnostic.pageErrors, 1);
+  assert.equal(result.diagnostic.completenessState, 'incomplete');
+  assert.equal(result.diagnostic.unexplainedDelta, 0);
+  assert.match(result.diagnostic.errors[0] ?? '', /has_more=true but returned 18\/20 resources after 3 attempt\(s\)/);
 });
 
 test('counts unavailable, non-video, and missing-id favorite resources as filtered', async () => {
@@ -63,6 +96,8 @@ test('counts unavailable, non-video, and missing-id favorite resources as filter
   assert.equal(result.diagnostic.filteredNonVideoItems, 1);
   assert.equal(result.diagnostic.filteredMissingIdItems, 1);
   assert.equal(result.diagnostic.filteredItems, 3);
+  assert.equal(result.diagnostic.pageErrors, 0);
+  assert.equal(result.diagnostic.completenessState, 'complete');
   assert.equal(result.diagnostic.unexplainedDelta, 0);
 });
 
@@ -71,6 +106,7 @@ test('blocks incomplete favorite sync diagnostics before snapshot replacement', 
     mediaId: 100,
     title: 'Default',
     reportedMediaCount: 158,
+    requestedPages: 7,
     pagesFetched: 7,
     rawResourcesSeen: 137,
     storedVideoItems: 137,
@@ -78,9 +114,11 @@ test('blocks incomplete favorite sync diagnostics before snapshot replacement', 
     filteredMissingIdItems: 0,
     filteredNonVideoItems: 0,
     filteredItems: 0,
+    pageErrors: 0,
     hasMoreAfterStop: false,
     stoppedByMaxPages: false,
     unexplainedDelta: 21,
+    completenessState: 'incomplete',
     errors: [],
   }];
 
@@ -88,6 +126,7 @@ test('blocks incomplete favorite sync diagnostics before snapshot replacement', 
 
   assert.equal(assessment.complete, false);
   assert.match(assessment.reason ?? '', /FAVORITE_SYNC_INCOMPLETE/);
+  assert.match(assessment.reason ?? '', /requested\/fetched 7\/7/);
   assert.match(assessment.reason ?? '', /delta 21/);
 });
 
@@ -167,6 +206,7 @@ function makeIncompleteDiagnostic(): FavoriteFolderSyncDiagnostic {
     mediaId: 100,
     title: 'Default',
     reportedMediaCount: 158,
+    requestedPages: 7,
     pagesFetched: 7,
     rawResourcesSeen: 137,
     storedVideoItems: 137,
@@ -174,9 +214,11 @@ function makeIncompleteDiagnostic(): FavoriteFolderSyncDiagnostic {
     filteredMissingIdItems: 0,
     filteredNonVideoItems: 0,
     filteredItems: 0,
+    pageErrors: 0,
     hasMoreAfterStop: false,
     stoppedByMaxPages: false,
     unexplainedDelta: 21,
+    completenessState: 'incomplete',
     errors: [],
   };
 }

--- a/tests/smart-favorites-qa.test.ts
+++ b/tests/smart-favorites-qa.test.ts
@@ -93,13 +93,15 @@ test('marks answers when the Smart Favorites index is stale', () => {
   });
 
   assert.equal(response.status.kind, 'stale_index');
+  assert.equal(response.status.indexCoverage.bilibiliReportedItems, 1);
+  assert.equal(response.status.indexCoverage.storedItems, 1);
   assert.equal(response.status.indexCoverage.staleItems, 1);
   assert.match(response.status.notes.join(' '), /stale or partial/);
 });
 
 test('scopes answers to currently synced data when sync diagnostics are incomplete', () => {
   const item = makeFavoriteItem(1, { title: 'Creator workflow automation' });
-  const folder = makeFolder({ lastSyncDiagnostic: makeIncompleteDiagnostic() });
+  const folder = makeFolder({ mediaCount: 20, lastSyncDiagnostic: makeIncompleteDiagnostic() });
 
   const response = buildSmartFavoriteQaResponse({
     query: 'creator workflow',
@@ -111,7 +113,32 @@ test('scopes answers to currently synced data when sync diagnostics are incomple
   assert.equal(response.status.kind, 'incomplete_sync');
   assert.equal(response.status.syncCoverage.complete, false);
   assert.equal(response.status.syncCoverage.problemFolders, 1);
-  assert.match(response.answer, /currently synced/);
+  assert.match(response.answer, /当前已同步收藏中/);
+  assert.match(response.status.notes.join(' '), /Index coverage: Bilibili reported 20, locally stored 1, indexed 0, failed 0, pending 1/);
+});
+
+test('reports index coverage counts for Bilibili reported, locally stored, indexed, failed, and pending items', () => {
+  const indexed = makeFavoriteItem(1, { title: 'Indexed item' });
+  const failed = makeFavoriteItem(2, { title: 'Failed item' });
+  const pending = makeFavoriteItem(3, { title: 'Pending item' });
+  const failedIndex = makeIndex(failed, { status: 'failed' });
+
+  const response = buildSmartFavoriteQaResponse({
+    query: 'item',
+    items: [indexed, failed, pending],
+    indexes: new Map([
+      [indexed.itemKey, makeIndex(indexed, { keywords: ['item'] })],
+      [failed.itemKey, failedIndex],
+    ]),
+    folders: [makeFolder({ mediaCount: 5 })],
+  });
+
+  assert.equal(response.status.indexCoverage.bilibiliReportedItems, 5);
+  assert.equal(response.status.indexCoverage.storedItems, 3);
+  assert.equal(response.status.indexCoverage.indexedItems, 1);
+  assert.equal(response.status.indexCoverage.failedItems, 1);
+  assert.equal(response.status.indexCoverage.pendingItems, 1);
+  assert.match(response.status.notes.join(' '), /indexed 1, failed 1, pending 1/);
 });
 
 test('generates optional AI synthesis from cited videos only', async () => {
@@ -294,6 +321,8 @@ test('redacts incomplete sync diagnostic folder details from Smart Favorites Q&A
   assert.equal(payload.syncCoverage.problemFolders, 1);
   assert.equal(payload.syncCoverage.coverageStatus, 'incomplete');
   assert.equal('note' in payload.syncCoverage, false);
+  assert.equal('bilibiliReportedItems' in payload.indexCoverage, false);
+  assert.equal('storedItems' in payload.indexCoverage, false);
   assert.doesNotMatch(rawPayload, /Private research folder/);
   assert.doesNotMatch(rawPayload, /987654/);
   assert.doesNotMatch(rawPayload, /FAVORITE_SYNC_INCOMPLETE/);
@@ -386,6 +415,7 @@ function makeIncompleteDiagnostic(overrides: Partial<FavoriteFolderSyncDiagnosti
     mediaId: 100,
     title: 'Default',
     reportedMediaCount: 20,
+    requestedPages: 1,
     pagesFetched: 1,
     rawResourcesSeen: 10,
     storedVideoItems: 10,
@@ -393,9 +423,11 @@ function makeIncompleteDiagnostic(overrides: Partial<FavoriteFolderSyncDiagnosti
     filteredMissingIdItems: 0,
     filteredNonVideoItems: 0,
     filteredItems: 0,
+    pageErrors: 1,
     hasMoreAfterStop: true,
     stoppedByMaxPages: false,
     unexplainedDelta: 10,
+    completenessState: 'incomplete',
     errors: [],
     ...overrides,
   };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "outDir": "dist",
     "rootDir": ".",


### PR DESCRIPTION
## Summary
- tighten Smart Favorites sync completeness diagnostics so each folder explicitly shows reported count, requested/fetched pages, raw resources, stored videos, filtered counts, unexplained delta, page issues, and final completeness state
- retry short `has_more=true` pages, continue collecting usable data, and mark the folder/sync incomplete instead of silently treating the snapshot as complete
- keep incomplete syncs non-destructive, and clarify Smart Favorites / AI index coverage as Bilibili reported vs locally stored vs indexed vs failed vs pending

## Root cause judgment
The user-visible mismatch came from two related issues:
1. Smart Favorites sync treated short `has_more=true` pages as if the crawl had simply ended, so the run could look close to complete while still missing items.
2. AI index coverage was only being interpreted against locally stored favorites, but the product surface did not clearly separate Bilibili-reported counts from locally stored counts, so partial syncs looked like AI indexing coverage bugs.

## Diagnostics added
- per-folder completeness state plus requested/fetched page counts and page issue counts
- explicit filtered breakdown for unavailable, missing-id, and non-video resources
- overview counts for Bilibili reported, locally stored, indexed, failed, pending, and incomplete folder count
- incomplete-sync Q&A scoping that explicitly says answers are limited to the currently synced favorites

## Fix behavior
- short pages with `has_more=true` are retried safely before the sync proceeds
- if the anomaly persists, the sync keeps usable data, marks the folder/snapshot incomplete, and avoids destructive snapshot replacement
- Smart Favorites overview and Q&A now explain that AI indexing covers the current local snapshot, not the full reported folder count when sync is incomplete
- AI synthesis payloads still keep the tighter privacy boundary and do not receive the expanded local-only coverage counters

## Validation
- `git diff --check`
- `npm run test:favorites`
- `npm run typecheck`
- `npm run build`
- Extension-runtime smoke test not run in this task

## Blocker / Must-fix / Follow-up
- blocker: none
- must-fix: none identified from local validation
- follow-up: verify against a real logged-in favorites account that exhibits repeated short-page responses to confirm the runtime diagnostics match the real Bilibili behavior and to observe whether later pages recover the missing items or leave a persistent unexplained delta

## Privacy boundary
- did not read `C:\Users\LittleNub\Desktop\Key.txt`
- did not read cookies, browser profiles, or Bilibili login-state files
- did not upload full favorites/history/following/local DB contents
- did not write back to Bilibili favorites

Closes #78
