### PR TITLE
[codex] Improve Smart Favorites category precision

### DIFF
--- a/dashboard/modules/favorites/SmartFavoritesPage.tsx
+++ b/dashboard/modules/favorites/SmartFavoritesPage.tsx
@@ -6,6 +6,7 @@ import type {
   FavoriteFolderGapProbeResult,
   FavoriteFolderSyncDiagnostic,
   FavoriteSyncResult,
+  SmartFavoriteCategoryEvidenceKind,
   SmartFavoriteOverview,
   SmartFavoriteQaCitedVideo,
   SmartFavoriteQaResponse,
@@ -383,7 +384,7 @@ export function SmartFavoritesPage() {
             </div>
           </div>
           <div style={{ color: '#666', fontSize: '11px', lineHeight: 1.5, marginBottom: '8px' }}>
-            未分类包含模型归入未分类、索引失败和待索引内容；失败项再次生成索引会重试。
+            待确认表示只有宽泛分类或路径提示，证据不足，未放入具体子类；未分类包含索引失败和待索引内容。
           </div>
           {treeRows.length === 0 ? (
             <div style={{ color: '#666', fontSize: '12px', lineHeight: 1.6 }}>同步并生成智能索引后显示分类</div>
@@ -1042,6 +1043,7 @@ function TreeRow({
 function ResultCard({ result }: { result: SmartFavoriteResult }) {
   const item = result.item;
   const videoUrl = getVideoUrl(item);
+  const categoryEvidence = result.smart?.categoryEvidence;
   return (
     <a
       href={videoUrl ?? undefined}
@@ -1068,6 +1070,9 @@ function ResultCard({ result }: { result: SmartFavoriteResult }) {
         <div style={{ color: '#A0A0B0', fontSize: '12px', lineHeight: 1.5 }}>
           {result.smart?.summary || item.intro || '暂无摘要'}
         </div>
+        <div style={{ color: getCategoryEvidenceColor(categoryEvidence?.kind), fontSize: '11px', lineHeight: 1.5, marginTop: '6px' }}>
+          分类证据：{categoryEvidence?.summary ?? '暂无分类证据说明。'}
+        </div>
         <div style={{ display: 'flex', justifyContent: 'space-between', gap: '8px', alignItems: 'center', marginTop: '6px' }}>
           <span style={{ color: '#666', fontSize: '11px' }}>
             {result.reasons.join(' · ')}{result.score > 0 ? ` · 分数 ${Math.round(result.score)}` : ''}
@@ -1085,6 +1090,21 @@ function getVideoUrl(item: SmartFavoriteResult['item']): string | null {
   if (item.bvid) return `https://www.bilibili.com/video/${item.bvid}`;
   if (item.avid) return `https://www.bilibili.com/video/av${item.avid}`;
   return null;
+}
+
+function getCategoryEvidenceColor(kind: SmartFavoriteCategoryEvidenceKind | undefined): string {
+  switch (kind) {
+    case 'ai':
+      return '#7FD1FF';
+    case 'metadata':
+      return '#A8E6A1';
+    case 'mixed':
+      return '#C9B6FF';
+    case 'path_fallback':
+      return '#FFB347';
+    default:
+      return '#9090A0';
+  }
 }
 
 interface TreeRowData extends SmartFavoriteTreeNode {

--- a/src/background/favorites/smart.ts
+++ b/src/background/favorites/smart.ts
@@ -36,6 +36,7 @@ interface AiQueryRewriteResponse {
 }
 
 const DEFAULT_INDEX_LIMIT = 200;
+const SMART_FAVORITE_INDEX_VERSION = 'smart-favorites-category-v2';
 
 type SmartAiConfig = Awaited<ReturnType<typeof loadConfig>>['ai'];
 
@@ -71,7 +72,7 @@ export async function buildSmartFavoriteIndex(
   const result: SmartIndexResult = { processed: 0, indexed: 0, failed: 0, skipped: 0, notes: [] };
   const candidates = items
     .map(item => {
-      const contentHash = hashText(buildFavoriteDocument(item));
+      const contentHash = hashText(buildFavoriteIndexFingerprint(item));
       const current = indexes.get(item.itemKey);
       return { item, contentHash, current };
     })
@@ -391,6 +392,10 @@ function buildFavoriteDocument(item: FavoriteItem): string {
     `B站分区：${item.tagName || '未知'}`,
     `B站标签：${(item.tags ?? []).join('、') || '无'}`,
   ].join('\n');
+}
+
+function buildFavoriteIndexFingerprint(item: FavoriteItem): string {
+  return [SMART_FAVORITE_INDEX_VERSION, buildFavoriteDocument(item)].join('\n');
 }
 
 function buildSearchableText(item: FavoriteItem, ai?: AiFavoriteIndexResponse, path = classifyFavoritePath(item, ai).path): string {

--- a/src/background/favorites/smart.ts
+++ b/src/background/favorites/smart.ts
@@ -19,8 +19,8 @@ import {
 import { chatJson } from '../ai/openai-compatible.ts';
 import {
   buildTaxonomyPromptSummary,
+  classifyFavoritePath,
   expandFavoriteSearchTerms,
-  normalizeFavoritePath,
   UNCATEGORIZED_PATH,
 } from './taxonomy.ts';
 
@@ -89,14 +89,15 @@ export async function buildSmartFavoriteIndex(
     result.processed++;
     try {
       const ai = await deps.createSmartIndex(item, config.ai);
-      const path = normalizeFavoritePath(ai.path, item);
+      const classification = classifyFavoritePath(item, ai);
       const write = await deps.putSmartFavoriteIndex({
         itemKey: item.itemKey,
-        path,
+        path: classification.path,
         summary: normalizeText(ai.summary, item.intro || item.title),
         keywords: normalizeTextArray(ai.keywords).slice(0, 12),
         aliases: normalizeTextArray(ai.aliases).slice(0, 8),
-        searchableText: buildSearchableText(item, ai, path),
+        categoryEvidence: classification.evidence,
+        searchableText: buildSearchableText(item, ai, classification.path),
         contentHash,
         model: config.ai.chatModel,
         status: 'indexed',
@@ -115,6 +116,13 @@ export async function buildSmartFavoriteIndex(
         summary: item.intro || item.title,
         keywords: [],
         aliases: [],
+        categoryEvidence: {
+          kind: 'path_fallback',
+          summary: '路径兜底：智能索引失败，暂列未分类。',
+          directTerms: [],
+          weakTerms: [],
+          downgraded: true,
+        },
         searchableText: buildSearchableText(item, undefined, UNCATEGORIZED_PATH),
         contentHash,
         model: config.ai.chatModel,
@@ -212,7 +220,7 @@ export async function getSmartFavoritesByPath(path: string[], limit = 200): Prom
         item,
         ...(smart ? { smart } : {}),
         score: 0,
-        reasons: ['分类路径匹配'],
+        reasons: ['分类浏览'],
       } satisfies SmartFavoriteResult;
     })
     .filter((result): result is SmartFavoriteResult => result !== null)
@@ -226,7 +234,9 @@ async function createSmartIndex(item: FavoriteItem, config: SmartAiConfig): Prom
       role: 'system',
       content: [
         '你是一个 B站收藏夹整理助手。请只输出 JSON。',
-        'B站分区和标签是主要依据，原收藏夹名是辅助依据。',
+        '优先依据标题、简介、B站分区、标签和可见文本；原收藏夹名只能作为弱提示。',
+        '只有在标题、简介、标签、AI摘要或关键词出现直接证据时，才输出具体子类，例如“娱乐 / 游戏”。',
+        '如果只能判断到宽泛父类，请返回父类；如果证据不足，请返回 ["待确认"] 或 ["未分类"]，不要强行猜测具体叶子类。',
         '分类路径最多 4 层，颗粒度从高到低；优先使用下面的标准路径，不要随意创造新的一级类目。',
         buildTaxonomyPromptSummary(),
         'JSON 字段：path: string[]，summary: string，keywords: string[]，aliases: string[]。',
@@ -383,7 +393,7 @@ function buildFavoriteDocument(item: FavoriteItem): string {
   ].join('\n');
 }
 
-function buildSearchableText(item: FavoriteItem, ai?: AiFavoriteIndexResponse, path = normalizeFavoritePath(ai?.path, item)): string {
+function buildSearchableText(item: FavoriteItem, ai?: AiFavoriteIndexResponse, path = classifyFavoritePath(item, ai).path): string {
   return [
     buildFavoriteDocument(item),
     path.join(' '),

--- a/src/background/favorites/taxonomy.ts
+++ b/src/background/favorites/taxonomy.ts
@@ -1,16 +1,65 @@
-import type { FavoriteItem } from '../../shared/types/favorite.ts';
+import type {
+  FavoriteItem,
+  SmartFavoriteCategoryEvidence,
+  SmartFavoriteCategoryEvidenceKind,
+} from '../../shared/types/favorite.ts';
 
 export const UNCATEGORIZED_PATH = ['未分类'];
+export const NEEDS_REVIEW_LABEL = '待确认';
 
 interface TaxonomyEntry {
   path: string[];
   terms: string[];
 }
 
-interface TaxonomyMatch {
+interface TaxonomyTermRef {
   entry: TaxonomyEntry;
-  matchedTerm: string;
-  matchedIndex: number;
+  display: string;
+  normalized: string;
+  pathIndex: number;
+  isLeafEvidence: boolean;
+}
+
+interface AiFavoriteClassificationInput {
+  path?: unknown;
+  summary?: unknown;
+  keywords?: unknown;
+  aliases?: unknown;
+}
+
+interface MatchSource {
+  label: string;
+  kind: 'metadata' | 'ai' | 'path';
+  direct: boolean;
+  weight: number;
+  values: string[];
+}
+
+interface LeafScore {
+  entry: TaxonomyEntry;
+  leafDirectScore: number;
+  leafWeakScore: number;
+  directTerms: Set<string>;
+  weakTerms: Set<string>;
+  directSourceKinds: Set<'metadata' | 'ai'>;
+  directLabels: Set<string>;
+  weakLabels: Set<string>;
+}
+
+interface ParentScore {
+  path: string[];
+  directScore: number;
+  weakScore: number;
+  directTerms: Set<string>;
+  weakTerms: Set<string>;
+  directSourceKinds: Set<'metadata' | 'ai'>;
+  directLabels: Set<string>;
+  weakLabels: Set<string>;
+}
+
+export interface FavoritePathClassification {
+  path: string[];
+  evidence: SmartFavoriteCategoryEvidence;
 }
 
 const TAXONOMY: TaxonomyEntry[] = [
@@ -22,11 +71,11 @@ const TAXONOMY: TaxonomyEntry[] = [
   { path: ['知识', '学习'], terms: ['校园学习', '学习', '教程', '公开课', '课程', '考试', '英语', '语言学习'] },
   { path: ['知识', '财经'], terms: ['财经商业', '财经', '商业', '投资', '理财', '金融', '股票', '基金'] },
   { path: ['知识', '职场'], terms: ['职场', '职业', '效率', '办公', '生产力', '管理'] },
-  { path: ['娱乐', '游戏'], terms: ['游戏', '单机游戏', '网络游戏', '电子竞技', '手游', '游戏实况', '主机游戏', 'Steam', '独立游戏'] },
+  { path: ['娱乐', '游戏'], terms: ['游戏', '单机游戏', '网络游戏', '电子竞技', '手游', '游戏实况', '游戏解说', '攻略', '主机游戏', 'Steam', '独立游戏', '开荒', '速通'] },
   { path: ['娱乐', '影视'], terms: ['影视', '电影', '电视剧', '影评', '影视剪辑', '纪录片', '动画电影'] },
   { path: ['娱乐', '动漫'], terms: ['动画', '动漫', '番剧', '国创', 'MAD', 'MMD', '二次元'] },
   { path: ['娱乐', '音乐'], terms: ['音乐', '原创音乐', '翻唱', 'VOCALOID', '演奏', '乐器', '音乐现场'] },
-  { path: ['娱乐', '生活'], terms: ['生活', '日常', '搞笑', '美食', '旅行', '家居', '手工', '萌宠'] },
+  { path: ['娱乐', '生活'], terms: ['生活', '日常', '搞笑', '美食', '探店', '餐厅', '菜品', '旅行', '家居', '手工', '萌宠', 'vlog'] },
   { path: ['创作', '设计'], terms: ['设计', '绘画', '美术', '摄影', '视觉设计', '平面设计', 'UI', '建模'] },
   { path: ['创作', '剪辑'], terms: ['剪辑', '视频制作', '后期', '特效', '拍摄', '调色'] },
   { path: ['科技', '数码'], terms: ['数码', '科技', '手机', '电脑', '硬件', '测评', '装机', 'AI', '人工智能'] },
@@ -34,25 +83,81 @@ const TAXONOMY: TaxonomyEntry[] = [
   { path: ['体育', '运动'], terms: ['体育', '运动', '健身', '篮球', '足球', '跑步', '格斗'] },
 ];
 
-const TERM_INDEX = buildTermIndex(TAXONOMY);
+const TERM_REFS = buildTermRefs(TAXONOMY);
 
-export function normalizeFavoritePath(aiPath: unknown, item: FavoriteItem): string[] {
-  const aiParts = normalizeTextArray(aiPath).slice(0, 4);
-  const candidates = [
-    ...aiParts,
-    item.tagName,
-    ...(item.tags ?? []),
-    item.folderTitle,
-  ];
-  const match = findBestTaxonomyMatch(candidates);
+export function classifyFavoritePath(
+  item: FavoriteItem,
+  ai: AiFavoriteClassificationInput | undefined,
+): FavoritePathClassification {
+  const leafScores = new Map<string, LeafScore>();
+  const parentScores = new Map<string, ParentScore>();
+  const sources = buildSources(item, ai);
 
-  if (match) {
-    return appendSpecificTail(match, aiParts);
+  for (const source of sources) {
+    for (const value of source.values) {
+      const normalizedValue = normalizeForTaxonomy(value);
+      if (!normalizedValue) continue;
+
+      for (const ref of TERM_REFS) {
+        if (!normalizedValue.includes(ref.normalized)) continue;
+        accumulateLeafScore(leafScores, ref, source, value);
+        accumulateParentScore(parentScores, ref, source, value);
+      }
+    }
   }
 
-  if (item.tagName.trim()) return [item.tagName.trim()].slice(0, 4);
-  if (item.folderTitle.trim()) return [item.folderTitle.trim()].slice(0, 4);
-  return UNCATEGORIZED_PATH;
+  const bestLeaf = pickBestLeaf(leafScores);
+  if (bestLeaf && bestLeaf.leafDirectScore > 0) {
+    return {
+      path: bestLeaf.entry.path.slice(0, 4),
+      evidence: buildResolvedEvidence(bestLeaf),
+    };
+  }
+
+  const bestParent = pickBestParent(parentScores);
+  const bestWeakLeaf = bestLeaf && bestLeaf.leafWeakScore > 0 ? bestLeaf : null;
+
+  if (bestParent && bestParent.directScore > 0) {
+    const path = bestWeakLeaf && isPathPrefix(bestParent.path, bestWeakLeaf.entry.path)
+      ? [...bestParent.path, NEEDS_REVIEW_LABEL].slice(0, 4)
+      : bestParent.path.slice(0, 4);
+    return {
+      path,
+      evidence: buildParentFallbackEvidence(bestParent, bestWeakLeaf),
+    };
+  }
+
+  if (bestWeakLeaf) {
+    const parentPath = bestWeakLeaf.entry.path.slice(0, -1);
+    if (parentPath.length > 0) {
+      return {
+        path: [...parentPath, NEEDS_REVIEW_LABEL].slice(0, 4),
+        evidence: buildWeakFallbackEvidence(parentPath, bestWeakLeaf),
+      };
+    }
+  }
+
+  if (bestParent && bestParent.weakScore > 0) {
+    return {
+      path: [...bestParent.path, NEEDS_REVIEW_LABEL].slice(0, 4),
+      evidence: buildWeakParentFallbackEvidence(bestParent),
+    };
+  }
+
+  return {
+    path: UNCATEGORIZED_PATH,
+    evidence: {
+      kind: 'path_fallback',
+      summary: '路径兜底：缺少可用分类证据，暂列未分类。',
+      directTerms: [],
+      weakTerms: [],
+      downgraded: true,
+    },
+  };
+}
+
+export function normalizeFavoritePath(aiPath: unknown, item: FavoriteItem): string[] {
+  return classifyFavoritePath(item, { path: aiPath }).path;
 }
 
 export function expandFavoriteSearchTerms(terms: string[]): string[] {
@@ -72,64 +177,229 @@ export function buildTaxonomyPromptSummary(): string {
     .join('\n');
 }
 
-function buildTermIndex(entries: TaxonomyEntry[]): Map<string, TaxonomyEntry[]> {
-  const index = new Map<string, TaxonomyEntry[]>();
+function buildTermRefs(entries: TaxonomyEntry[]): TaxonomyTermRef[] {
+  const refs: TaxonomyTermRef[] = [];
   for (const entry of entries) {
-    for (const term of [...entry.path, ...entry.terms]) {
-      const key = normalizeForTaxonomy(term);
-      const bucket = index.get(key) ?? [];
-      bucket.push(entry);
-      index.set(key, bucket);
+    entry.path.forEach((part, pathIndex) => {
+      refs.push({
+        entry,
+        display: part,
+        normalized: normalizeForTaxonomy(part),
+        pathIndex,
+        isLeafEvidence: pathIndex === entry.path.length - 1,
+      });
+    });
+    for (const term of entry.terms) {
+      refs.push({
+        entry,
+        display: term,
+        normalized: normalizeForTaxonomy(term),
+        pathIndex: entry.path.length - 1,
+        isLeafEvidence: true,
+      });
     }
   }
-  return index;
+  return refs;
 }
 
-function findBestTaxonomyMatch(terms: string[]): TaxonomyMatch | null {
-  let best: TaxonomyMatch | null = null;
+function buildSources(item: FavoriteItem, ai: AiFavoriteClassificationInput | undefined): MatchSource[] {
+  return [
+    { label: '标题', kind: 'metadata', direct: true, weight: 7, values: [item.title] },
+    { label: '简介', kind: 'metadata', direct: true, weight: 4, values: [item.intro] },
+    { label: 'B站分区', kind: 'metadata', direct: true, weight: 6, values: [item.tagName] },
+    { label: 'B站标签', kind: 'metadata', direct: true, weight: 6, values: item.tags ?? [] },
+    { label: 'AI摘要', kind: 'ai', direct: true, weight: 5, values: [normalizeText(ai?.summary)] },
+    { label: 'AI关键词', kind: 'ai', direct: true, weight: 6, values: normalizeTextArray(ai?.keywords) },
+    { label: 'AI别名', kind: 'ai', direct: true, weight: 4, values: normalizeTextArray(ai?.aliases) },
+    { label: 'AI路径', kind: 'path', direct: false, weight: 3, values: normalizeTextArray(ai?.path) },
+    { label: '原收藏夹', kind: 'path', direct: false, weight: 2, values: [item.folderTitle] },
+  ];
+}
 
-  terms.forEach((term, matchedIndex) => {
-    const entries = TERM_INDEX.get(normalizeForTaxonomy(term)) ?? [];
-    for (const entry of entries) {
-      if (!best || entry.path.length > best.entry.path.length) {
-        best = { entry, matchedTerm: term, matchedIndex };
+function accumulateLeafScore(
+  scores: Map<string, LeafScore>,
+  ref: TaxonomyTermRef,
+  source: MatchSource,
+  rawValue: string,
+): void {
+  const key = pathKey(ref.entry.path);
+  const score = scores.get(key) ?? {
+    entry: ref.entry,
+    leafDirectScore: 0,
+    leafWeakScore: 0,
+    directTerms: new Set<string>(),
+    weakTerms: new Set<string>(),
+    directSourceKinds: new Set<'metadata' | 'ai'>(),
+    directLabels: new Set<string>(),
+    weakLabels: new Set<string>(),
+  };
+
+  if (ref.isLeafEvidence) {
+    if (source.direct) {
+      score.leafDirectScore += source.weight;
+      score.directTerms.add(extractMatchedTerm(rawValue, ref.display, ref.normalized, ref.entry.path.at(-1) ?? ''));
+      score.directLabels.add(source.label);
+      if (source.kind !== 'path') {
+        score.directSourceKinds.add(source.kind);
       }
+    } else {
+      score.leafWeakScore += source.weight;
+      score.weakTerms.add(extractMatchedTerm(rawValue, ref.display, ref.normalized, ref.entry.path.at(-1) ?? ''));
+      score.weakLabels.add(source.label);
     }
-  });
-
-  return best;
-}
-
-function appendSpecificTail(match: TaxonomyMatch, aiParts: string[]): string[] {
-  const path = [...match.entry.path];
-  const matchedPartIndex = aiParts.findIndex(part => normalizeForTaxonomy(part) === normalizeForTaxonomy(match.matchedTerm));
-  const tailStart = matchedPartIndex >= 0 ? matchedPartIndex + 1 : match.matchedIndex + 1;
-
-  for (const part of aiParts.slice(tailStart)) {
-    const trimmed = part.trim();
-    if (!trimmed) continue;
-    if (path.some(existing => normalizeForTaxonomy(existing) === normalizeForTaxonomy(trimmed))) continue;
-    if (TERM_INDEX.has(normalizeForTaxonomy(trimmed))) continue;
-    path.push(trimmed);
-    if (path.length >= 4) break;
+  } else if (!source.direct) {
+    score.weakLabels.add(source.label);
   }
 
-  return path.slice(0, 4);
+  scores.set(key, score);
+}
+
+function accumulateParentScore(
+  scores: Map<string, ParentScore>,
+  ref: TaxonomyTermRef,
+  source: MatchSource,
+  rawValue: string,
+): void {
+  const parentPath = ref.isLeafEvidence ? ref.entry.path.slice(0, -1) : ref.entry.path.slice(0, ref.pathIndex + 1);
+  if (parentPath.length === 0) return;
+
+  const key = pathKey(parentPath);
+  const score = scores.get(key) ?? {
+    path: parentPath,
+    directScore: 0,
+    weakScore: 0,
+    directTerms: new Set<string>(),
+    weakTerms: new Set<string>(),
+    directSourceKinds: new Set<'metadata' | 'ai'>(),
+    directLabels: new Set<string>(),
+    weakLabels: new Set<string>(),
+  };
+
+  if (source.direct) {
+    score.directScore += Math.max(1, source.weight - (ref.isLeafEvidence ? 1 : 0));
+    score.directTerms.add(extractMatchedTerm(rawValue, ref.display, ref.normalized, parentPath.at(-1) ?? ''));
+    score.directLabels.add(source.label);
+    if (source.kind !== 'path') {
+      score.directSourceKinds.add(source.kind);
+    }
+  } else {
+    score.weakScore += source.weight;
+    score.weakTerms.add(extractMatchedTerm(rawValue, ref.display, ref.normalized, parentPath.at(-1) ?? ''));
+    score.weakLabels.add(source.label);
+  }
+
+  scores.set(key, score);
+}
+
+function pickBestLeaf(scores: Map<string, LeafScore>): LeafScore | null {
+  const ranked = Array.from(scores.values()).sort((a, b) => {
+    return (
+      b.leafDirectScore - a.leafDirectScore
+      || b.leafWeakScore - a.leafWeakScore
+      || b.directTerms.size - a.directTerms.size
+      || b.entry.path.length - a.entry.path.length
+      || a.entry.path.join('/').localeCompare(b.entry.path.join('/'), 'zh-CN')
+    );
+  });
+  return ranked[0] ?? null;
+}
+
+function pickBestParent(scores: Map<string, ParentScore>): ParentScore | null {
+  const ranked = Array.from(scores.values()).sort((a, b) => {
+    return (
+      b.directScore - a.directScore
+      || b.weakScore - a.weakScore
+      || b.path.length - a.path.length
+      || a.path.join('/').localeCompare(b.path.join('/'), 'zh-CN')
+    );
+  });
+  return ranked[0] ?? null;
+}
+
+function buildResolvedEvidence(score: LeafScore): SmartFavoriteCategoryEvidence {
+  const kind = resolveEvidenceKind(score.directSourceKinds);
+  const directTerms = Array.from(score.directTerms).filter(Boolean).slice(0, 3);
+  const sourceLabels = Array.from(score.directLabels).slice(0, 2).join('、') || '直接证据';
+  return {
+    kind,
+    summary: `${labelForEvidenceKind(kind)}：${sourceLabels}命中“${directTerms.join('、') || score.entry.path.at(-1)}”，归入 ${score.entry.path.join(' / ')}。`,
+    directTerms,
+    weakTerms: Array.from(score.weakTerms).filter(Boolean).slice(0, 3),
+    downgraded: false,
+  };
+}
+
+function buildParentFallbackEvidence(parent: ParentScore, weakLeaf: LeafScore | null): SmartFavoriteCategoryEvidence {
+  const directTerms = Array.from(parent.directTerms).filter(Boolean).slice(0, 3);
+  const weakLeafName = weakLeaf?.entry.path.at(-1) ?? '具体子类';
+  return {
+    kind: weakLeaf ? 'path_fallback' : resolveEvidenceKind(parent.directSourceKinds),
+    summary: weakLeaf
+      ? `路径兜底：只能确认到 ${parent.path.join(' / ')}，但标题、简介、标签和 AI 关键词里缺少“${weakLeafName}”直接证据，暂放 ${[...parent.path, NEEDS_REVIEW_LABEL].join(' / ')}。`
+      : `${labelForEvidenceKind(resolveEvidenceKind(parent.directSourceKinds))}：目前只能确认到 ${parent.path.join(' / ')}，证据不足，未放入具体子类。`,
+    directTerms,
+    weakTerms: weakLeaf ? Array.from(weakLeaf.weakTerms).filter(Boolean).slice(0, 3) : [],
+    downgraded: true,
+  };
+}
+
+function buildWeakFallbackEvidence(parentPath: string[], leaf: LeafScore): SmartFavoriteCategoryEvidence {
+  const weakLeafName = leaf.entry.path.at(-1) ?? '具体子类';
+  return {
+    kind: 'path_fallback',
+    summary: `路径兜底：${Array.from(leaf.weakLabels).slice(0, 2).join('、') || '弱路径提示'}指向“${weakLeafName}”，但缺少标题、简介、标签或 AI 关键词的直接证据，暂放 ${[...parentPath, NEEDS_REVIEW_LABEL].join(' / ')}。`,
+    directTerms: [],
+    weakTerms: Array.from(leaf.weakTerms).filter(Boolean).slice(0, 3),
+    downgraded: true,
+  };
+}
+
+function buildWeakParentFallbackEvidence(parent: ParentScore): SmartFavoriteCategoryEvidence {
+  return {
+    kind: 'path_fallback',
+    summary: `路径兜底：只有${Array.from(parent.weakLabels).slice(0, 2).join('、') || '弱路径提示'}支持 ${parent.path.join(' / ')}，证据不足，暂放 ${[...parent.path, NEEDS_REVIEW_LABEL].join(' / ')}。`,
+    directTerms: [],
+    weakTerms: Array.from(parent.weakTerms).filter(Boolean).slice(0, 3),
+    downgraded: true,
+  };
+}
+
+function resolveEvidenceKind(kinds: Set<'metadata' | 'ai'>): SmartFavoriteCategoryEvidenceKind {
+  if (kinds.has('metadata') && kinds.has('ai')) return 'mixed';
+  if (kinds.has('ai')) return 'ai';
+  return 'metadata';
+}
+
+function labelForEvidenceKind(kind: SmartFavoriteCategoryEvidenceKind): string {
+  switch (kind) {
+    case 'ai':
+      return 'AI证据';
+    case 'mixed':
+      return 'AI + 元数据证据';
+    case 'path_fallback':
+      return '路径兜底';
+    case 'metadata':
+    default:
+      return '元数据证据';
+  }
 }
 
 function getRelatedTerms(term: string): string[] {
   const normalized = normalizeForTaxonomy(term);
-  const exact = TERM_INDEX.get(normalized);
-  if (exact) {
-    return exact.flatMap(entry => [...entry.path, ...entry.terms]);
-  }
+  if (!normalized) return [];
+  return Array.from(new Set(TERM_REFS
+    .filter(ref => ref.normalized.includes(normalized) || normalized.includes(ref.normalized))
+    .flatMap(ref => [...ref.entry.path, ...ref.entry.terms])));
+}
 
-  return TAXONOMY
-    .filter(entry => [...entry.path, ...entry.terms].some(candidate => {
-      const value = normalizeForTaxonomy(candidate);
-      return value.includes(normalized) || normalized.includes(value);
-    }))
-    .flatMap(entry => [...entry.path, ...entry.terms]);
+function extractMatchedTerm(rawValue: string, displayTerm: string, normalizedNeedle: string, fallback: string): string {
+  const trimmed = rawValue.trim();
+  if (!trimmed) return fallback || displayTerm || normalizedNeedle;
+  return displayTerm || fallback || normalizedNeedle;
+}
+
+function normalizeText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
 }
 
 function normalizeTextArray(value: unknown): string[] {
@@ -137,6 +407,15 @@ function normalizeTextArray(value: unknown): string[] {
   return value
     .map(item => typeof item === 'string' ? item.trim() : '')
     .filter(Boolean);
+}
+
+function pathKey(path: string[]): string {
+  return path.join('\u0001');
+}
+
+function isPathPrefix(prefix: string[], path: string[]): boolean {
+  if (prefix.length > path.length) return false;
+  return prefix.every((part, index) => part === path[index]);
 }
 
 function normalizeForTaxonomy(value: string): string {

--- a/src/background/storage/favorite-write-prep.ts
+++ b/src/background/storage/favorite-write-prep.ts
@@ -140,6 +140,7 @@ function mergeSmartFavoriteIndex(current: SmartFavoriteIndex | undefined, next: 
     summary: next.summary || current.summary,
     keywords: next.keywords.length > 0 ? next.keywords : current.keywords,
     aliases: next.aliases.length > 0 ? next.aliases : current.aliases,
+    categoryEvidence: next.categoryEvidence ?? current.categoryEvidence,
     searchableText: next.searchableText || current.searchableText,
     contentHash: next.contentHash || current.contentHash,
     model: next.model || current.model,

--- a/src/shared/types/favorite.ts
+++ b/src/shared/types/favorite.ts
@@ -38,12 +38,27 @@ export interface SmartFavoriteIndex {
   summary: string;
   keywords: string[];
   aliases: string[];
+  categoryEvidence?: SmartFavoriteCategoryEvidence;
   searchableText: string;
   contentHash: string;
   model: string;
   status: 'indexed' | 'failed';
   error?: string;
   indexedAt: number;
+}
+
+export type SmartFavoriteCategoryEvidenceKind =
+  | 'ai'
+  | 'metadata'
+  | 'mixed'
+  | 'path_fallback';
+
+export interface SmartFavoriteCategoryEvidence {
+  kind: SmartFavoriteCategoryEvidenceKind;
+  summary: string;
+  directTerms: string[];
+  weakTerms: string[];
+  downgraded: boolean;
 }
 
 export interface SmartFavoriteTreeNode {

--- a/tests/smart-favorite-index.test.ts
+++ b/tests/smart-favorite-index.test.ts
@@ -101,7 +101,68 @@ test('corrupt itemKey writes become skipped diagnostics instead of raw Constrain
   assert.match(result.notes.join(' '), /缺少 itemKey/);
 });
 
-function makeFavoriteItem(itemKey: string): FavoriteItem {
+test('food and lifestyle videos do not fall into 游戏 from broad entertainment hints alone', async () => {
+  const item = makeFavoriteItem('200:BVFOOD', {
+    folderTitle: '娱乐收藏',
+    title: '美食探店，品尝活鱼馆菜品',
+    intro: '探店记录，试吃招牌活鱼菜。',
+    tagName: '娱乐',
+    tags: ['美食', '探店'],
+  });
+  const writes = await buildIndexAndCollectWrites(item, {
+    path: ['娱乐', '游戏'],
+    summary: '这是一条美食探店视频，重点是菜品和餐厅体验。',
+    keywords: ['美食', '探店', '菜品'],
+    aliases: [],
+  });
+
+  assert.deepEqual(writes[0]?.path, ['娱乐', '生活']);
+  assert.equal(writes[0]?.categoryEvidence?.kind, 'mixed');
+  assert.match(writes[0]?.categoryEvidence?.summary ?? '', /美食|探店/);
+  assert.doesNotMatch((writes[0]?.path ?? []).join('/'), /游戏/);
+});
+
+test('real game videos still enter 游戏 when direct evidence exists', async () => {
+  const item = makeFavoriteItem('201:BVGAME', {
+    folderTitle: '娱乐收藏',
+    title: '原神 5.0 深渊配队攻略',
+    intro: '这期聊原神深渊思路和实战技巧。',
+    tagName: '游戏',
+    tags: ['原神', '攻略', '游戏'],
+  });
+  const writes = await buildIndexAndCollectWrites(item, {
+    path: ['娱乐', '游戏'],
+    summary: '游戏攻略视频，围绕原神深渊配队展开。',
+    keywords: ['原神', '游戏', '攻略'],
+    aliases: ['配队'],
+  });
+
+  assert.deepEqual(writes[0]?.path, ['娱乐', '游戏']);
+  assert.equal(writes[0]?.categoryEvidence?.downgraded, false);
+  assert.match(writes[0]?.categoryEvidence?.summary ?? '', /游戏/);
+});
+
+test('ambiguous entertainment items downgrade to 待确认 with insufficient-evidence copy', async () => {
+  const item = makeFavoriteItem('202:BVAMB', {
+    folderTitle: '娱乐收藏',
+    title: '这也太离谱了',
+    intro: '一次普通分享。',
+    tagName: '娱乐',
+    tags: [],
+  });
+  const writes = await buildIndexAndCollectWrites(item, {
+    path: ['娱乐', '游戏'],
+    summary: '轻松内容分享。',
+    keywords: [],
+    aliases: [],
+  });
+
+  assert.deepEqual(writes[0]?.path, ['娱乐', '待确认']);
+  assert.equal(writes[0]?.categoryEvidence?.kind, 'path_fallback');
+  assert.match(writes[0]?.categoryEvidence?.summary ?? '', /证据不足，未放入具体子类|缺少.*直接证据/);
+});
+
+function makeFavoriteItem(itemKey: string, overrides: Partial<FavoriteItem> = {}): FavoriteItem {
   return {
     itemKey,
     mediaId: 100,
@@ -119,6 +180,7 @@ function makeFavoriteItem(itemKey: string): FavoriteItem {
     pubtime: 0,
     favTime: 1,
     syncedAt: 1,
+    ...overrides,
   };
 }
 
@@ -136,4 +198,46 @@ function makeSmartIndex(itemKey: string, overrides: Partial<SmartFavoriteIndex> 
     indexedAt: 1,
     ...overrides,
   };
+}
+
+async function buildIndexAndCollectWrites(item: FavoriteItem, aiResponse: {
+  path?: unknown;
+  summary?: unknown;
+  keywords?: unknown;
+  aliases?: unknown;
+}): Promise<SmartFavoriteIndex[]> {
+  const writes: SmartFavoriteIndex[] = [];
+  const result = await buildSmartFavoriteIndex(
+    4,
+    {},
+    {
+      async createSmartIndex() {
+        return aiResponse;
+      },
+      async getFavoriteItems() {
+        return [item];
+      },
+      async getSmartFavoriteIndexMap() {
+        return new Map();
+      },
+      async loadConfig() {
+        return {
+          ai: {
+            baseURL: 'https://example.com',
+            apiKey: 'test-key',
+            chatModel: 'test-model',
+          },
+        };
+      },
+      async putSmartFavoriteIndex(index) {
+        writes.push(index);
+        return { written: 1, notes: [] };
+      },
+    },
+  );
+
+  assert.equal(result.processed, 1);
+  assert.equal(result.indexed, 1);
+  assert.equal(result.failed, 0);
+  return writes;
 }


### PR DESCRIPTION
﻿## Summary
- harden Smart Favorites category assignment so specific leaf categories require direct evidence from metadata or AI summary/keywords
- downgrade weak path-only matches to broader parents or `待确认`, and persist concise Chinese category evidence with each index row
- surface category evidence in the Smart Favorites UI and add focused regression tests for food/lifestyle, true game, and ambiguous items

## Root Cause
Issue #93 came from a combination problem, not a single layer:
- AI `path` output could already point at a specific leaf like `娱乐 / 游戏`
- `normalizeFavoritePath` then reinforced that leaf using broad `tagName`, `tags`, or `folderTitle` matches, even when those only supported a parent category
- tree aggregation and the UI later surfaced the stored leaf path, while path browsing only showed a generic `分类路径匹配` reason, which hid whether the category came from AI evidence or a weak fallback

This change makes leaf-category assignment conservative: only direct evidence in title, intro, B站分区/标签, AI summary, or AI keywords can place an item in a specific child category. Weak folder/path hints now downgrade to a broader parent or `待确认` instead of forcing a misleading leaf.

## Validation
- `git diff --check`
- `npm run test:favorites`
- `npm run typecheck`
- `npm run build`

Refs #93


## Main-agent review
- Scope verified: Smart Favorites taxonomy/category evidence, index rebuild fingerprint, and focused tests only; #92 itemKey idempotence remains covered by `npm run test:favorites`.
- Re-ran validation in clean review worktree: `npm ci`, `node --test tests/smart-favorite-index.test.ts`, `npm run test:favorites`, `npm run typecheck`, `npm run build`, `git diff --check`, and forbidden-copy scan for `未消费|猜你喜欢`.
- Root-cause judgment accepted: weak path/folder hints and broad entertainment metadata could previously reinforce AI leaf paths; this PR requires direct evidence for leaf categories and downgrades weak evidence to parent/待确认.

Closes #93
