### PR TITLE
[codex] Add history API tail coverage probe

### DIFF
--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -3,6 +3,7 @@ import { quickStats, loading, error, lastSyncResult, syncInProgress, syncProgres
 import { requestSW } from './utils/messaging';
 import type { QuickStats } from '../src/shared/types/analytics';
 import type { SyncNowResult } from '../src/shared/types/messages';
+import type { HistoryTailProbeReport } from '../src/shared/types/history-tail-probe';
 import type { HistorySyncProgress, HistorySyncStatus } from '../src/shared/types/history-sync';
 import type { CurrentVideoContextResult } from '../src/shared/types/current-video-context';
 import type { CurrentVideoSummaryResult } from '../src/shared/types/current-video-summary';
@@ -19,6 +20,9 @@ export function App() {
   const [jumpPreviewNodeId, setJumpPreviewNodeId] = useState<string | null>(null);
   const [jumpStatus, setJumpStatus] = useState<string | null>(null);
   const [summaryLoading, setSummaryLoading] = useState(false);
+  const [tailProbeReport, setTailProbeReport] = useState<HistoryTailProbeReport | null>(null);
+  const [tailProbeLoading, setTailProbeLoading] = useState(false);
+  const [tailProbeError, setTailProbeError] = useState<string | null>(null);
   const summaryRequestRef = useRef(0);
 
   useEffect(() => {
@@ -174,6 +178,21 @@ export function App() {
     await refreshSyncStatus();
   }
 
+  async function runTailProbe() {
+    setTailProbeLoading(true);
+    setTailProbeError(null);
+    try {
+      const report = await requestSW<HistoryTailProbeReport>('PROBE_HISTORY_TAIL', {
+        maxPages: syncPageLimit.value,
+      });
+      setTailProbeReport(report);
+    } catch (e) {
+      setTailProbeError((e as Error).message);
+    } finally {
+      setTailProbeLoading(false);
+    }
+  }
+
   return (
     <div style={{ padding: '12px 0' }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '0 12px', gap: '8px' }}>
@@ -251,6 +270,52 @@ export function App() {
           </button>
         )}
       </div>
+      <section style={{
+        margin: '8px 18px 12px',
+        padding: '10px 12px',
+        border: '1px solid rgba(0, 161, 214, 0.25)',
+        borderRadius: '8px',
+        background: 'rgba(0, 161, 214, 0.08)',
+      }}>
+        <div style={{
+          color: '#7FDBFF',
+          fontSize: '12px',
+          fontWeight: 700,
+          marginBottom: '4px',
+        }}>
+          History API tail probe
+        </div>
+        <div style={{ color: '#A0A0B0', fontSize: '10px', lineHeight: 1.5 }}>
+          Diagnostic only. Uses the current runtime login state, fetches bounded history pages, and stores no history rows.
+        </div>
+        <button
+          onClick={runTailProbe}
+          disabled={tailProbeLoading || syncInProgress.value}
+          style={{
+            marginTop: '8px',
+            background: 'rgba(0, 161, 214, 0.16)',
+            color: '#7FDBFF',
+            border: '1px solid rgba(0, 161, 214, 0.32)',
+            borderRadius: '6px',
+            cursor: tailProbeLoading || syncInProgress.value ? 'default' : 'pointer',
+            fontSize: '11px',
+            padding: '6px 8px',
+            opacity: tailProbeLoading || syncInProgress.value ? 0.7 : 1,
+          }}
+        >
+          {tailProbeLoading ? 'Probing...' : 'Probe API tail'}
+        </button>
+        {tailProbeError && (
+          <div style={{ color: '#FFB347', fontSize: '10px', lineHeight: 1.45, marginTop: '8px' }}>
+            {tailProbeError}
+          </div>
+        )}
+        {tailProbeReport && (
+          <div style={{ color: '#C8EFFF', fontSize: '10px', lineHeight: 1.55, marginTop: '8px', whiteSpace: 'pre-wrap' }}>
+            {formatTailProbeReport(tailProbeReport)}
+          </div>
+        )}
+      </section>
       <OpenDashboard />
       <CurrentVideoAssistantStatus
         context={currentVideoContext}
@@ -754,4 +819,35 @@ function formatPopupDuration(seconds: number): string {
   const minutes = Math.floor(safe / 60);
   const rest = safe % 60;
   return `${minutes}:${String(rest).padStart(2, '0')}`;
+}
+
+function formatTailProbeReport(report: HistoryTailProbeReport): string {
+  const lines = [
+    `requested=${report.requestedMaxPages ?? 'default'} pages; normalized=${report.normalizedPageLimit}; pageSize=${report.pageSize}`,
+    `fetchedPages=${report.fetchedPages}; fetchedItems=${report.fetchedItems}; stop=${report.stopReason}; reachedEnd=${String(report.reachedDeclaredEnd)}`,
+    `range=${formatProbeViewAt(report.oldestFetchedAt)} -> ${formatProbeViewAt(report.newestFetchedAt)}`,
+    `repeatedCursor=${String(report.repeatedCursorDetected)}; shortPages=${report.shortPageAnomalyCount}; emptyAnomalies=${report.emptyPageAnomalyCount}`,
+  ];
+
+  if (report.finalCursor) {
+    lines.push(`finalCursor=${formatProbeCursor(report.finalCursor)}`);
+  }
+
+  for (const page of report.pages) {
+    lines.push(
+      `p${page.pageIndex}: items=${page.itemCount}; range=${formatProbeViewAt(page.oldestViewAt)} -> ${formatProbeViewAt(page.newestViewAt)}; request=${formatProbeCursor(page.requestedCursor)}; cursor=${formatProbeCursor(page.responseCursor)}; repeated=${String(page.repeatedCursor)}; short=${String(page.shortPageAnomaly)}; empty=${String(page.emptyPage)}; end=${String(page.declaredEnd)}`,
+    );
+  }
+
+  return lines.join('\n');
+}
+
+function formatProbeCursor(cursor: HistoryTailProbeReport['finalCursor']): string {
+  if (!cursor) return 'initial';
+  return `max=${cursor.max ?? 'null'},view_at=${cursor.viewAt ?? 'null'},business=${cursor.business ?? 'null'},has_more=${cursor.hasMore == null ? 'null' : String(cursor.hasMore)}`;
+}
+
+function formatProbeViewAt(value: number | null): string {
+  if (!value) return 'n/a';
+  return new Date(value * 1000).toLocaleString('zh-CN');
 }

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -4,6 +4,7 @@ import type { CurrentVideoContextResult, CurrentVideoNoContext } from '../../sha
 import type { VideoKnowledgeJumpResponse } from '../../shared/types/video-knowledge';
 import type { DynamicBillFeedbackScope, DynamicBillStatusFilter } from '../../shared/types/dynamic-bill';
 import { normalizePageLimit, runInitialBackfill } from '../sync/initial-backfill';
+import { probeHistoryTailCoverage } from '../sync/history-tail-probe';
 import {
   saveConfig,
   getLastSyncTime,
@@ -254,6 +255,18 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
           backfillComplete,
           syncProgress,
         } satisfies HistorySyncStatus as T,
+      };
+    }
+    case 'PROBE_HISTORY_TAIL': {
+      const requestedMaxPages = Number(request.params?.maxPages);
+      if (await getHistorySyncing()) {
+        throw new Error('HISTORY_SYNC_IN_PROGRESS');
+      }
+      return {
+        success: true,
+        data: await probeHistoryTailCoverage({
+          maxPages: Number.isFinite(requestedMaxPages) ? requestedMaxPages : undefined,
+        }) as T,
       };
     }
     case 'GET_CURRENT_VIDEO_CONTEXT':

--- a/src/background/sync/history-tail-probe.ts
+++ b/src/background/sync/history-tail-probe.ts
@@ -1,0 +1,135 @@
+import { fetchHistoryPage, type HistoryCursorParams } from '../api/history.ts';
+import { HISTORY_PAGE_SIZE } from '../../shared/constants.ts';
+import {
+  buildHistoryTailProbePageDiagnostic,
+  classifyHistoryTailProbeStop,
+  createHistoryTailCursorKey,
+} from '../../shared/history-tail-probe-core.ts';
+import { normalizeHistoryPageLimit } from '../../shared/history-sync-core.ts';
+import type { HistoryTailProbeReport } from '../../shared/types/history-tail-probe.ts';
+import type { HistorySyncCursorSnapshot } from '../../shared/types/history-sync.ts';
+
+export interface HistoryTailProbeOptions {
+  maxPages?: number;
+  signal?: AbortSignal;
+}
+
+export async function probeHistoryTailCoverage(options: HistoryTailProbeOptions = {}): Promise<HistoryTailProbeReport> {
+  const startedAt = Date.now();
+  const requestedMaxPages = Number.isFinite(options.maxPages) ? Math.floor(options.maxPages!) : null;
+  const normalizedPageLimit = normalizeHistoryPageLimit(options.maxPages);
+  const pages: HistoryTailProbeReport['pages'] = [];
+  const seenResponseCursors = new Set<string>();
+  let cursor: HistoryCursorParams = {};
+  let fetchedItems = 0;
+  let oldestFetchedAt: number | null = null;
+  let newestFetchedAt: number | null = null;
+  let repeatedCursorDetected = false;
+  let shortPageAnomalyCount = 0;
+  let emptyPageAnomalyCount = 0;
+  let stopReason: HistoryTailProbeReport['stopReason'] = 'page_limit';
+  let reachedDeclaredEnd = false;
+  let finalCursor: HistorySyncCursorSnapshot | null = null;
+
+  for (let pageIndex = 1; pageIndex <= normalizedPageLimit; pageIndex++) {
+    if (options.signal?.aborted) {
+      stopReason = 'cancelled';
+      break;
+    }
+
+    const requestedCursor = toRequestedCursorSnapshot(cursor);
+    const { list, cursor: responseCursorRaw } = await fetchHistoryPage(cursor, options.signal);
+    const responseCursor = toResponseCursorSnapshot(responseCursorRaw);
+    finalCursor = responseCursor;
+
+    const cursorKey = createHistoryTailCursorKey(responseCursor);
+    const repeatedCursor = seenResponseCursors.has(cursorKey);
+    if (!repeatedCursor) {
+      seenResponseCursors.add(cursorKey);
+    } else {
+      repeatedCursorDetected = true;
+    }
+
+    const page = buildHistoryTailProbePageDiagnostic({
+      pageIndex,
+      list,
+      requestedCursor,
+      responseCursor,
+      repeatedCursor,
+      pageSize: HISTORY_PAGE_SIZE,
+    });
+    pages.push(page);
+    fetchedItems += list.length;
+    if (page.shortPageAnomaly) shortPageAnomalyCount++;
+    if (page.emptyPage && !page.declaredEnd) emptyPageAnomalyCount++;
+
+    if (page.newestViewAt !== null) {
+      newestFetchedAt = newestFetchedAt === null ? page.newestViewAt : Math.max(newestFetchedAt, page.newestViewAt);
+    }
+    if (page.oldestViewAt !== null) {
+      oldestFetchedAt = oldestFetchedAt === null ? page.oldestViewAt : Math.min(oldestFetchedAt, page.oldestViewAt);
+    }
+
+    const stop = classifyHistoryTailProbeStop({
+      listCount: list.length,
+      cursor: responseCursorRaw,
+      repeatedCursor,
+    });
+    if (stop.stopReason) {
+      stopReason = stop.stopReason;
+      reachedDeclaredEnd = stop.reachedDeclaredEnd;
+      break;
+    }
+
+    cursor = {
+      max: responseCursorRaw.max,
+      viewAt: responseCursorRaw.view_at,
+      business: responseCursorRaw.business,
+    };
+  }
+
+  return {
+    startedAt,
+    finishedAt: Date.now(),
+    requestedMaxPages,
+    normalizedPageLimit,
+    pageSize: HISTORY_PAGE_SIZE,
+    fetchedPages: pages.length,
+    fetchedItems,
+    oldestFetchedAt,
+    newestFetchedAt,
+    repeatedCursorDetected,
+    shortPageAnomalyCount,
+    emptyPageAnomalyCount,
+    stopReason,
+    reachedDeclaredEnd,
+    finalCursor,
+    pages,
+  };
+}
+
+function toRequestedCursorSnapshot(cursor: HistoryCursorParams): HistorySyncCursorSnapshot | null {
+  if (
+    cursor.max === undefined
+    && cursor.viewAt === undefined
+    && cursor.business === undefined
+  ) {
+    return null;
+  }
+
+  return {
+    max: cursor.max ?? null,
+    viewAt: cursor.viewAt ?? null,
+    business: cursor.business ?? null,
+    hasMore: null,
+  };
+}
+
+function toResponseCursorSnapshot(cursor: { max: number; view_at: number; business?: string; has_more?: boolean }): HistorySyncCursorSnapshot {
+  return {
+    max: cursor.max,
+    viewAt: cursor.view_at,
+    business: cursor.business ?? null,
+    hasMore: typeof cursor.has_more === 'boolean' ? cursor.has_more : null,
+  };
+}

--- a/src/shared/history-tail-probe-core.ts
+++ b/src/shared/history-tail-probe-core.ts
@@ -1,0 +1,71 @@
+import { HISTORY_PAGE_SIZE } from './constants.ts';
+import { isHistoryCursorEnd } from './history-sync-core.ts';
+import type { HistoryTailProbePageDiagnostic, HistoryTailProbeStopReason } from './types/history-tail-probe.ts';
+import type { HistorySyncCursorSnapshot } from './types/history-sync.ts';
+import type { HistoryCursorItem } from './types/video-info.ts';
+
+export function classifyHistoryTailProbeStop(args: {
+  listCount: number;
+  cursor: { max: number; view_at: number; has_more?: boolean };
+  repeatedCursor: boolean;
+}): {
+  stopReason: HistoryTailProbeStopReason | null;
+  reachedDeclaredEnd: boolean;
+} {
+  if (args.repeatedCursor) {
+    return { stopReason: 'repeated_cursor', reachedDeclaredEnd: false };
+  }
+
+  if (args.listCount === 0) {
+    return isHistoryCursorEnd(args.cursor)
+      ? { stopReason: 'api_end_empty_page', reachedDeclaredEnd: true }
+      : { stopReason: 'empty_page_cursor_anomaly', reachedDeclaredEnd: false };
+  }
+
+  if (isHistoryCursorEnd(args.cursor)) {
+    return { stopReason: 'api_end', reachedDeclaredEnd: true };
+  }
+
+  return { stopReason: null, reachedDeclaredEnd: false };
+}
+
+export function buildHistoryTailProbePageDiagnostic(args: {
+  pageIndex: number;
+  list: Pick<HistoryCursorItem, 'view_at'>[];
+  requestedCursor: HistorySyncCursorSnapshot | null;
+  responseCursor: HistorySyncCursorSnapshot;
+  repeatedCursor: boolean;
+  pageSize?: number;
+}): HistoryTailProbePageDiagnostic {
+  let newestViewAt: number | null = null;
+  let oldestViewAt: number | null = null;
+
+  for (const item of args.list) {
+    newestViewAt = newestViewAt === null ? item.view_at : Math.max(newestViewAt, item.view_at);
+    oldestViewAt = oldestViewAt === null ? item.view_at : Math.min(oldestViewAt, item.view_at);
+  }
+
+  const declaredEnd = args.responseCursor.hasMore === false
+    || (args.responseCursor.max === 0 && args.responseCursor.viewAt === 0);
+  const emptyPage = args.list.length === 0;
+  const shortPageAnomaly = args.list.length > 0
+    && args.list.length < (args.pageSize ?? HISTORY_PAGE_SIZE)
+    && !declaredEnd;
+
+  return {
+    pageIndex: args.pageIndex,
+    itemCount: args.list.length,
+    newestViewAt,
+    oldestViewAt,
+    requestedCursor: args.requestedCursor,
+    responseCursor: args.responseCursor,
+    repeatedCursor: args.repeatedCursor,
+    shortPageAnomaly,
+    emptyPage,
+    declaredEnd,
+  };
+}
+
+export function createHistoryTailCursorKey(cursor: HistorySyncCursorSnapshot): string {
+  return `${cursor.max ?? 'null'}:${cursor.viewAt ?? 'null'}:${cursor.business ?? 'null'}:${cursor.hasMore == null ? 'null' : String(cursor.hasMore)}`;
+}

--- a/src/shared/types/history-tail-probe.ts
+++ b/src/shared/types/history-tail-probe.ts
@@ -1,0 +1,41 @@
+import type { HistorySyncCursorSnapshot } from './history-sync';
+
+export type HistoryTailProbeStopReason =
+  | 'page_limit'
+  | 'api_end'
+  | 'api_end_empty_page'
+  | 'empty_page_cursor_anomaly'
+  | 'repeated_cursor'
+  | 'cancelled';
+
+export interface HistoryTailProbePageDiagnostic {
+  pageIndex: number;
+  itemCount: number;
+  newestViewAt: number | null;
+  oldestViewAt: number | null;
+  requestedCursor: HistorySyncCursorSnapshot | null;
+  responseCursor: HistorySyncCursorSnapshot;
+  repeatedCursor: boolean;
+  shortPageAnomaly: boolean;
+  emptyPage: boolean;
+  declaredEnd: boolean;
+}
+
+export interface HistoryTailProbeReport {
+  startedAt: number;
+  finishedAt: number;
+  requestedMaxPages: number | null;
+  normalizedPageLimit: number;
+  pageSize: number;
+  fetchedPages: number;
+  fetchedItems: number;
+  oldestFetchedAt: number | null;
+  newestFetchedAt: number | null;
+  repeatedCursorDetected: boolean;
+  shortPageAnomalyCount: number;
+  emptyPageAnomalyCount: number;
+  stopReason: HistoryTailProbeStopReason;
+  reachedDeclaredEnd: boolean;
+  finalCursor: HistorySyncCursorSnapshot | null;
+  pages: HistoryTailProbePageDiagnostic[];
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -5,3 +5,4 @@ export * from './analytics';
 export * from './messages';
 export * from './config';
 export * from './dynamic-bill';
+export * from './history-tail-probe';

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -30,6 +30,7 @@ import type {
 import type { CurrentVideoContextResult } from './current-video-context';
 import type { CurrentVideoSummaryResult } from './current-video-summary';
 import type { VideoKnowledgeJumpResponse, VideoKnowledgeResult } from './video-knowledge';
+import type { HistoryTailProbeReport } from './history-tail-probe';
 import type { HistorySyncCursorSnapshot, HistorySyncMode } from './history-sync';
 
 // Popup / Dashboard → Service Worker
@@ -48,6 +49,7 @@ export type RequestAction =
   | 'EXPORT_DATA'
   | 'EXPORT_DATA_PAGE'
   | 'GET_SYNC_STATUS'
+  | 'PROBE_HISTORY_TAIL'
   | 'GET_CURRENT_VIDEO_CONTEXT'
   | 'GET_CURRENT_VIDEO_SUMMARY'
   | 'GET_VIDEO_KNOWLEDGE'
@@ -176,3 +178,4 @@ export type DynamicBillItemsResponse = BiliVizResponse<DynamicBillItem[]>;
 export type DynamicBillItemResponse = BiliVizResponse<DynamicBillItem | null>;
 export type DynamicBillFilterResponse = BiliVizResponse<DynamicBillFilterPreference>;
 export type DynamicBillFeedbackResponse = BiliVizResponse<DynamicBillFeedbackResult>;
+export type HistoryTailProbeResponse = BiliVizResponse<HistoryTailProbeReport>;

--- a/tests/history-tail-probe.test.ts
+++ b/tests/history-tail-probe.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildHistoryTailProbePageDiagnostic,
+  classifyHistoryTailProbeStop,
+} from '../src/shared/history-tail-probe-core.ts';
+
+test('classifies repeated cursor as a terminal probe stop', () => {
+  const stop = classifyHistoryTailProbeStop({
+    listCount: 30,
+    repeatedCursor: true,
+    cursor: {
+      max: 777,
+      view_at: 1_718_000_000,
+      has_more: true,
+    },
+  });
+
+  assert.equal(stop.stopReason, 'repeated_cursor');
+  assert.equal(stop.reachedDeclaredEnd, false);
+});
+
+test('marks short non-terminal pages as anomalies without forcing a stop', () => {
+  const page = buildHistoryTailProbePageDiagnostic({
+    pageIndex: 2,
+    list: [{ view_at: 1_718_000_000 }, { view_at: 1_717_900_000 }],
+    requestedCursor: null,
+    responseCursor: {
+      max: 456,
+      viewAt: 1_717_900_000,
+      business: 'archive',
+      hasMore: true,
+    },
+    repeatedCursor: false,
+    pageSize: 30,
+  });
+
+  assert.equal(page.shortPageAnomaly, true);
+  assert.equal(page.emptyPage, false);
+  assert.equal(page.declaredEnd, false);
+});
+
+test('classifies empty non-terminal pages as cursor anomalies', () => {
+  const stop = classifyHistoryTailProbeStop({
+    listCount: 0,
+    repeatedCursor: false,
+    cursor: {
+      max: 123,
+      view_at: 1_717_000_000,
+      has_more: true,
+    },
+  });
+
+  assert.equal(stop.stopReason, 'empty_page_cursor_anomaly');
+  assert.equal(stop.reachedDeclaredEnd, false);
+});
+
+test('classifies declared end cursors as terminal end', () => {
+  const stop = classifyHistoryTailProbeStop({
+    listCount: 30,
+    repeatedCursor: false,
+    cursor: {
+      max: 0,
+      view_at: 0,
+      has_more: false,
+    },
+  });
+
+  assert.equal(stop.stopReason, 'api_end');
+  assert.equal(stop.reachedDeclaredEnd, true);
+});


### PR DESCRIPTION
## Summary
- add a bounded `PROBE_HISTORY_TAIL` runtime path that pages the Bilibili history cursor API without writing history rows
- report requested/normalized page limits, per-page item counts and view_at range, requested/response cursors, repeated-cursor detection, short/empty page anomalies, final stop reason, and API-declared end state
- expose the probe from the popup as a diagnostics-only action with aggregated output only

Closes #86

## Root-cause judgment
Still inconclusive from this thread.

What this PR proves:
- the extension now has a bounded runtime probe that can distinguish API-declared end, repeated cursor loops, empty-page anomalies, and page-limit stops without touching the local history DB
- the probe output is privacy-bounded and sufficient to decide whether the upstream API itself stops early once someone runs it in the logged-in extension runtime

What this PR does not yet prove:
- whether this specific account/session can only page a short recent history range from Bilibili
- whether the live API can page deeper than the current sync path for this user

Why still inconclusive:
- I did not execute the new probe inside a live logged-in extension runtime in this thread, and I did not read cookies, browser profiles, or login-state files

## Diagnostics
- runtime request action: `PROBE_HISTORY_TAIL`
- bounded report fields: requested max pages, normalized page limit, page index, per-page item count, newest/oldest `view_at`, requested/response cursor (`max` / `view_at` / `business` / `has_more`), repeated cursor flag, short-page anomaly, empty-page anomaly, terminal stop reason, reached declared end
- focused tests cover repeated cursor, short page anomaly classification, empty-page anomaly, and terminal end classification

## Validation
- `git diff --check`
- `node --test tests/history-tail-probe.test.ts tests/history-sync-diagnostics.test.ts tests/streak-diagnostics.test.ts`
- `npm run typecheck`
- `npm run build`

## Blocker
- live probe execution in a logged-in extension runtime is still needed to make the final API-vs-sync root-cause call

## Must-fix
- none

## Follow-up
- run the popup tail probe with the affected logged-in session and capture only the aggregated report
- if the probe reaches `api_end` or `api_end_empty_page` near the current recent range, conclude the upstream API is short for that session
- if the probe pages substantially deeper than the current synced range without early end, inspect the sync path separately

## Privacy boundary
- no cookie files, browser profiles, login-state files, local key files, raw API dumps, full history rows, or DB exports were read or uploaded
- the probe stores no fetched history rows and surfaces aggregate/page-level diagnostics only
