### PR TITLE
[codex] Fix history backfill and streak diagnostics

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -11,6 +11,7 @@ import { BehaviorPage } from './modules/behavior/BehaviorPage';
 import { ExperimentsPage } from './modules/experiments/ExperimentsPage';
 import { SmartFavoritesPage } from './modules/favorites/SmartFavoritesPage';
 import type { WatchHistoryRecord } from '../src/shared/types/watch-event';
+import type { HistorySyncStatus } from '../src/shared/types/history-sync';
 
 const NAV_ITEMS = [
   { id: 'overview', label: '总览', caption: '观看历史概览', shortLabel: '览' },
@@ -49,7 +50,7 @@ export function App() {
   const [exporting, setExporting] = useState(false);
 
   useEffect(() => {
-    requestSW<{ lastSyncTime: number; totalRecords: number }>('GET_SYNC_STATUS').then(s => {
+    requestSW<HistorySyncStatus>('GET_SYNC_STATUS').then(s => {
       if (s.lastSyncTime > 0) {
         const d = new Date(s.lastSyncTime);
         setSynced(`已同步 ${s.totalRecords} 条记录 · 最后更新: ${d.toLocaleString('zh-CN')}`);

--- a/dashboard/modules/overview/OverviewPage.tsx
+++ b/dashboard/modules/overview/OverviewPage.tsx
@@ -2,13 +2,14 @@ import { useEffect, useState } from 'preact/hooks';
 import { overviewData, overviewLoading, overviewError } from '../../signals';
 import { requestSW } from '../../utils/messaging';
 import type { DashboardOverview } from '../../../src/shared/types/analytics';
+import type { HistorySyncProgress } from '../../../src/shared/types/history-sync';
 import { ChartContainer } from '../../components/ChartContainer';
 import { StatCard } from '../../components/StatCard';
 import { LoadingSkeleton } from '../../components/LoadingSkeleton';
 import { EmptyState } from '../../components/EmptyState';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
 import { formatTimeHHMM, formatPercent, formatDate } from '../../../src/shared/utils/format';
-import { HOUR_LABELS, WEEKDAY_LABELS, BILI_PINK, CHART_COLORS } from '../../../src/shared/constants';
+import { HOUR_LABELS, WEEKDAY_LABELS, BILI_PINK } from '../../../src/shared/constants';
 import type { EChartsOption } from 'echarts';
 
 interface DeviceData {
@@ -48,7 +49,15 @@ export function OverviewPage() {
     grid: { top: 30, right: 20, bottom: 20, left: 50 },
     xAxis: { type: 'category', data: HOUR_LABELS, splitArea: { show: true } },
     yAxis: { type: 'category', data: WEEKDAY_LABELS, splitArea: { show: true } },
-    visualMap: { min: 0, max: maxHeat, calculable: true, orient: 'horizontal', left: 'center', bottom: 0, inRange: { color: ['#1A1A2E', '#00A1D6', '#FB7299'] } },
+    visualMap: {
+      min: 0,
+      max: maxHeat,
+      calculable: true,
+      orient: 'horizontal',
+      left: 'center',
+      bottom: 0,
+      inRange: { color: ['#1A1A2E', '#00A1D6', '#FB7299'] },
+    },
     series: [{
       type: 'heatmap' as const,
       data: d.hourlyHeatmap.flatMap((row, hour) => row.map((val, day) => [hour, day, val])),
@@ -63,7 +72,7 @@ export function OverviewPage() {
       type: 'pie' as const,
       radius: ['40%', '70%'],
       center: ['50%', '50%'],
-      data: device.breakdown.map((b, i) => ({
+      data: device.breakdown.map(b => ({
         name: b.label,
         value: Math.round(b.watchTime / 60),
       })),
@@ -75,13 +84,13 @@ export function OverviewPage() {
   const hourlyMax = device ? Math.max(...device.hourly.mobile, ...device.hourly.pc, 1) : 1;
   const deviceHourlyOption = device ? {
     tooltip: { trigger: 'axis' as const },
-    legend: { textStyle: { color: '#A0A0B0' }, top: 0, data: ['手机/平板', 'PC'] },
+    legend: { textStyle: { color: '#A0A0B0' }, top: 0, data: ['Mobile/Tablet', 'PC'] },
     grid: { top: 30, right: 10, bottom: 20, left: 40 },
     xAxis: { type: 'category' as const, data: HOUR_LABELS },
     yAxis: { type: 'value' as const, show: false, max: Math.ceil(hourlyMax / 60) },
     series: [
       {
-        name: '手机/平板',
+        name: 'Mobile/Tablet',
         type: 'line' as const,
         data: device.hourly.mobile.map(v => Math.round(v / 60)),
         smooth: true,
@@ -101,9 +110,10 @@ export function OverviewPage() {
     ],
   } : null;
 
-  const recordRangeText = d.oldestRecordDate && d.newestRecordDate
-    ? `本地历史：${formatDate(d.oldestRecordDate)} - ${formatDate(d.newestRecordDate)}`
-    : '本地历史：暂无记录';
+  const historyRangeText = d.oldestRecordDate && d.newestRecordDate
+    ? `本地历史范围：${formatDate(d.oldestRecordDate)} - ${formatDate(d.newestRecordDate)}`
+    : '本地历史范围：暂无记录';
+  const coverageTone = d.historyCoverageStatus === 'complete' ? '#00D4AA' : d.historyCoverageStatus === 'partial' ? '#FFB347' : '#9090A0';
 
   return (
     <ErrorBoundary>
@@ -113,6 +123,7 @@ export function OverviewPage() {
           <StatCard label="本月观看" value={formatTimeHHMM(d.monthlyWatchTime)} change={d.monthlyChange} accent="#00A1D6" />
           <StatCard label="平均完播率" value={formatPercent(d.avgCompletion)} accent="#00D4AA" />
         </div>
+
         <div style={{
           display: 'grid',
           gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
@@ -127,25 +138,53 @@ export function OverviewPage() {
             本月范围：{formatDate(d.monthStart)} - {formatDate(d.monthEnd)}，命中 {d.monthlyRecordCount} 条
           </div>
         </div>
+
         <div style={{ color: '#707080', fontSize: '11px', padding: '0 2px' }}>
-          {recordRangeText}；本周已计入 PC {formatTimeHHMM(d.weeklyLocalPcWatchTime)}，覆盖 {d.weeklyLocalPcDays} 天
+          {historyRangeText}；本周已计入 PC {formatTimeHHMM(d.weeklyLocalPcWatchTime)}，覆盖 {d.weeklyLocalPcDays} 天
         </div>
         <div style={{ color: '#606070', fontSize: '11px', padding: '0 2px' }}>
-          数据来源：B站历史记录用于跨设备估算；本机 PC 播放事件用于修正网页端实际观看。
+          数据来源：B 站历史用于跨设备估算，本机 PC 播放事件用于修正网页端有效观看。
         </div>
+
+        <div style={{
+          background: '#222244',
+          borderRadius: '10px',
+          padding: '12px',
+          borderLeft: `3px solid ${coverageTone}`,
+        }}>
+          <div style={{ color: '#FFFFFF', fontSize: '14px', fontWeight: 700, marginBottom: '6px' }}>
+            历史覆盖诊断：{coverageLabel(d.historyCoverageStatus)}
+          </div>
+          <div style={{ color: '#A0A0B0', fontSize: '12px', lineHeight: 1.6 }}>
+            {d.historyCoverageNote}
+          </div>
+          <div style={{ color: d.streakTrustworthy ? '#00D4AA' : '#FFB347', fontSize: '12px', lineHeight: 1.6, marginTop: '6px' }}>
+            连续天数可信度：{d.streakTrustworthy ? '可信' : '覆盖不足'}
+          </div>
+          <div style={{ color: '#9090A0', fontSize: '11px', lineHeight: 1.6 }}>
+            {d.streakCoverageNote}
+          </div>
+          {d.historySyncDiagnostics && (
+            <div style={{ marginTop: '8px', color: '#C8C8D8', fontSize: '11px', lineHeight: 1.6 }}>
+              {formatHistorySyncDiagnostics(d.historySyncDiagnostics)}
+            </div>
+          )}
+        </div>
+
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '8px' }}>
           <DetailStatCard
             label="当前连续"
-            value={`${d.streakDays}天`}
+            value={`${d.streakDays} 天`}
             detail={formatDateRange(d.streakStartDate, d.streakEndDate)}
+            accent={d.streakTrustworthy ? BILI_PINK : '#FFB347'}
           />
           <DetailStatCard
             label="最长连续"
-            value={`${d.longestStreak}天`}
+            value={`${d.longestStreak} 天`}
             detail={formatDateRange(d.longestStreakStartDate, d.longestStreakEndDate)}
-            accent="#00A1D6"
+            accent={d.streakTrustworthy ? '#00A1D6' : '#FFB347'}
           />
-          <StatCard label="效率评分" value={`${d.efficiencyScore}分`} />
+          <StatCard label="效率评分" value={`${d.efficiencyScore} 分`} />
         </div>
 
         {device && (
@@ -154,24 +193,16 @@ export function OverviewPage() {
               {device.breakdown.map(b => (
                 <StatCard
                   key={b.deviceType}
-                  label={`${b.label}端`}
+                  label={`${b.label} 端`}
                   value={formatTimeHHMM(b.watchTime)}
                   accent={b.deviceType <= 2 ? BILI_PINK : '#00A1D6'}
                 />
               ))}
-              {device.breakdown.length === 0 && <StatCard label="全设备" value="-" />}
+              {device.breakdown.length === 0 && <StatCard label="全部设备" value="-" />}
             </div>
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' }}>
-              <StatCard
-                label="手机端完播率"
-                value={formatPercent(device.deviceCompletion.mobile)}
-                accent={BILI_PINK}
-              />
-              <StatCard
-                label="PC端完播率"
-                value={formatPercent(device.deviceCompletion.pc)}
-                accent="#00A1D6"
-              />
+              <StatCard label="手机端完播率" value={formatPercent(device.deviceCompletion.mobile)} accent={BILI_PINK} />
+              <StatCard label="PC 端完播率" value={formatPercent(device.deviceCompletion.pc)} accent="#00A1D6" />
             </div>
             {devicePieOption && (
               <div style={{ background: '#222244', borderRadius: '10px', padding: '12px' }}>
@@ -236,8 +267,46 @@ function DetailStatCard({
   );
 }
 
+function coverageLabel(status: DashboardOverview['historyCoverageStatus']): string {
+  switch (status) {
+    case 'complete':
+      return '已确认到达历史末尾';
+    case 'partial':
+      return '仅覆盖局部历史';
+    default:
+      return '尚无诊断';
+  }
+}
+
 function formatDateRange(startDate: string | null, endDate: string | null): string {
   if (!startDate || !endDate) return '暂无连续时间段';
   if (startDate === endDate) return formatDate(startDate);
   return `${formatDate(startDate)} - ${formatDate(endDate)}`;
+}
+
+function formatHistorySyncDiagnostics(progress: HistorySyncProgress): string {
+  const parts = [
+    `mode=${progress.mode ?? 'unknown'}`,
+    `requested=${progress.requestedPageLimit ?? 'default'} pages`,
+    `normalized=${progress.pageLimit} pages`,
+    `fetchedPages=${progress.fetchedPages}`,
+    `fetchedItems=${progress.fetchedCount}`,
+    `inserted=${progress.insertedCount}`,
+    `updated=${progress.updatedCount}`,
+    `skipped=${progress.skippedCount}`,
+    `range=${formatViewAt(progress.oldestFetchedAt)} -> ${formatViewAt(progress.newestFetchedAt)}`,
+    `stoppedReason=${progress.stoppedReason}`,
+    `reachedEnd=${String(progress.reachedEnd)}`,
+  ];
+  if (progress.finalCursor) {
+    parts.push(
+      `cursor(max=${progress.finalCursor.max ?? 'null'}, view_at=${progress.finalCursor.viewAt ?? 'null'}, business=${progress.finalCursor.business ?? 'null'}, has_more=${progress.finalCursor.hasMore == null ? 'null' : String(progress.finalCursor.hasMore)})`,
+    );
+  }
+  return parts.join(' · ');
+}
+
+function formatViewAt(value: number | null): string {
+  if (!value) return 'n/a';
+  return new Date(value * 1000).toLocaleString('zh-CN');
 }

--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -2,7 +2,8 @@ import { useEffect, useRef, useState } from 'preact/hooks';
 import { quickStats, loading, error, lastSyncResult, syncInProgress, syncProgress, syncPageLimit } from './signals';
 import { requestSW } from './utils/messaging';
 import type { QuickStats } from '../src/shared/types/analytics';
-import type { SyncNowResult, SyncProgress } from '../src/shared/types/messages';
+import type { SyncNowResult } from '../src/shared/types/messages';
+import type { HistorySyncProgress, HistorySyncStatus } from '../src/shared/types/history-sync';
 import type { CurrentVideoContextResult } from '../src/shared/types/current-video-context';
 import type { CurrentVideoSummaryResult } from '../src/shared/types/current-video-summary';
 import type { VideoKnowledgeJumpResponse, VideoKnowledgeNode, VideoKnowledgeResult } from '../src/shared/types/video-knowledge';
@@ -10,12 +11,6 @@ import { cancelledCurrentVideoSummary, loadingCurrentVideoSummary } from '../src
 import { ProgressRing } from './components/ProgressRing';
 import { QuickStats as QuickStatsPanel } from './components/QuickStats';
 import { OpenDashboard } from './components/OpenDashboard';
-
-interface SyncStatus {
-  lastSyncTime: number;
-  totalRecords: number;
-  syncProgress: SyncProgress | null;
-}
 
 export function App() {
   const [currentVideoContext, setCurrentVideoContext] = useState<CurrentVideoContextResult | null>(null);
@@ -37,7 +32,7 @@ export function App() {
 
   async function refreshSyncStatus() {
     try {
-      const status = await requestSW<SyncStatus>('GET_SYNC_STATUS');
+      const status = await requestSW<HistorySyncStatus>('GET_SYNC_STATUS');
       syncProgress.value = status.syncProgress;
       syncInProgress.value = status.syncProgress?.syncing ?? false;
 

--- a/popup/signals.ts
+++ b/popup/signals.ts
@@ -1,13 +1,14 @@
 import { signal, computed } from '@preact/signals';
 import type { QuickStats } from '../src/shared/types/analytics';
-import type { SyncNowResult, SyncProgress } from '../src/shared/types/messages';
+import type { SyncNowResult } from '../src/shared/types/messages';
+import type { HistorySyncProgress } from '../src/shared/types/history-sync';
 
 export const quickStats = signal<QuickStats | null>(null);
 export const loading = signal(true);
 export const error = signal<string | null>(null);
 export const lastSyncResult = signal<SyncNowResult | null>(null);
 export const syncInProgress = signal(false);
-export const syncProgress = signal<SyncProgress | null>(null);
+export const syncProgress = signal<HistorySyncProgress | null>(null);
 export const syncPageLimit = signal(50);
 
 export const completionPercent = computed(() => {

--- a/src/background/analytics/metrics.ts
+++ b/src/background/analytics/metrics.ts
@@ -1,11 +1,14 @@
 import type { WatchHistoryRecord, DailyAggregate } from '../../shared/types/watch-event';
 import type { DashboardOverview, QuickStats } from '../../shared/types/analytics';
-import { startOfWeek, startOfMonth, daysAgo, dateKey, daysBetween } from '../../shared/utils/time';
+import { assessHistoryCoverage } from '../../shared/history-sync-diagnostics';
+import { computeStreakFromDateSet } from '../../shared/streak';
+import { startOfWeek, startOfMonth, daysAgo, dateKey } from '../../shared/utils/time';
 import { percentChange } from '../../shared/utils/math';
-import { getNewestRecord, getOldestRecord, getRecordsByDateRange } from '../storage/watch-history-repo';
+import { getNewestRecord, getOldestRecord, getRecordsByDateRange, getTotalCount } from '../storage/watch-history-repo';
 import { loadConfig } from '../storage/config-store';
 import { aggregateWindow } from './aggregator';
 import { getEffectiveWatchDatesByDateRange, getEffectiveWatchRecordsByDateRange } from './effective-watch';
+import { getBackfillComplete, getHistorySyncProgress } from '../storage/config-store';
 
 interface StreakDetails {
   current: number;
@@ -32,59 +35,6 @@ export function computeStreak(dailyList: DailyAggregate[]): StreakDetails {
 export function computeStreakFromRecords(records: WatchHistoryRecord[]): StreakDetails {
   const dates = new Set(records.map(r => dateKey(new Date(r.viewAt * 1000))));
   return computeStreakFromDateSet(dates);
-}
-
-function computeStreakFromDateSet(dates: Set<string>): StreakDetails {
-  if (dates.size === 0) {
-    return {
-      current: 0,
-      currentStartDate: null,
-      currentEndDate: null,
-      longest: 0,
-      longestStartDate: null,
-      longestEndDate: null,
-    };
-  }
-
-  const sorted = Array.from(dates).sort();
-  const ranges: Array<{ startDate: string; endDate: string; days: number }> = [];
-  let startDate = sorted[0];
-  let endDate = sorted[0];
-
-  for (let i = 1; i < sorted.length; i++) {
-    const prev = parseDateKey(sorted[i - 1]);
-    const curr = parseDateKey(sorted[i]);
-    if (daysBetween(prev, curr) === 1) {
-      endDate = sorted[i];
-      continue;
-    }
-
-    ranges.push({ startDate, endDate, days: countInclusiveDays(startDate, endDate) });
-    startDate = sorted[i];
-    endDate = sorted[i];
-  }
-  ranges.push({ startDate, endDate, days: countInclusiveDays(startDate, endDate) });
-
-  const today = dateKey();
-  const yesterday = dateKey(daysAgo(1));
-  const currentAnchor = dates.has(today) ? today : dates.has(yesterday) ? yesterday : null;
-  const currentRange = currentAnchor
-    ? ranges.find(range => range.startDate <= currentAnchor && range.endDate >= currentAnchor)
-    : null;
-  const longestRange = ranges.reduce((best, range) => {
-    if (!best || range.days > best.days) return range;
-    if (range.days === best.days && range.endDate > best.endDate) return range;
-    return best;
-  }, null as { startDate: string; endDate: string; days: number } | null);
-
-  return {
-    current: currentRange?.days ?? 0,
-    currentStartDate: currentRange?.startDate ?? null,
-    currentEndDate: currentRange?.endDate ?? null,
-    longest: longestRange?.days ?? 0,
-    longestStartDate: longestRange?.startDate ?? null,
-    longestEndDate: longestRange?.endDate ?? null,
-  };
 }
 
 export async function getQuickStats(): Promise<QuickStats> {
@@ -132,6 +82,11 @@ export async function getDashboardOverview(): Promise<DashboardOverview> {
     getOldestRecord(),
     getNewestRecord(),
   ]);
+  const [syncProgress, backfillComplete, totalRecords] = await Promise.all([
+    getHistorySyncProgress(),
+    getBackfillComplete(),
+    getTotalCount(),
+  ]);
   const oldestRecordDate = oldestRecord ? dateKey(new Date(oldestRecord.viewAt * 1000)) : dateKey(daysAgo(365));
   const effectiveDates = await getEffectiveWatchDatesByDateRange(oldestRecordDate, todayKey);
   const thisWeekWindow = aggregateWindow(thisWeekRecords);
@@ -151,6 +106,10 @@ export async function getDashboardOverview(): Promise<DashboardOverview> {
   const lastMonthEnd = dateKey(new Date(now.getFullYear(), now.getMonth(), 0));
   const lastMonthRecords = (await getEffectiveWatchRecordsByDateRange(lastMonthStart, lastMonthEnd)).records;
   const lastMonthWatch = aggregateWindow(lastMonthRecords).totalWatchTime;
+  const coverage = assessHistoryCoverage(syncProgress, backfillComplete, totalRecords);
+  const streakCoverageNote = coverage.trustworthy
+    ? 'Current and longest streaks are based on fully confirmed watch-date coverage.'
+    : `Current and longest streaks use only currently available local watch dates. ${coverage.note}`;
 
   return {
     weeklyWatchTime: weeklyWatch,
@@ -176,6 +135,11 @@ export async function getDashboardOverview(): Promise<DashboardOverview> {
     weeklyLocalPcDays: thisWeekEffective.localPcDates.length,
     oldestRecordDate: oldestRecord ? oldestRecordDate : null,
     newestRecordDate: newestRecord ? dateKey(new Date(newestRecord.viewAt * 1000)) : null,
+    historyCoverageStatus: coverage.status,
+    historyCoverageNote: coverage.note,
+    streakTrustworthy: coverage.trustworthy,
+    streakCoverageNote,
+    historySyncDiagnostics: syncProgress,
   };
 }
 
@@ -193,13 +157,4 @@ function computeRawEfficiency(records: WatchHistoryRecord[], dailyGoalSeconds: n
     0.3 * goalScore +
     0.2 * diversityScore
   ) * 100);
-}
-
-function parseDateKey(key: string): Date {
-  const [year, month, day] = key.split('-').map(Number);
-  return new Date(year, month - 1, day);
-}
-
-function countInclusiveDays(startDate: string, endDate: string): number {
-  return daysBetween(parseDateKey(startDate), parseDateKey(endDate)) + 1;
 }

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -1,13 +1,15 @@
 import type { BiliVizRequest, BiliVizContentMessage, BiliVizResponse, PlayerActionPayload, PlayerHeartbeatPayload, SyncNowResult } from '../../shared/types/messages';
+import type { HistorySyncStatus } from '../../shared/types/history-sync';
 import type { CurrentVideoContextResult, CurrentVideoNoContext } from '../../shared/types/current-video-context';
 import type { VideoKnowledgeJumpResponse } from '../../shared/types/video-knowledge';
 import type { DynamicBillFeedbackScope, DynamicBillStatusFilter } from '../../shared/types/dynamic-bill';
-import { runInitialBackfill } from '../sync/initial-backfill';
+import { normalizePageLimit, runInitialBackfill } from '../sync/initial-backfill';
 import {
   saveConfig,
   getLastSyncTime,
   getHistorySyncing,
   getHistorySyncProgress,
+  getBackfillComplete,
   loadConfig,
   requestHistorySyncCancel,
   clearOrphanedHistorySyncLock,
@@ -164,6 +166,7 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
         const requestedMode = request.params?.mode === 'full' ? 'full' : request.params?.mode === 'incremental' ? 'incremental' : null;
         const requestedMaxPages = Number(request.params?.maxPages);
         const maxPages = Number.isFinite(requestedMaxPages) ? requestedMaxPages : undefined;
+        const normalizedMaxPages = normalizePageLimit(maxPages);
         const storedCount = await db.watchHistory.count();
         const mode = requestedMode ?? (storedCount === 0 ? 'full' : 'incremental');
         if (await getHistorySyncing()) {
@@ -184,16 +187,19 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
           data: {
             synced: true,
             mode,
-            pageLimit: maxPages ?? 0,
+            requestedPageLimit: maxPages ?? null,
+            pageLimit: normalizedMaxPages,
             currentTask: 'sync_started',
             fetchedPages: 0,
             fetchedCount: 0,
             insertedCount: 0,
             updatedCount: 0,
+            skippedCount: 0,
             stoppedReason: 'sync_started',
             reachedEnd: false,
             oldestFetchedAt: null,
             newestFetchedAt: null,
+            finalCursor: null,
           } satisfies SyncNowResult as T,
         };
       }
@@ -236,8 +242,19 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
       }
       const lastSync = await getLastSyncTime();
       const count = await db.watchHistory.count();
-      const syncProgress = await getHistorySyncProgress();
-      return { success: true, data: { lastSyncTime: lastSync, totalRecords: count, syncProgress } as T };
+      const [syncProgress, backfillComplete] = await Promise.all([
+        getHistorySyncProgress(),
+        getBackfillComplete(),
+      ]);
+      return {
+        success: true,
+        data: {
+          lastSyncTime: lastSync,
+          totalRecords: count,
+          backfillComplete,
+          syncProgress,
+        } satisfies HistorySyncStatus as T,
+      };
     }
     case 'GET_CURRENT_VIDEO_CONTEXT':
       return { success: true, data: await getCurrentVideoContextForActiveTab() as T };

--- a/src/background/storage/config-store.ts
+++ b/src/background/storage/config-store.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_CONFIG, type UserConfig } from '../../shared/types/config';
-import type { SyncProgress } from '../../shared/types/messages';
+import type { HistorySyncProgress } from '../../shared/types/history-sync';
 
 const CONFIG_KEY = 'userConfig';
 const HISTORY_SYNC_PROGRESS_KEY = 'historySyncProgress';
@@ -86,16 +86,16 @@ export async function setHistorySyncing(syncing: boolean): Promise<void> {
   await chrome.storage.local.remove('historySyncStartedAt');
 }
 
-export async function getHistorySyncProgress(): Promise<SyncProgress | null> {
+export async function getHistorySyncProgress(): Promise<HistorySyncProgress | null> {
   const result = await chrome.storage.local.get(HISTORY_SYNC_PROGRESS_KEY);
-  return result[HISTORY_SYNC_PROGRESS_KEY] ?? null;
+  return normalizeHistorySyncProgress(result[HISTORY_SYNC_PROGRESS_KEY] ?? null);
 }
 
-export async function setHistorySyncProgress(progress: SyncProgress): Promise<void> {
+export async function setHistorySyncProgress(progress: HistorySyncProgress): Promise<void> {
   await chrome.storage.local.set({ [HISTORY_SYNC_PROGRESS_KEY]: progress });
 }
 
-export async function patchHistorySyncProgress(progress: Partial<SyncProgress>): Promise<void> {
+export async function patchHistorySyncProgress(progress: Partial<HistorySyncProgress>): Promise<void> {
   const current = await getHistorySyncProgress();
   if (!current) return;
   await setHistorySyncProgress({
@@ -135,8 +135,8 @@ export async function getBackfillComplete(): Promise<boolean> {
   return result.backfillComplete ?? false;
 }
 
-export async function setBackfillComplete(): Promise<void> {
-  await chrome.storage.local.set({ backfillComplete: true });
+export async function setBackfillComplete(complete = true): Promise<void> {
+  await chrome.storage.local.set({ backfillComplete: complete });
 }
 
 export async function getDeviceTypeMigrationComplete(): Promise<boolean> {
@@ -146,4 +146,56 @@ export async function getDeviceTypeMigrationComplete(): Promise<boolean> {
 
 export async function setDeviceTypeMigrationComplete(): Promise<void> {
   await chrome.storage.local.set({ deviceTypeMigrationComplete: true });
+}
+
+function normalizeHistorySyncProgress(value: unknown): HistorySyncProgress | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Partial<HistorySyncProgress> & {
+    skippedCount?: unknown;
+    requestedPageLimit?: unknown;
+    finalCursor?: unknown;
+  };
+
+  const fetchedCount = asRequiredNumber(raw.fetchedCount, 0);
+  const insertedCount = asRequiredNumber(raw.insertedCount, 0);
+  const skippedCount = Math.max(0, asRequiredNumber(raw.skippedCount, fetchedCount - insertedCount));
+
+  return {
+    syncing: raw.syncing === true,
+    mode: raw.mode === 'full' || raw.mode === 'incremental' ? raw.mode : null,
+    requestedPageLimit: raw.requestedPageLimit == null ? null : asOptionalNumber(raw.requestedPageLimit, null),
+    pageLimit: asRequiredNumber(raw.pageLimit, 0),
+    currentTask: typeof raw.currentTask === 'string' ? raw.currentTask : '',
+    startedAt: asRequiredNumber(raw.startedAt, 0),
+    updatedAt: asRequiredNumber(raw.updatedAt, 0),
+    fetchedPages: asRequiredNumber(raw.fetchedPages, 0),
+    fetchedCount,
+    insertedCount,
+    updatedCount: asRequiredNumber(raw.updatedCount, 0),
+    skippedCount,
+    stoppedReason: typeof raw.stoppedReason === 'string' ? raw.stoppedReason : '',
+    reachedEnd: raw.reachedEnd === true,
+    oldestFetchedAt: asOptionalNumber(raw.oldestFetchedAt, null),
+    newestFetchedAt: asOptionalNumber(raw.newestFetchedAt, null),
+    finalCursor: normalizeCursor(raw.finalCursor),
+  };
+}
+
+function normalizeCursor(value: unknown): HistorySyncProgress['finalCursor'] {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+  return {
+    max: asOptionalNumber(raw.max, null),
+    viewAt: asOptionalNumber(raw.viewAt, null),
+    business: typeof raw.business === 'string' ? raw.business : null,
+    hasMore: typeof raw.hasMore === 'boolean' ? raw.hasMore : null,
+  };
+}
+
+function asRequiredNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function asOptionalNumber(value: unknown, fallback: number | null): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
 }

--- a/src/background/sync/initial-backfill.ts
+++ b/src/background/sync/initial-backfill.ts
@@ -13,26 +13,20 @@ import {
   setLastSyncTime,
 } from '../storage/config-store';
 import type { HistoryCursorItem } from '../../shared/types/video-info';
+import type { VideoInfo } from '../../shared/types/video-info';
 import { MAX_BACKFILL_PAGES } from '../../shared/constants';
+import {
+  classifyHistoryPageStop,
+  isHistoryCursorEnd,
+  normalizeHistoryPageLimit,
+} from '../../shared/history-sync-core';
 import { getHistoryBvid, getHistoryDeviceType, toWatchHistoryRecord } from './watch-history-mapper';
-import type { HistorySyncMode } from '../../shared/types/messages';
+import type { HistorySyncCursorSnapshot, HistorySyncMode, HistorySyncProgress } from '../../shared/types/history-sync';
 import { beginHistorySyncAbortScope, endHistorySyncAbortScope } from './sync-control';
 import { abortableDelay } from '../utils/abortable-delay';
 import { markDynamicBillItemsConsumedByHistoryRecords } from '../storage/dynamic-bill-repo';
 
-export interface BackfillResult {
-  mode: HistorySyncMode;
-  pageLimit: number;
-  currentTask: string;
-  fetchedPages: number;
-  fetchedCount: number;
-  insertedCount: number;
-  updatedCount: number;
-  stoppedReason: string;
-  reachedEnd: boolean;
-  oldestFetchedAt: number | null;
-  newestFetchedAt: number | null;
-}
+export interface BackfillResult extends Omit<HistorySyncProgress, 'syncing' | 'startedAt' | 'updatedAt'> {}
 
 export interface HistorySyncOptions {
   maxPages?: number;
@@ -81,8 +75,9 @@ async function runHistorySyncUnlocked(
   }
 
   console.log(`[BiliViz] Starting ${mode} history sync...`);
-  const pageLimit = normalizePageLimit(options.maxPages);
-  const result = createResult(mode, 'page_limit', pageLimit);
+  const requestedPageLimit = Number.isFinite(options.maxPages) ? Math.floor(options.maxPages!) : null;
+  const pageLimit = normalizeHistoryPageLimit(options.maxPages);
+  const result = createResult(mode, 'page_limit', pageLimit, requestedPageLimit);
   const startedAt = Date.now();
   await writeProgress(result, startedAt, true);
   let cursor: HistoryCursorParams = {};
@@ -90,12 +85,8 @@ async function runHistorySyncUnlocked(
   while (result.fetchedPages < pageLimit) {
     if (signal.aborted || await getHistorySyncCancelRequested()) {
       result.stoppedReason = 'cancelled';
-      result.currentTask = '用户已停止同步';
       break;
     }
-
-    result.currentTask = `正在请求第 ${result.fetchedPages + 1} 页历史记录`;
-    await writeProgress(result, startedAt, true);
 
     let page;
     try {
@@ -103,23 +94,32 @@ async function runHistorySyncUnlocked(
     } catch (error) {
       if (error instanceof Error && error.message === 'SYNC_CANCELLED') {
         result.stoppedReason = 'cancelled';
-        result.currentTask = '用户已停止同步';
         break;
       }
       throw error;
     }
+
     const { list, cursor: nextCursor } = page;
+    result.finalCursor = toCursorSnapshot(nextCursor);
     if (list.length === 0) {
-      result.stoppedReason = 'empty_page';
-      result.currentTask = '接口返回空页，同步结束';
-      result.reachedEnd = true;
+      const stop = classifyHistoryPageStop({
+        mode,
+        listCount: 0,
+        firstStored: false,
+        lastStored: false,
+        newItemsCount: 0,
+        cursor: nextCursor,
+      });
+      if (stop.stoppedReason) {
+        result.stoppedReason = stop.stoppedReason;
+        result.reachedEnd = stop.reachedEnd;
+      }
       break;
     }
 
     result.fetchedPages++;
     result.fetchedCount += list.length;
     updateFetchedRange(result, list);
-    result.currentTask = `已获取第 ${result.fetchedPages} 页，正在去重`;
     await writeProgress(result, startedAt, true);
 
     const [firstStored, lastStored] = await Promise.all([
@@ -127,8 +127,6 @@ async function runHistorySyncUnlocked(
       isHistoryItemStored(list[list.length - 1]),
     ]);
 
-    result.currentTask = `第 ${result.fetchedPages} 页：正在更新设备信息`;
-    await writeProgress(result, startedAt, true);
     result.updatedCount += await updateDeviceTypesFromHistory(
       list.map(item => ({
         kid: item.kid,
@@ -140,33 +138,29 @@ async function runHistorySyncUnlocked(
     );
 
     const newItems = await filterNewItems(list);
+    result.skippedCount += Math.max(0, list.length - newItems.length);
     if (newItems.length > 0) {
-      result.currentTask = `第 ${result.fetchedPages} 页：正在补全 ${newItems.length} 条视频信息`;
-      await writeProgress(result, startedAt, true);
       const bvids = [...new Set(newItems.map(getHistoryBvid).filter(Boolean))];
-      let videoInfo: Map<string, any>;
+      let videoInfo: Map<string, VideoInfo>;
       try {
         if (signal.aborted || await getHistorySyncCancelRequested()) {
           result.stoppedReason = 'cancelled';
-          result.currentTask = '用户已停止同步';
           break;
         }
         videoInfo = await batchFetchVideoInfo(bvids, signal);
       } catch (error) {
         if (error instanceof Error && error.message === 'SYNC_CANCELLED') {
           result.stoppedReason = 'cancelled';
-          result.currentTask = '用户已停止同步';
           break;
         }
         throw error;
       }
+
       if (signal.aborted || await getHistorySyncCancelRequested()) {
         result.stoppedReason = 'cancelled';
-        result.currentTask = '用户已停止同步';
         break;
       }
-      result.currentTask = `第 ${result.fetchedPages} 页：正在写入本地历史`;
-      await writeProgress(result, startedAt, true);
+
       const records = newItems.map(item => toWatchHistoryRecord(item, videoInfo.get(getHistoryBvid(item))));
       await bulkInsert(records);
       await markDynamicBillItemsConsumedByHistoryRecords(records);
@@ -174,28 +168,19 @@ async function runHistorySyncUnlocked(
     }
 
     console.log(`[BiliViz] ${mode} sync page: ${newItems.length} new items (total inserted: ${result.insertedCount})`);
-    result.currentTask = `第 ${result.fetchedPages} 页处理完成`;
     await writeProgress(result, startedAt, true);
 
-    if (mode === 'incremental') {
-      if (newItems.length === 0) {
-        result.stoppedReason = 'no_new_records';
-        result.currentTask = '未发现新记录，增量同步结束';
-        await writeProgress(result, startedAt, true);
-        break;
-      }
-      if (firstStored && lastStored) {
-        result.stoppedReason = 'boundary_records_seen';
-        result.currentTask = '已遇到本地边界记录，增量同步结束';
-        await writeProgress(result, startedAt, true);
-        break;
-      }
-    }
-
-    if (isCursorEnd(nextCursor)) {
-      result.stoppedReason = 'api_end';
-      result.currentTask = 'B站接口已无更多历史记录';
-      result.reachedEnd = true;
+    const stop = classifyHistoryPageStop({
+      mode,
+      listCount: list.length,
+      firstStored,
+      lastStored,
+      newItemsCount: newItems.length,
+      cursor: nextCursor,
+    });
+    if (stop.stoppedReason) {
+      result.stoppedReason = stop.stoppedReason;
+      result.reachedEnd = stop.reachedEnd;
       await writeProgress(result, startedAt, true);
       break;
     }
@@ -211,7 +196,6 @@ async function runHistorySyncUnlocked(
     } catch (error) {
       if (error instanceof Error && error.message === 'SYNC_CANCELLED') {
         result.stoppedReason = 'cancelled';
-        result.currentTask = '用户已停止同步';
         break;
       }
       throw error;
@@ -219,14 +203,12 @@ async function runHistorySyncUnlocked(
   }
 
   if (mode === 'full' && result.reachedEnd) {
-    await setBackfillComplete();
+    await setBackfillComplete(true);
+  } else if (mode === 'full') {
+    await setBackfillComplete(false);
   }
   await setLastSyncTime(Date.now());
-  if (result.stoppedReason === 'cancelled') {
-    result.currentTask = '同步已停止';
-  } else {
-    result.currentTask = '同步完成';
-  }
+  result.currentTask = result.stoppedReason === 'cancelled' ? 'sync_cancelled' : 'sync_complete';
   await writeProgress(result, startedAt, false);
 
   console.log(`[BiliViz] ${mode} history sync complete: ${result.insertedCount} inserted, ${result.updatedCount} updated`);
@@ -237,31 +219,33 @@ function createResult(
   mode: HistorySyncMode,
   stoppedReason: string,
   pageLimit = MAX_BACKFILL_PAGES,
+  requestedPageLimit: number | null = null,
 ): BackfillResult {
   return {
     mode,
+    requestedPageLimit,
     pageLimit,
     currentTask: stoppedReason,
     fetchedPages: 0,
     fetchedCount: 0,
     insertedCount: 0,
     updatedCount: 0,
+    skippedCount: 0,
     stoppedReason,
     reachedEnd: false,
     oldestFetchedAt: null,
     newestFetchedAt: null,
+    finalCursor: null,
   };
 }
 
-function normalizePageLimit(maxPages: number | undefined): number {
-  if (!Number.isFinite(maxPages)) return MAX_BACKFILL_PAGES;
-  return Math.max(1, Math.min(MAX_BACKFILL_PAGES, Math.floor(maxPages!)));
-}
+export const normalizePageLimit = normalizeHistoryPageLimit;
 
 async function writeProgress(result: BackfillResult, startedAt: number, syncing: boolean): Promise<void> {
   await setHistorySyncProgress({
     syncing,
     mode: result.mode,
+    requestedPageLimit: result.requestedPageLimit,
     pageLimit: result.pageLimit,
     currentTask: result.currentTask,
     startedAt,
@@ -270,10 +254,12 @@ async function writeProgress(result: BackfillResult, startedAt: number, syncing:
     fetchedCount: result.fetchedCount,
     insertedCount: result.insertedCount,
     updatedCount: result.updatedCount,
+    skippedCount: result.skippedCount,
     stoppedReason: result.stoppedReason,
     reachedEnd: result.reachedEnd,
     oldestFetchedAt: result.oldestFetchedAt,
     newestFetchedAt: result.newestFetchedAt,
+    finalCursor: result.finalCursor,
   });
 }
 
@@ -288,6 +274,14 @@ function updateFetchedRange(result: BackfillResult, items: HistoryCursorItem[]):
   }
 }
 
-function isCursorEnd(cursor: { max: number; view_at: number; has_more?: boolean }): boolean {
-  return cursor.has_more === false || (cursor.max === 0 && cursor.view_at === 0);
+export const classifyPageStop = classifyHistoryPageStop;
+export const isCursorEnd = isHistoryCursorEnd;
+
+function toCursorSnapshot(cursor: { max: number; view_at: number; business?: string; has_more?: boolean }): HistorySyncCursorSnapshot {
+  return {
+    max: cursor.max,
+    viewAt: cursor.view_at,
+    business: cursor.business ?? null,
+    hasMore: typeof cursor.has_more === 'boolean' ? cursor.has_more : null,
+  };
 }

--- a/src/shared/history-sync-core.ts
+++ b/src/shared/history-sync-core.ts
@@ -1,0 +1,45 @@
+type HistorySyncMode = 'full' | 'incremental';
+
+const MAX_BACKFILL_PAGES = 300;
+
+export function normalizeHistoryPageLimit(maxPages: number | undefined): number {
+  if (!Number.isFinite(maxPages)) return MAX_BACKFILL_PAGES;
+  return Math.max(1, Math.min(MAX_BACKFILL_PAGES, Math.floor(maxPages!)));
+}
+
+export function classifyHistoryPageStop(args: {
+  mode: HistorySyncMode;
+  listCount: number;
+  firstStored: boolean;
+  lastStored: boolean;
+  newItemsCount: number;
+  cursor: { max: number; view_at: number; has_more?: boolean; business?: string };
+}): {
+  stoppedReason: string | null;
+  reachedEnd: boolean;
+} {
+  if (args.listCount === 0) {
+    return isHistoryCursorEnd(args.cursor)
+      ? { stoppedReason: 'api_end_empty_page', reachedEnd: true }
+      : { stoppedReason: 'empty_page_cursor_anomaly', reachedEnd: false };
+  }
+
+  if (args.mode === 'incremental') {
+    if (args.newItemsCount === 0) {
+      return { stoppedReason: 'no_new_records', reachedEnd: false };
+    }
+    if (args.firstStored && args.lastStored) {
+      return { stoppedReason: 'boundary_records_seen', reachedEnd: false };
+    }
+  }
+
+  if (isHistoryCursorEnd(args.cursor)) {
+    return { stoppedReason: 'api_end', reachedEnd: true };
+  }
+
+  return { stoppedReason: null, reachedEnd: false };
+}
+
+export function isHistoryCursorEnd(cursor: { max: number; view_at: number; has_more?: boolean }): boolean {
+  return cursor.has_more === false || (cursor.max === 0 && cursor.view_at === 0);
+}

--- a/src/shared/history-sync-diagnostics.ts
+++ b/src/shared/history-sync-diagnostics.ts
@@ -1,0 +1,80 @@
+import type { HistorySyncProgress } from './types/history-sync';
+
+export type HistoryCoverageStatus = 'not_started' | 'partial' | 'complete';
+
+export interface HistoryCoverageAssessment {
+  status: HistoryCoverageStatus;
+  trustworthy: boolean;
+  note: string;
+}
+
+export function assessHistoryCoverage(
+  progress: HistorySyncProgress | null,
+  backfillComplete: boolean,
+  totalRecords: number,
+): HistoryCoverageAssessment {
+  if (!progress) {
+    if (backfillComplete && totalRecords > 0) {
+      return {
+        status: 'complete',
+        trustworthy: true,
+        note: 'Full history coverage was previously confirmed.',
+      };
+    }
+
+    return {
+      status: totalRecords > 0 ? 'partial' : 'not_started',
+      trustworthy: false,
+      note: totalRecords > 0
+        ? 'Only local partial history is available; full backfill has not been confirmed.'
+        : 'No history sync diagnostic is available yet.',
+    };
+  }
+
+  if (progress.reachedEnd && isTerminalCompleteReason(progress.stoppedReason)) {
+    return {
+      status: 'complete',
+      trustworthy: true,
+      note: 'History sync reached the upstream end cursor.',
+    };
+  }
+
+  const suffix = historyStopReasonExplanation(progress.stoppedReason);
+  return {
+    status: totalRecords > 0 ? 'partial' : 'not_started',
+    trustworthy: false,
+    note: suffix,
+  };
+}
+
+export function isTerminalCompleteReason(reason: string): boolean {
+  return reason === 'api_end' || reason === 'api_end_empty_page';
+}
+
+export function historyStopReasonExplanation(reason: string): string {
+  switch (reason) {
+    case 'page_limit':
+      return 'Stopped at the configured page limit before the upstream end was confirmed.';
+    case 'empty_page_cursor_anomaly':
+      return 'The API returned an empty page before the end cursor; coverage is incomplete.';
+    case 'cancelled':
+      return 'The sync was cancelled before full coverage was confirmed.';
+    case 'service_worker_restarted':
+      return 'The service worker restarted during sync; coverage may be incomplete.';
+    case 'stale_lock_cleared':
+      return 'A stale sync lock was cleared; the previous run did not finish cleanly.';
+    case 'sync_started':
+      return 'A sync was started but no terminal diagnostic has been written yet.';
+    case 'already_complete':
+      return 'Full history had already been marked complete before this run.';
+    case 'no_new_records':
+      return 'Incremental sync found no new rows; this does not confirm older coverage.';
+    case 'boundary_records_seen':
+      return 'Incremental sync reached local boundary rows; this does not confirm older coverage.';
+    case 'api_end':
+    case 'api_end_empty_page':
+      return 'History sync reached the upstream end cursor.';
+    default:
+      return `History coverage is incomplete or unknown (reason: ${reason}).`;
+  }
+}

--- a/src/shared/streak.ts
+++ b/src/shared/streak.ts
@@ -1,0 +1,86 @@
+export interface StreakDetails {
+  current: number;
+  currentStartDate: string | null;
+  currentEndDate: string | null;
+  longest: number;
+  longestStartDate: string | null;
+  longestEndDate: string | null;
+}
+
+export function computeStreakFromDateSet(dates: Set<string>, todayKey = dateKey()): StreakDetails {
+  if (dates.size === 0) {
+    return {
+      current: 0,
+      currentStartDate: null,
+      currentEndDate: null,
+      longest: 0,
+      longestStartDate: null,
+      longestEndDate: null,
+    };
+  }
+
+  const sorted = Array.from(dates).sort();
+  const ranges: Array<{ startDate: string; endDate: string; days: number }> = [];
+  let startDate = sorted[0];
+  let endDate = sorted[0];
+
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = parseDateKey(sorted[i - 1]);
+    const curr = parseDateKey(sorted[i]);
+    if (daysBetween(prev, curr) === 1) {
+      endDate = sorted[i];
+      continue;
+    }
+
+    ranges.push({ startDate, endDate, days: countInclusiveDays(startDate, endDate) });
+    startDate = sorted[i];
+    endDate = sorted[i];
+  }
+  ranges.push({ startDate, endDate, days: countInclusiveDays(startDate, endDate) });
+
+  const yesterdayKey = dateKey(offsetDays(parseDateKey(todayKey), -1));
+  const currentAnchor = dates.has(todayKey) ? todayKey : dates.has(yesterdayKey) ? yesterdayKey : null;
+  const currentRange = currentAnchor
+    ? ranges.find(range => range.startDate <= currentAnchor && range.endDate >= currentAnchor)
+    : null;
+  const longestRange = ranges.reduce((best, range) => {
+    if (!best || range.days > best.days) return range;
+    if (range.days === best.days && range.endDate > best.endDate) return range;
+    return best;
+  }, null as { startDate: string; endDate: string; days: number } | null);
+
+  return {
+    current: currentRange?.days ?? 0,
+    currentStartDate: currentRange?.startDate ?? null,
+    currentEndDate: currentRange?.endDate ?? null,
+    longest: longestRange?.days ?? 0,
+    longestStartDate: longestRange?.startDate ?? null,
+    longestEndDate: longestRange?.endDate ?? null,
+  };
+}
+
+export function dateKey(date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function parseDateKey(key: string): Date {
+  const [year, month, day] = key.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+function countInclusiveDays(startDate: string, endDate: string): number {
+  return daysBetween(parseDateKey(startDate), parseDateKey(endDate)) + 1;
+}
+
+function daysBetween(a: Date, b: Date): number {
+  const aUtc = Date.UTC(a.getFullYear(), a.getMonth(), a.getDate());
+  const bUtc = Date.UTC(b.getFullYear(), b.getMonth(), b.getDate());
+  return Math.round((bUtc - aUtc) / 86_400_000);
+}
+
+function offsetDays(date: Date, days: number): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + days);
+}

--- a/src/shared/types/analytics.ts
+++ b/src/shared/types/analytics.ts
@@ -1,3 +1,5 @@
+import type { HistorySyncProgress } from './history-sync';
+
 export interface QuickStats {
   todayWatchTime: number;
   dailyGoal: number;
@@ -33,6 +35,11 @@ export interface DashboardOverview {
   weeklyLocalPcDays: number;
   oldestRecordDate: string | null;
   newestRecordDate: string | null;
+  historyCoverageStatus: 'not_started' | 'partial' | 'complete';
+  historyCoverageNote: string;
+  streakTrustworthy: boolean;
+  streakCoverageNote: string;
+  historySyncDiagnostics: HistorySyncProgress | null;
 }
 
 export interface CategoryDistribution {

--- a/src/shared/types/history-sync.ts
+++ b/src/shared/types/history-sync.ts
@@ -1,0 +1,35 @@
+export type HistorySyncMode = 'full' | 'incremental';
+
+export interface HistorySyncCursorSnapshot {
+  max: number | null;
+  viewAt: number | null;
+  business: string | null;
+  hasMore: boolean | null;
+}
+
+export interface HistorySyncProgress {
+  syncing: boolean;
+  mode: HistorySyncMode | null;
+  requestedPageLimit: number | null;
+  pageLimit: number;
+  currentTask: string;
+  startedAt: number;
+  updatedAt: number;
+  fetchedPages: number;
+  fetchedCount: number;
+  insertedCount: number;
+  updatedCount: number;
+  skippedCount: number;
+  stoppedReason: string;
+  reachedEnd: boolean;
+  oldestFetchedAt: number | null;
+  newestFetchedAt: number | null;
+  finalCursor: HistorySyncCursorSnapshot | null;
+}
+
+export interface HistorySyncStatus {
+  lastSyncTime: number;
+  totalRecords: number;
+  backfillComplete: boolean;
+  syncProgress: HistorySyncProgress | null;
+}

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -30,6 +30,7 @@ import type {
 import type { CurrentVideoContextResult } from './current-video-context';
 import type { CurrentVideoSummaryResult } from './current-video-summary';
 import type { VideoKnowledgeJumpResponse, VideoKnowledgeResult } from './video-knowledge';
+import type { HistorySyncCursorSnapshot, HistorySyncMode } from './history-sync';
 
 // Popup / Dashboard → Service Worker
 export type RequestAction =
@@ -117,38 +118,22 @@ export interface BiliVizResponse<T = unknown> {
   error?: string;
 }
 
-export type HistorySyncMode = 'full' | 'incremental';
-
 export interface SyncNowResult {
   synced: true;
   mode: HistorySyncMode;
+  requestedPageLimit: number | null;
   pageLimit: number;
   currentTask: string;
   fetchedPages: number;
   fetchedCount: number;
   insertedCount: number;
   updatedCount: number;
+  skippedCount: number;
   stoppedReason: string;
   reachedEnd: boolean;
   oldestFetchedAt: number | null;
   newestFetchedAt: number | null;
-}
-
-export interface SyncProgress {
-  syncing: boolean;
-  mode: HistorySyncMode | null;
-  pageLimit: number;
-  currentTask: string;
-  startedAt: number;
-  updatedAt: number;
-  fetchedPages: number;
-  fetchedCount: number;
-  insertedCount: number;
-  updatedCount: number;
-  stoppedReason: string;
-  reachedEnd: boolean;
-  oldestFetchedAt: number | null;
-  newestFetchedAt: number | null;
+  finalCursor: HistorySyncCursorSnapshot | null;
 }
 
 // Typed response data

--- a/tests/history-sync-diagnostics.test.ts
+++ b/tests/history-sync-diagnostics.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildWatchSessionKey } from '../src/shared/utils/session-key.ts';
+import { classifyHistoryPageStop, normalizeHistoryPageLimit } from '../src/shared/history-sync-core.ts';
+
+test('full sync continues across non-terminal pages', () => {
+  const stop = classifyHistoryPageStop({
+    mode: 'full',
+    listCount: 30,
+    firstStored: false,
+    lastStored: false,
+    newItemsCount: 30,
+    cursor: {
+      max: 123,
+      view_at: 1_717_000_000,
+      business: 'archive',
+      has_more: true,
+    },
+  });
+
+  assert.equal(stop.stoppedReason, null);
+  assert.equal(stop.reachedEnd, false);
+});
+
+test('empty page with has_more cursor is not treated as full completion', () => {
+  const stop = classifyHistoryPageStop({
+    mode: 'full',
+    listCount: 0,
+    firstStored: false,
+    lastStored: false,
+    newItemsCount: 0,
+    cursor: {
+      max: 456,
+      view_at: 1_716_000_000,
+      business: 'archive',
+      has_more: true,
+    },
+  });
+
+  assert.equal(stop.stoppedReason, 'empty_page_cursor_anomaly');
+  assert.equal(stop.reachedEnd, false);
+});
+
+test('requested 9000-row equivalent still normalizes to 300 pages', () => {
+  assert.equal(normalizeHistoryPageLimit(300), 300);
+});
+
+test('similar records on different dates produce distinct dedup session keys', () => {
+  const keyA = buildWatchSessionKey(0, 1_717_000_000, 'BV1abc', 42);
+  const keyB = buildWatchSessionKey(0, 1_717_086_400, 'BV1abc', 42);
+
+  assert.notEqual(keyA, keyB);
+});

--- a/tests/streak-diagnostics.test.ts
+++ b/tests/streak-diagnostics.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { computeStreakFromDateSet, dateKey } from '../src/shared/streak.ts';
+
+test('thirty-day consecutive fixture reports longest streak of 30', () => {
+  const dates = new Set(
+    Array.from({ length: 30 }, (_, index) => dateKey(offsetDays(index))),
+  );
+
+  const streak = computeStreakFromDateSet(dates, dateKey());
+
+  assert.equal(streak.current, 30);
+  assert.equal(streak.longest, 30);
+});
+
+test('gapped history fixture reports current and longest streak separately', () => {
+  const dates = new Set<string>([
+    dateKey(offsetDays(0)),
+    dateKey(offsetDays(1)),
+    dateKey(offsetDays(10)),
+    dateKey(offsetDays(11)),
+    dateKey(offsetDays(12)),
+    dateKey(offsetDays(13)),
+    dateKey(offsetDays(14)),
+  ]);
+
+  const streak = computeStreakFromDateSet(dates, dateKey());
+
+  assert.equal(streak.current, 2);
+  assert.equal(streak.longest, 5);
+});
+
+function offsetDays(daysAgo: number): Date {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate() - daysAgo);
+}


### PR DESCRIPTION
## Summary
- add persistent history sync diagnostics for requested limit, normalized page limit, fetched pages/items, inserted/updated/skipped counts, fetched date range, stop reason, reached-end state, and final cursor state
- mark history coverage and streak trustworthiness in dashboard instead of presenting partial local history like a completed full sync
- stop treating empty cursor pages with `has_more`/non-terminal cursor state as successful full-history completion

## Root Cause Judgment
The main confirmed bug was in the full-history stop path: `runInitialBackfill()` treated any empty page as `reachedEnd=true`, which could incorrectly mark `backfillComplete` and make partial history look like a completed full sync. That directly explains cases where a 9000-row request stops far early but still looks "done".

A second confirmed gap was observability: the sync model exposed only coarse counters, so users could not tell whether the run hit the Bilibili history end, a page limit, an empty-page cursor anomaly, cancellation, stale lock cleanup, or service worker restart.

The streak issue was partly downstream: current/longest streaks were computed from whatever local dates existed, without clearly marking whether history coverage was trustworthy. That made 2-day local coverage look like a real 2-day streak instead of an incomplete-history artifact.

I did not claim a Bilibili upstream API bug beyond the observed empty-page/non-terminal-cursor anomaly path. Real-account reruns are still useful to determine how often that upstream anomaly occurs.

## Diagnostics Added
- `requestedPageLimit`
- normalized `pageLimit`
- `fetchedPages`
- `fetchedCount`
- `insertedCount`
- `updatedCount`
- `skippedCount`
- `oldestFetchedAt` / `newestFetchedAt`
- `stoppedReason`
- `reachedEnd`
- `finalCursor { max, viewAt, business, hasMore }`
- dashboard coverage assessment and streak trustworthiness note

## Fix Behavior
- full sync now marks completion only when the upstream cursor really ends (`api_end` or terminal empty page)
- empty page with a non-terminal cursor is reported as `empty_page_cursor_anomaly` and does **not** mark full coverage complete
- full sync clears `backfillComplete` when it stops before confirmed upstream end
- sync status payloads are normalized so diagnostics stay readable across older stored states
- dashboard overview now shows whether local history is full, partial, or not yet diagnosed, plus why streak values may be untrustworthy

## Validation
- `node --test tests/history-sync-diagnostics.test.ts tests/streak-diagnostics.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Blocker / Must-Fix / Follow-Up
- blocker: none
- must-fix: none identified in this scope
- follow-up: rerun a real logged-in full sync in extension runtime to confirm whether the user case is primarily page-limit constrained or triggered by upstream empty-page cursor anomalies

## Privacy Boundary
- no key file, cookie file, browser profile, login-state file, or local DB dump was read
- no watch-history export or write-back to Bilibili was performed

Closes #77
