### PR TITLE
[codex] fix Smart Favorites itemKey uniqueness crashes

### DIFF
--- a/dashboard/modules/favorites/SmartFavoritesPage.tsx
+++ b/dashboard/modules/favorites/SmartFavoritesPage.tsx
@@ -89,10 +89,16 @@ export function SmartFavoritesPage() {
     try {
       const result = await requestSW<FavoriteSyncResult>('SYNC_FAVORITES');
       if (result.status === 'blocked') {
-        setError(result.blockedReason ?? 'Favorite sync incomplete; available data was kept.');
-        setNotice(`Sync incomplete: kept/updated ${result.insertedOrUpdated} usable videos, deleted nothing. Bilibili reported ${result.reportedItems}, newly stored ${result.items}, filtered ${result.filteredItems}; see audit below.`);
+        setError(result.blockedReason ?? '收藏同步未完成，已保留当前可用数据。');
+        setNotice(joinNoticeParts([
+          `收藏同步未完成：已保留并更新 ${result.insertedOrUpdated} 条可用视频，未删除旧数据。Bilibili 报告 ${result.reportedItems} 条，本次写入 ${result.items} 条，过滤 ${result.filteredItems} 条。`,
+          ...result.notes,
+        ]));
       } else {
-        setNotice(`Sync complete: ${result.folders} folders, ${result.items} locally stored videos, ${result.filteredItems} filtered resources.`);
+        setNotice(joinNoticeParts([
+          `收藏同步完成：${result.folders} 个收藏夹，本地写入 ${result.insertedOrUpdated} 条视频，过滤 ${result.filteredItems} 条资源。`,
+          ...result.notes,
+        ]));
       }
       setOverview(await requestSW<SmartFavoriteOverview>('GET_SMART_FAVORITES'));
     } catch (e) {
@@ -106,7 +112,7 @@ export function SmartFavoritesPage() {
     setBusy('index');
     setError(null);
     try {
-      const result: SmartIndexResult = { processed: 0, indexed: 0, failed: 0, skipped: 0 };
+      const result: SmartIndexResult = { processed: 0, indexed: 0, failed: 0, skipped: 0, notes: [] };
       const initialOverview = overview ?? await requestSW<SmartFavoriteOverview>('GET_SMART_FAVORITES');
       let pending = initialOverview.pendingItems;
       let guard = Math.ceil((initialOverview.totalItems + initialOverview.failedItems) / 8) + 4;
@@ -120,7 +126,10 @@ export function SmartFavoritesPage() {
         const latest = await requestSW<SmartFavoriteOverview>('GET_SMART_FAVORITES');
         setOverview(latest);
         pending = latest.pendingItems;
-        setNotice(`智能索引生成中：已处理 ${result.processed} 条，成功 ${result.indexed} 条，失败 ${result.failed} 条`);
+        setNotice(joinNoticeParts([
+          `智能索引生成中：已处理 ${result.processed} 条，成功 ${result.indexed} 条，失败 ${result.failed} 条，跳过 ${result.skipped} 条。`,
+          ...result.notes,
+        ]));
         if (batch.processed === 0) break;
       }
 
@@ -136,11 +145,17 @@ export function SmartFavoritesPage() {
         failedRetriesLeft -= batch.processed;
         const latest = await requestSW<SmartFavoriteOverview>('GET_SMART_FAVORITES');
         setOverview(latest);
-        setNotice(`失败项重试中：已处理 ${result.processed} 条，成功 ${result.indexed} 条，失败 ${result.failed} 条`);
+        setNotice(joinNoticeParts([
+          `失败项重试中：已处理 ${result.processed} 条，成功 ${result.indexed} 条，失败 ${result.failed} 条，跳过 ${result.skipped} 条。`,
+          ...result.notes,
+        ]));
         if (batch.processed === 0) break;
       }
 
-      setNotice(`智能索引完成：新增/更新 ${result.indexed} 条，失败 ${result.failed} 条，跳过 ${result.skipped} 条`);
+      setNotice(joinNoticeParts([
+        `智能索引完成：新增或更新 ${result.indexed} 条，失败 ${result.failed} 条，跳过 ${result.skipped} 条。`,
+        ...result.notes,
+      ]));
       setOverview(await requestSW<SmartFavoriteOverview>('GET_SMART_FAVORITES'));
     } catch (e) {
       setError((e as Error).message);
@@ -407,6 +422,15 @@ function mergeIndexResult(total: SmartIndexResult, batch: SmartIndexResult): voi
   total.indexed += batch.indexed;
   total.failed += batch.failed;
   total.skipped += batch.skipped;
+  for (const note of batch.notes) {
+    if (!total.notes.includes(note)) {
+      total.notes.push(note);
+    }
+  }
+}
+
+function joinNoticeParts(parts: string[]): string {
+  return parts.filter(Boolean).join(' ');
 }
 
 function ResultSection({

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite build --watch --mode development",
     "build": "tsc --noEmit && vite build && vite build --config vite.player-monitor.config.ts",
     "typecheck": "tsc --noEmit",
-    "test:favorites": "node --test tests/favorite-sync-audit.test.ts tests/favorite-folder-gap-probe.test.ts tests/smart-favorites-qa.test.ts",
+    "test:favorites": "node --test tests/favorite-sync-audit.test.ts tests/favorite-folder-gap-probe.test.ts tests/favorite-itemkey-persistence.test.ts tests/smart-favorite-index.test.ts tests/smart-favorites-qa.test.ts",
     "test:current-video-summary": "node --test tests/current-video-summary.test.ts",
     "test:video-knowledge": "node --test tests/video-knowledge.test.ts"
   },

--- a/src/background/ai/openai-compatible.ts
+++ b/src/background/ai/openai-compatible.ts
@@ -1,4 +1,4 @@
-import type { AiConfig } from '../../shared/types/config';
+import type { AiConfig } from '../../shared/types/config.ts';
 
 interface ChatMessage {
   role: 'system' | 'user';

--- a/src/background/favorites/smart.ts
+++ b/src/background/favorites/smart.ts
@@ -9,20 +9,20 @@ import type {
 } from '../../shared/types/favorite';
 import { normalizeFavoriteFoldersWithDiagnostics } from '../../shared/favorite-sync-diagnostics.ts';
 import { summarizeSmartFavoriteIndexCoverage } from '../../shared/smart-favorite-coverage.ts';
-import { loadConfig } from '../storage/config-store';
+import { loadConfig } from '../storage/config-store.ts';
 import {
   getFavoriteFolders,
   getFavoriteItems,
   getSmartFavoriteIndexMap,
   putSmartFavoriteIndex,
-} from '../storage/favorite-repo';
-import { chatJson } from '../ai/openai-compatible';
+} from '../storage/favorite-repo.ts';
+import { chatJson } from '../ai/openai-compatible.ts';
 import {
   buildTaxonomyPromptSummary,
   expandFavoriteSearchTerms,
   normalizeFavoritePath,
   UNCATEGORIZED_PATH,
-} from './taxonomy';
+} from './taxonomy.ts';
 
 interface AiFavoriteIndexResponse {
   path?: unknown;
@@ -37,6 +37,24 @@ interface AiQueryRewriteResponse {
 
 const DEFAULT_INDEX_LIMIT = 200;
 
+type SmartAiConfig = Awaited<ReturnType<typeof loadConfig>>['ai'];
+
+interface SmartFavoriteIndexDeps {
+  createSmartIndex: (item: FavoriteItem, config: SmartAiConfig) => Promise<AiFavoriteIndexResponse>;
+  getFavoriteItems: typeof getFavoriteItems;
+  getSmartFavoriteIndexMap: typeof getSmartFavoriteIndexMap;
+  loadConfig: typeof loadConfig;
+  putSmartFavoriteIndex: typeof putSmartFavoriteIndex;
+}
+
+const defaultSmartFavoriteIndexDeps: SmartFavoriteIndexDeps = {
+  createSmartIndex,
+  getFavoriteItems,
+  getSmartFavoriteIndexMap,
+  loadConfig,
+  putSmartFavoriteIndex,
+};
+
 export interface SmartFavoriteIndexOptions {
   includeFailed?: boolean;
   failedOnly?: boolean;
@@ -45,11 +63,12 @@ export interface SmartFavoriteIndexOptions {
 export async function buildSmartFavoriteIndex(
   maxItems = DEFAULT_INDEX_LIMIT,
   options: SmartFavoriteIndexOptions = {},
+  deps: SmartFavoriteIndexDeps = defaultSmartFavoriteIndexDeps,
 ): Promise<SmartIndexResult> {
-  const config = await loadConfig();
-  const items = await getFavoriteItems();
-  const indexes = await getSmartFavoriteIndexMap();
-  const result: SmartIndexResult = { processed: 0, indexed: 0, failed: 0, skipped: 0 };
+  const config = await deps.loadConfig();
+  const items = await deps.getFavoriteItems();
+  const indexes = await deps.getSmartFavoriteIndexMap();
+  const result: SmartIndexResult = { processed: 0, indexed: 0, failed: 0, skipped: 0, notes: [] };
   const candidates = items
     .map(item => {
       const contentHash = hashText(buildFavoriteDocument(item));
@@ -69,9 +88,9 @@ export async function buildSmartFavoriteIndex(
 
     result.processed++;
     try {
-      const ai = await createSmartIndex(item, config.ai);
+      const ai = await deps.createSmartIndex(item, config.ai);
       const path = normalizeFavoritePath(ai.path, item);
-      await putSmartFavoriteIndex({
+      const write = await deps.putSmartFavoriteIndex({
         itemKey: item.itemKey,
         path,
         summary: normalizeText(ai.summary, item.intro || item.title),
@@ -83,9 +102,14 @@ export async function buildSmartFavoriteIndex(
         status: 'indexed',
         indexedAt: Date.now(),
       });
-      result.indexed++;
+      mergeNotes(result.notes, write.notes);
+      if (write.written > 0) {
+        result.indexed++;
+      } else {
+        result.skipped++;
+      }
     } catch (error) {
-      await putSmartFavoriteIndex({
+      const write = await deps.putSmartFavoriteIndex({
         itemKey: item.itemKey,
         path: UNCATEGORIZED_PATH,
         summary: item.intro || item.title,
@@ -98,7 +122,12 @@ export async function buildSmartFavoriteIndex(
         error: error instanceof Error ? error.message : String(error),
         indexedAt: Date.now(),
       });
-      result.failed++;
+      mergeNotes(result.notes, write.notes);
+      if (write.written > 0) {
+        result.failed++;
+      } else {
+        result.skipped++;
+      }
     }
   }
 
@@ -191,7 +220,7 @@ export async function getSmartFavoritesByPath(path: string[], limit = 200): Prom
     .slice(0, limit);
 }
 
-async function createSmartIndex(item: FavoriteItem, config: Awaited<ReturnType<typeof loadConfig>>['ai']): Promise<AiFavoriteIndexResponse> {
+async function createSmartIndex(item: FavoriteItem, config: SmartAiConfig): Promise<AiFavoriteIndexResponse> {
   return chatJson<AiFavoriteIndexResponse>(config, [
     {
       role: 'system',
@@ -209,6 +238,14 @@ async function createSmartIndex(item: FavoriteItem, config: Awaited<ReturnType<t
       content: buildFavoriteDocument(item),
     },
   ]);
+}
+
+function mergeNotes(target: string[], incoming: string[]): void {
+  for (const note of incoming) {
+    if (!target.includes(note)) {
+      target.push(note);
+    }
+  }
 }
 
 async function rewriteQuery(

--- a/src/background/favorites/sync-persistence.ts
+++ b/src/background/favorites/sync-persistence.ts
@@ -1,12 +1,13 @@
 import type { FavoriteFolder, FavoriteFolderSyncDiagnostic, FavoriteItem } from '../../shared/types/favorite';
+import type { FavoriteRepoWriteResult } from '../storage/favorite-repo';
 
 export interface FavoriteSyncPersistenceRepo {
-  replaceFavoriteSnapshot(folders: FavoriteFolder[], items: FavoriteItem[]): Promise<number>;
+  replaceFavoriteSnapshot(folders: FavoriteFolder[], items: FavoriteItem[]): Promise<FavoriteRepoWriteResult>;
   updateFavoriteFolderSyncDiagnostics(
     folders: FavoriteFolder[],
     diagnostics: FavoriteFolderSyncDiagnostic[],
-  ): Promise<void>;
-  upsertFavoriteItems(items: FavoriteItem[]): Promise<number>;
+  ): Promise<FavoriteRepoWriteResult>;
+  upsertFavoriteItems(items: FavoriteItem[]): Promise<FavoriteRepoWriteResult>;
 }
 
 export interface FavoriteSyncPersistenceInput {
@@ -19,6 +20,7 @@ export interface FavoriteSyncPersistenceInput {
 export interface FavoriteSyncPersistenceResult {
   insertedOrUpdated: number;
   destructiveReplacement: boolean;
+  notes: string[];
 }
 
 export async function persistFavoriteSyncData(
@@ -28,16 +30,20 @@ export async function persistFavoriteSyncData(
   const foldersWithDiagnostics = attachDiagnosticsToFolders(input.folders, input.diagnostics);
 
   if (input.complete) {
+    const write = await repo.replaceFavoriteSnapshot(foldersWithDiagnostics, input.items);
     return {
-      insertedOrUpdated: await repo.replaceFavoriteSnapshot(foldersWithDiagnostics, input.items),
+      insertedOrUpdated: write.written,
       destructiveReplacement: true,
+      notes: write.notes,
     };
   }
 
-  await repo.updateFavoriteFolderSyncDiagnostics(foldersWithDiagnostics, input.diagnostics);
+  const folderWrite = await repo.updateFavoriteFolderSyncDiagnostics(foldersWithDiagnostics, input.diagnostics);
+  const itemWrite = await repo.upsertFavoriteItems(input.items);
   return {
-    insertedOrUpdated: await repo.upsertFavoriteItems(input.items),
+    insertedOrUpdated: itemWrite.written,
     destructiveReplacement: false,
+    notes: [...folderWrite.notes, ...itemWrite.notes],
   };
 }
 

--- a/src/background/favorites/sync.ts
+++ b/src/background/favorites/sync.ts
@@ -54,6 +54,7 @@ export async function syncFavorites(): Promise<FavoriteSyncResult> {
       filteredItems: diagnostics.reduce((sum, diagnostic) => sum + diagnostic.filteredItems, 0),
       blockedReason: assessment.reason,
       diagnostics,
+      notes: persistence.notes,
       syncedAt,
     };
   }
@@ -71,6 +72,7 @@ export async function syncFavorites(): Promise<FavoriteSyncResult> {
     reportedItems: reportedItemCount,
     filteredItems: diagnostics.reduce((sum, diagnostic) => sum + diagnostic.filteredItems, 0),
     diagnostics,
+    notes: persistence.notes,
     syncedAt,
   };
 }

--- a/src/background/favorites/taxonomy.ts
+++ b/src/background/favorites/taxonomy.ts
@@ -1,4 +1,4 @@
-import type { FavoriteItem } from '../../shared/types/favorite';
+import type { FavoriteItem } from '../../shared/types/favorite.ts';
 
 export const UNCATEGORIZED_PATH = ['未分类'];
 

--- a/src/background/storage/config-store.ts
+++ b/src/background/storage/config-store.ts
@@ -1,5 +1,5 @@
-import { DEFAULT_CONFIG, type UserConfig } from '../../shared/types/config';
-import type { HistorySyncProgress } from '../../shared/types/history-sync';
+import { DEFAULT_CONFIG, type UserConfig } from '../../shared/types/config.ts';
+import type { HistorySyncProgress } from '../../shared/types/history-sync.ts';
 
 const CONFIG_KEY = 'userConfig';
 const HISTORY_SYNC_PROGRESS_KEY = 'historySyncProgress';

--- a/src/background/storage/db.ts
+++ b/src/background/storage/db.ts
@@ -1,13 +1,13 @@
 import Dexie, { type Table } from 'dexie';
-import type { WatchHistoryRecord, PlayerEvent, DailyAggregate } from '../../shared/types/watch-event';
-import type { FavoriteFolder, FavoriteItem, SmartFavoriteIndex } from '../../shared/types/favorite';
+import type { WatchHistoryRecord, PlayerEvent, DailyAggregate } from '../../shared/types/watch-event.ts';
+import type { FavoriteFolder, FavoriteItem, SmartFavoriteIndex } from '../../shared/types/favorite.ts';
 import type {
   DynamicBillExplanation,
   DynamicBillFeedbackRecord,
   DynamicBillItem,
   FollowedCreator,
   FollowedVideoUpdate,
-} from '../../shared/types/dynamic-bill';
+} from '../../shared/types/dynamic-bill.ts';
 
 export class BiliAnalyticsDB extends Dexie {
   watchHistory!: Table<WatchHistoryRecord, number>;

--- a/src/background/storage/favorite-repo.ts
+++ b/src/background/storage/favorite-repo.ts
@@ -1,16 +1,39 @@
-import type { FavoriteFolder, FavoriteFolderSyncDiagnostic, FavoriteItem, SmartFavoriteIndex } from '../../shared/types/favorite';
-import { db } from './db';
+import type {
+  FavoriteFolder,
+  FavoriteFolderSyncDiagnostic,
+  FavoriteItem,
+  SmartFavoriteIndex,
+} from '../../shared/types/favorite';
+import { db } from './db.ts';
+import {
+  prepareFavoriteFolderRows,
+  prepareFavoriteItemRows,
+  prepareSmartFavoriteIndexRows,
+} from './favorite-write-prep.ts';
 
-export async function replaceFavoriteSnapshot(folders: FavoriteFolder[], items: FavoriteItem[]): Promise<number> {
-  const folderMediaIds = new Set(folders.map(folder => folder.mediaId));
-  const itemKeys = new Set(items.map(item => item.itemKey));
+export interface FavoriteRepoWriteResult {
+  written: number;
+  notes: string[];
+}
+
+export async function replaceFavoriteSnapshot(
+  folders: FavoriteFolder[],
+  items: FavoriteItem[],
+): Promise<FavoriteRepoWriteResult> {
+  const preparedFolders = prepareFavoriteFolderRows(folders);
+  const preparedItems = prepareFavoriteItemRows(items);
+  const folderMediaIds = new Set(preparedFolders.rows.map(folder => folder.mediaId));
+  const itemKeys = new Set(preparedItems.rows.map(item => item.itemKey));
 
   await db.transaction('rw', db.favoriteFolders, db.favoriteItems, db.smartFavoriteIndex, async () => {
-    if (folders.length > 0) {
-      await db.favoriteFolders.bulkPut(folders);
+    const folderRows = await attachExistingFavoriteFolderIds(preparedFolders.rows);
+    const itemRows = await attachExistingFavoriteItemIds(preparedItems.rows);
+
+    if (folderRows.length > 0) {
+      await db.favoriteFolders.bulkPut(folderRows);
     }
-    if (items.length > 0) {
-      await db.favoriteItems.bulkPut(items);
+    if (itemRows.length > 0) {
+      await db.favoriteItems.bulkPut(itemRows);
     }
 
     await db.favoriteFolders
@@ -26,19 +49,28 @@ export async function replaceFavoriteSnapshot(folders: FavoriteFolder[], items: 
       .delete();
   });
 
-  return items.length;
+  return {
+    written: preparedItems.rows.length,
+    notes: [...preparedFolders.notes, ...preparedItems.notes],
+  };
 }
 
-export async function upsertFavoriteFolders(folders: FavoriteFolder[]): Promise<void> {
-  if (folders.length === 0) return;
-  await db.favoriteFolders.bulkPut(folders);
+export async function upsertFavoriteFolders(folders: FavoriteFolder[]): Promise<FavoriteRepoWriteResult> {
+  const prepared = prepareFavoriteFolderRows(folders);
+  if (prepared.rows.length === 0) {
+    return { written: 0, notes: prepared.notes };
+  }
+
+  const rows = await attachExistingFavoriteFolderIds(prepared.rows);
+  await db.favoriteFolders.bulkPut(rows);
+  return { written: rows.length, notes: prepared.notes };
 }
 
 export async function updateFavoriteFolderSyncDiagnostics(
   folders: FavoriteFolder[],
   diagnostics: FavoriteFolderSyncDiagnostic[],
-): Promise<void> {
-  if (folders.length === 0) return;
+): Promise<FavoriteRepoWriteResult> {
+  if (folders.length === 0) return { written: 0, notes: [] };
 
   const diagnosticByMediaId = new Map(diagnostics.map(diagnostic => [diagnostic.mediaId, diagnostic]));
   const existingFolders = await db.favoriteFolders.toArray();
@@ -49,13 +81,18 @@ export async function updateFavoriteFolderSyncDiagnostics(
     lastSyncDiagnostic: diagnosticByMediaId.get(folder.mediaId),
   }));
 
-  await db.favoriteFolders.bulkPut(merged);
+  return await upsertFavoriteFolders(merged);
 }
 
-export async function upsertFavoriteItems(items: FavoriteItem[]): Promise<number> {
-  if (items.length === 0) return 0;
-  await db.favoriteItems.bulkPut(items);
-  return items.length;
+export async function upsertFavoriteItems(items: FavoriteItem[]): Promise<FavoriteRepoWriteResult> {
+  const prepared = prepareFavoriteItemRows(items);
+  if (prepared.rows.length === 0) {
+    return { written: 0, notes: prepared.notes };
+  }
+
+  const rows = await attachExistingFavoriteItemIds(prepared.rows);
+  await db.favoriteItems.bulkPut(rows);
+  return { written: rows.length, notes: prepared.notes };
 }
 
 export async function getFavoriteFolders(): Promise<FavoriteFolder[]> {
@@ -87,10 +124,50 @@ export async function getSmartFavoriteIndexMap(): Promise<Map<string, SmartFavor
   return new Map(indexes.map(index => [index.itemKey, index]));
 }
 
-export async function putSmartFavoriteIndex(index: SmartFavoriteIndex): Promise<void> {
-  await db.smartFavoriteIndex.put(index);
+export async function putSmartFavoriteIndex(index: SmartFavoriteIndex): Promise<FavoriteRepoWriteResult> {
+  const prepared = prepareSmartFavoriteIndexRows([index]);
+  if (prepared.rows.length === 0) {
+    return { written: 0, notes: prepared.notes };
+  }
+
+  const [row] = await attachExistingSmartFavoriteIndexIds(prepared.rows);
+  await db.smartFavoriteIndex.put(row);
+  return { written: 1, notes: prepared.notes };
 }
 
 export async function countIndexedFavorites(): Promise<number> {
   return db.smartFavoriteIndex.where({ status: 'indexed' }).count();
+}
+
+async function attachExistingFavoriteFolderIds(folders: FavoriteFolder[]): Promise<FavoriteFolder[]> {
+  if (folders.length === 0) return [];
+  const mediaIds = folders.map(folder => folder.mediaId);
+  const existing = await db.favoriteFolders.where('mediaId').anyOf(mediaIds).toArray();
+  const existingByMediaId = new Map(existing.map(folder => [folder.mediaId, folder.id]));
+  return folders.map(folder => {
+    const id = existingByMediaId.get(folder.mediaId);
+    return typeof id === 'number' ? { ...folder, id } : folder;
+  });
+}
+
+async function attachExistingFavoriteItemIds(items: FavoriteItem[]): Promise<FavoriteItem[]> {
+  if (items.length === 0) return [];
+  const itemKeys = items.map(item => item.itemKey);
+  const existing = await db.favoriteItems.where('itemKey').anyOf(itemKeys).toArray();
+  const existingByItemKey = new Map(existing.map(item => [item.itemKey, item.id]));
+  return items.map(item => {
+    const id = existingByItemKey.get(item.itemKey);
+    return typeof id === 'number' ? { ...item, id } : item;
+  });
+}
+
+async function attachExistingSmartFavoriteIndexIds(indexes: SmartFavoriteIndex[]): Promise<SmartFavoriteIndex[]> {
+  if (indexes.length === 0) return [];
+  const itemKeys = indexes.map(index => index.itemKey);
+  const existing = await db.smartFavoriteIndex.where('itemKey').anyOf(itemKeys).toArray();
+  const existingByItemKey = new Map(existing.map(index => [index.itemKey, index.id]));
+  return indexes.map(index => {
+    const id = existingByItemKey.get(index.itemKey);
+    return typeof id === 'number' ? { ...index, id } : index;
+  });
 }

--- a/src/background/storage/favorite-write-prep.ts
+++ b/src/background/storage/favorite-write-prep.ts
@@ -1,0 +1,177 @@
+import type {
+  FavoriteFolder,
+  FavoriteItem,
+  SmartFavoriteIndex,
+} from '../../shared/types/favorite.ts';
+
+export interface PreparedRows<T> {
+  rows: T[];
+  notes: string[];
+}
+
+export function prepareFavoriteFolderRows(folders: FavoriteFolder[]): PreparedRows<FavoriteFolder> {
+  const byMediaId = new Map<number, FavoriteFolder>();
+  let duplicateCount = 0;
+  let invalidCount = 0;
+
+  for (const folder of folders) {
+    const mediaId = Number(folder.mediaId ?? 0);
+    if (!Number.isFinite(mediaId) || mediaId <= 0) {
+      invalidCount++;
+      continue;
+    }
+
+    const current = byMediaId.get(mediaId);
+    if (current) duplicateCount++;
+    byMediaId.set(mediaId, mergeFavoriteFolder(current, folder));
+  }
+
+  return {
+    rows: Array.from(byMediaId.values()),
+    notes: buildNotes(
+      invalidCount,
+      '收藏夹同步时跳过了 {count} 条缺少 mediaId 的异常收藏夹记录。',
+      duplicateCount,
+      '收藏夹同步时发现 {count} 个重复收藏夹，已按最新结果覆盖。',
+    ),
+  };
+}
+
+export function prepareFavoriteItemRows(items: FavoriteItem[]): PreparedRows<FavoriteItem> {
+  const byItemKey = new Map<string, FavoriteItem>();
+  let duplicateCount = 0;
+  let invalidCount = 0;
+
+  for (const item of items) {
+    const itemKey = normalizeItemKey(item.itemKey);
+    if (!itemKey) {
+      invalidCount++;
+      continue;
+    }
+
+    const current = byItemKey.get(itemKey);
+    if (current) duplicateCount++;
+    byItemKey.set(itemKey, mergeFavoriteItem(current, { ...item, itemKey }));
+  }
+
+  return {
+    rows: Array.from(byItemKey.values()),
+    notes: buildNotes(
+      invalidCount,
+      '收藏同步时跳过了 {count} 条缺少 itemKey 的异常视频记录。',
+      duplicateCount,
+      '收藏同步时发现 {count} 条重复收藏视频，已按最新记录覆盖。',
+    ),
+  };
+}
+
+export function prepareSmartFavoriteIndexRows(indexes: SmartFavoriteIndex[]): PreparedRows<SmartFavoriteIndex> {
+  const byItemKey = new Map<string, SmartFavoriteIndex>();
+  let duplicateCount = 0;
+  let invalidCount = 0;
+
+  for (const index of indexes) {
+    const itemKey = normalizeItemKey(index.itemKey);
+    if (!itemKey) {
+      invalidCount++;
+      continue;
+    }
+
+    const current = byItemKey.get(itemKey);
+    if (current) duplicateCount++;
+    byItemKey.set(itemKey, mergeSmartFavoriteIndex(current, { ...index, itemKey }));
+  }
+
+  return {
+    rows: Array.from(byItemKey.values()),
+    notes: buildNotes(
+      invalidCount,
+      '智能索引写入时跳过了 {count} 条缺少 itemKey 的异常索引记录。',
+      duplicateCount,
+      '智能索引写入时发现 {count} 条重复 itemKey，已按最新结果覆盖。',
+    ),
+  };
+}
+
+function mergeFavoriteFolder(current: FavoriteFolder | undefined, next: FavoriteFolder): FavoriteFolder {
+  if (!current) return next;
+  return {
+    ...current,
+    ...next,
+    title: next.title || current.title,
+    cover: next.cover || current.cover,
+    intro: next.intro || current.intro,
+    mediaCount: Math.max(current.mediaCount, next.mediaCount),
+    createdAt: pickPositive(current.createdAt, next.createdAt),
+    updatedAt: Math.max(current.updatedAt, next.updatedAt),
+    syncedAt: Math.max(current.syncedAt, next.syncedAt),
+    lastSyncDiagnostic: next.lastSyncDiagnostic ?? current.lastSyncDiagnostic,
+  };
+}
+
+function mergeFavoriteItem(current: FavoriteItem | undefined, next: FavoriteItem): FavoriteItem {
+  if (!current) return next;
+  return {
+    ...current,
+    ...next,
+    folderTitle: next.folderTitle || current.folderTitle,
+    avid: pickPositive(current.avid, next.avid),
+    bvid: next.bvid || current.bvid,
+    title: next.title || current.title,
+    intro: preferLongerText(current.intro, next.intro),
+    authorName: next.authorName || current.authorName,
+    authorMid: pickPositive(current.authorMid, next.authorMid),
+    tagName: next.tagName || current.tagName,
+    tags: next.tags.length > 0 ? next.tags : current.tags,
+    cover: next.cover || current.cover,
+    duration: Math.max(current.duration, next.duration),
+    pubtime: Math.max(current.pubtime, next.pubtime),
+    favTime: Math.max(current.favTime, next.favTime),
+    syncedAt: Math.max(current.syncedAt, next.syncedAt),
+  };
+}
+
+function mergeSmartFavoriteIndex(current: SmartFavoriteIndex | undefined, next: SmartFavoriteIndex): SmartFavoriteIndex {
+  if (!current) return next;
+  return {
+    ...current,
+    ...next,
+    path: next.path.length > 0 ? next.path : current.path,
+    summary: next.summary || current.summary,
+    keywords: next.keywords.length > 0 ? next.keywords : current.keywords,
+    aliases: next.aliases.length > 0 ? next.aliases : current.aliases,
+    searchableText: next.searchableText || current.searchableText,
+    contentHash: next.contentHash || current.contentHash,
+    model: next.model || current.model,
+    error: next.error || current.error,
+    indexedAt: Math.max(current.indexedAt, next.indexedAt),
+  };
+}
+
+function buildNotes(
+  invalidCount: number,
+  invalidTemplate: string,
+  duplicateCount: number,
+  duplicateTemplate: string,
+): string[] {
+  const notes: string[] = [];
+  if (invalidCount > 0) {
+    notes.push(invalidTemplate.replace('{count}', String(invalidCount)));
+  }
+  if (duplicateCount > 0) {
+    notes.push(duplicateTemplate.replace('{count}', String(duplicateCount)));
+  }
+  return notes;
+}
+
+function normalizeItemKey(itemKey: string | undefined): string {
+  return typeof itemKey === 'string' ? itemKey.trim() : '';
+}
+
+function pickPositive(current: number, next: number): number {
+  return next > 0 ? next : current;
+}
+
+function preferLongerText(current: string, next: string): string {
+  return next.length >= current.length ? next : current;
+}

--- a/src/shared/types/favorite.ts
+++ b/src/shared/types/favorite.ts
@@ -140,6 +140,7 @@ export interface FavoriteSyncResult {
   filteredItems: number;
   blockedReason?: string;
   diagnostics: FavoriteFolderSyncDiagnostic[];
+  notes: string[];
   syncedAt: number;
 }
 
@@ -188,6 +189,7 @@ export interface SmartIndexResult {
   indexed: number;
   failed: number;
   skipped: number;
+  notes: string[];
 }
 
 export interface SmartFavoriteSearchResponse {

--- a/tests/favorite-itemkey-persistence.test.ts
+++ b/tests/favorite-itemkey-persistence.test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  prepareFavoriteFolderRows,
+  prepareFavoriteItemRows,
+  prepareSmartFavoriteIndexRows,
+} from '../src/background/storage/favorite-write-prep.ts';
+import type { FavoriteFolder, FavoriteItem, SmartFavoriteIndex } from '../src/shared/types/favorite.ts';
+
+test('keeps the same video in different folders but dedupes duplicate itemKey rows within one sync batch', () => {
+  const duplicate = makeFavoriteItem(100, 1, {
+    title: 'Video 1 refreshed',
+    intro: 'A longer intro for the merged record.',
+    syncedAt: 99,
+  });
+  const prepared = prepareFavoriteItemRows([
+    makeFavoriteItem(100, 1),
+    duplicate,
+    makeFavoriteItem(101, 1),
+  ]);
+
+  assert.equal(prepared.rows.length, 2);
+  assert.deepEqual(
+    prepared.rows.map(item => item.itemKey).sort(),
+    ['100:BV1', '101:BV1'],
+  );
+  assert.equal(
+    prepared.rows.find(item => item.itemKey === '100:BV1')?.title,
+    'Video 1 refreshed',
+  );
+  assert.equal(
+    prepared.rows.find(item => item.itemKey === '100:BV1')?.intro,
+    'A longer intro for the merged record.',
+  );
+  assert.match(prepared.notes.join(' '), /重复收藏视频/);
+});
+
+test('dedupes repeated folder mediaId and keeps Chinese diagnostics', () => {
+  const prepared = prepareFavoriteFolderRows([
+    makeFavoriteFolder(100, { title: 'Old title', syncedAt: 1 }),
+    makeFavoriteFolder(100, { title: 'New title', syncedAt: 2 }),
+    { ...makeFavoriteFolder(0), mediaId: 0 },
+  ]);
+
+  assert.equal(prepared.rows.length, 1);
+  assert.equal(prepared.rows[0]?.title, 'New title');
+  assert.match(prepared.notes.join(' '), /重复收藏夹/);
+  assert.match(prepared.notes.join(' '), /缺少 mediaId/);
+});
+
+test('skips corrupt smart index itemKey values instead of propagating raw uniqueness errors', () => {
+  const prepared = prepareSmartFavoriteIndexRows([
+    makeSmartIndex(''),
+    makeSmartIndex('100:BV1', { summary: 'old' }),
+    makeSmartIndex('100:BV1', { summary: 'new' }),
+  ]);
+
+  assert.equal(prepared.rows.length, 1);
+  assert.equal(prepared.rows[0]?.summary, 'new');
+  assert.match(prepared.notes.join(' '), /缺少 itemKey/);
+  assert.match(prepared.notes.join(' '), /重复 itemKey/);
+});
+
+function makeFavoriteFolder(mediaId: number, overrides: Partial<FavoriteFolder> = {}): FavoriteFolder {
+  return {
+    mediaId,
+    title: `Folder ${mediaId}`,
+    cover: '',
+    intro: '',
+    mediaCount: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    syncedAt: 1,
+    ...overrides,
+  };
+}
+
+function makeFavoriteItem(mediaId: number, id: number, overrides: Partial<FavoriteItem> = {}): FavoriteItem {
+  return {
+    itemKey: `${mediaId}:BV${id}`,
+    mediaId,
+    folderTitle: `Folder ${mediaId}`,
+    avid: id,
+    bvid: `BV${id}`,
+    title: `Video ${id}`,
+    intro: '',
+    authorName: `UP ${id}`,
+    authorMid: id,
+    tagName: '',
+    tags: [],
+    cover: '',
+    duration: 0,
+    pubtime: 0,
+    favTime: id,
+    syncedAt: 1,
+    ...overrides,
+  };
+}
+
+function makeSmartIndex(itemKey: string, overrides: Partial<SmartFavoriteIndex> = {}): SmartFavoriteIndex {
+  return {
+    itemKey,
+    path: ['知识'],
+    summary: 'summary',
+    keywords: ['keyword'],
+    aliases: [],
+    searchableText: 'summary keyword',
+    contentHash: 'hash',
+    model: 'test-model',
+    status: 'indexed',
+    indexedAt: 1,
+    ...overrides,
+  };
+}

--- a/tests/favorite-sync-audit.test.ts
+++ b/tests/favorite-sync-audit.test.ts
@@ -190,17 +190,18 @@ test('incomplete favorite sync upserts fetched items without snapshot replacemen
     {
       async replaceFavoriteSnapshot() {
         calls.push('replace');
-        return 0;
+        return { written: 0, notes: [] };
       },
       async updateFavoriteFolderSyncDiagnostics(folders, diagnostics) {
         calls.push('diagnostics');
         assert.equal(folders[0].lastSyncDiagnostic?.unexplainedDelta, 21);
         assert.equal(diagnostics[0].mediaId, 100);
+        return { written: folders.length, notes: [] };
       },
       async upsertFavoriteItems(items) {
         calls.push('upsert-items');
         assert.deepEqual(items.map(saved => saved.itemKey), [item.itemKey]);
-        return items.length;
+        return { written: items.length, notes: [] };
       },
     },
   );
@@ -208,6 +209,7 @@ test('incomplete favorite sync upserts fetched items without snapshot replacemen
   assert.deepEqual(calls, ['diagnostics', 'upsert-items']);
   assert.equal(result.destructiveReplacement, false);
   assert.equal(result.insertedOrUpdated, 1);
+  assert.deepEqual(result.notes, []);
 });
 
 function makeVideos(count: number, offset: number): FavoriteResourceApiItem[] {

--- a/tests/smart-favorite-index.test.ts
+++ b/tests/smart-favorite-index.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildSmartFavoriteIndex } from '../src/background/favorites/smart.ts';
+import type { FavoriteItem, SmartFavoriteIndex } from '../src/shared/types/favorite.ts';
+
+test('repeated smart index generation rewrites an existing itemKey instead of crashing', async () => {
+  const item = makeFavoriteItem('100:BV1');
+  const writes: SmartFavoriteIndex[] = [];
+
+  const result = await buildSmartFavoriteIndex(
+    4,
+    {},
+    {
+      async createSmartIndex() {
+        return {
+          path: ['知识', '历史'],
+          summary: 'updated summary',
+          keywords: ['kursk'],
+          aliases: ['battle'],
+        };
+      },
+      async getFavoriteItems() {
+        return [item];
+      },
+      async getSmartFavoriteIndexMap() {
+        return new Map([[
+          item.itemKey,
+          makeSmartIndex(item.itemKey, {
+            status: 'failed',
+            contentHash: 'stale-hash',
+          }),
+        ]]);
+      },
+      async loadConfig() {
+        return {
+          ai: {
+            baseURL: 'https://example.com',
+            apiKey: 'test-key',
+            chatModel: 'test-model',
+          },
+        };
+      },
+      async putSmartFavoriteIndex(index) {
+        writes.push(index);
+        return { written: 1, notes: [] };
+      },
+    },
+  );
+
+  assert.equal(result.processed, 1);
+  assert.equal(result.indexed, 1);
+  assert.equal(result.failed, 0);
+  assert.equal(result.skipped, 0);
+  assert.deepEqual(result.notes, []);
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0]?.itemKey, item.itemKey);
+  assert.equal(writes[0]?.status, 'indexed');
+});
+
+test('corrupt itemKey writes become skipped diagnostics instead of raw ConstraintError failures', async () => {
+  const result = await buildSmartFavoriteIndex(
+    4,
+    {},
+    {
+      async createSmartIndex() {
+        return {
+          path: ['知识'],
+          summary: 'summary',
+          keywords: [],
+          aliases: [],
+        };
+      },
+      async getFavoriteItems() {
+        return [makeFavoriteItem('   ')];
+      },
+      async getSmartFavoriteIndexMap() {
+        return new Map();
+      },
+      async loadConfig() {
+        return {
+          ai: {
+            baseURL: 'https://example.com',
+            apiKey: 'test-key',
+            chatModel: 'test-model',
+          },
+        };
+      },
+      async putSmartFavoriteIndex() {
+        return {
+          written: 0,
+          notes: ['智能索引写入时跳过了 1 条缺少 itemKey 的异常索引记录。'],
+        };
+      },
+    },
+  );
+
+  assert.equal(result.processed, 1);
+  assert.equal(result.indexed, 0);
+  assert.equal(result.failed, 0);
+  assert.equal(result.skipped, 1);
+  assert.match(result.notes.join(' '), /缺少 itemKey/);
+});
+
+function makeFavoriteItem(itemKey: string): FavoriteItem {
+  return {
+    itemKey,
+    mediaId: 100,
+    folderTitle: 'Folder 100',
+    avid: 1,
+    bvid: 'BV1',
+    title: 'Video 1',
+    intro: 'intro',
+    authorName: 'UP 1',
+    authorMid: 1,
+    tagName: '知识',
+    tags: ['历史'],
+    cover: '',
+    duration: 0,
+    pubtime: 0,
+    favTime: 1,
+    syncedAt: 1,
+  };
+}
+
+function makeSmartIndex(itemKey: string, overrides: Partial<SmartFavoriteIndex> = {}): SmartFavoriteIndex {
+  return {
+    itemKey,
+    path: ['知识'],
+    summary: 'summary',
+    keywords: ['keyword'],
+    aliases: [],
+    searchableText: 'summary keyword',
+    contentHash: 'hash',
+    model: 'test-model',
+    status: 'indexed',
+    indexedAt: 1,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
﻿## Summary
- make Smart Favorites persistence upsert by business key instead of auto-increment id so repeated favorite syncs and repeated smart index writes stay idempotent
- dedupe duplicate favorite rows and invalid/corrupt itemKey inputs before writing, and surface clear Chinese diagnostics in sync/index results and Dashboard notices
- add focused regression tests for duplicate resources, repeated smart index generation, incomplete sync non-destructive behavior, and corrupt itemKey skips

## Root Cause
`favoriteItems` and `smartFavoriteIndex` use Dexie tables with auto-increment primary keys (`++id`) plus unique secondary indexes on `itemKey`. The sync and index code called `bulkPut`/`put` without first attaching the existing row `id`, so IndexedDB treated reruns as new inserts and then failed on the unique `itemKey` index with `ConstraintError`. The same pattern also affected favorite folder writes via the unique `mediaId` index.

## Validation
- `git diff --check`
- `npm run test:favorites`
- `npm run typecheck`
- `npm run build`

## Scope
- Fixes issue #92 only
- Does not redesign Smart Favorites taxonomy, Q&A behavior, or classification quality work tracked in #93


## Main-agent review
- Scope verified: Smart Favorites sync/index persistence and related diagnostics/tests only; category quality work remains in #93.
- Re-ran validation in clean review worktree: `npm ci`, `npm run test:favorites`, `npm run typecheck`, `npm run build`, `git diff --check`, and forbidden-copy scan for `未消费|猜你喜欢` in runtime/source/test paths.
- Root-cause judgment accepted: Dexie `++id` primary keys with unique secondary indexes require attaching existing row ids by business key before `put/bulkPut`; otherwise repeated sync/index writes can hit unique `itemKey`/`mediaId` constraints.

Closes #92
