### PR TITLE
[codex] redesign preference interest windows

### DIFF
--- a/dashboard/modules/preference/PreferencePage.tsx
+++ b/dashboard/modules/preference/PreferencePage.tsx
@@ -1,16 +1,19 @@
 import { useEffect, useState } from 'preact/hooks';
-import { prefData, prefLoading, prefError } from '../../signals';
+import { prefData, prefError, prefLoading } from '../../signals';
 import { requestSW } from '../../utils/messaging';
 import type {
   CategoryDistribution,
   DurationBucket,
-  InterestDrift,
+  HistoryCoverage,
   InterestDriftGranularity,
+  PreferenceAnalytics,
+  PreferenceWindowOption,
+  PreferenceWindowSummary,
 } from '../../../src/shared/types/analytics';
 import { ChartContainer } from '../../components/ChartContainer';
-import { LoadingSkeleton } from '../../components/LoadingSkeleton';
 import { EmptyState } from '../../components/EmptyState';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
+import { LoadingSkeleton } from '../../components/LoadingSkeleton';
 import { CHART_COLORS } from '../../../src/shared/constants';
 
 const GRANULARITY_OPTIONS: Array<{ value: InterestDriftGranularity; label: string }> = [
@@ -19,87 +22,349 @@ const GRANULARITY_OPTIONS: Array<{ value: InterestDriftGranularity; label: strin
   { value: 'monthly', label: '月' },
 ];
 
-const DRIFT_CATEGORY_LIMIT = 5;
-
 export function PreferencePage() {
   const [selectedGranularity, setSelectedGranularity] = useState<InterestDriftGranularity | null>(null);
+  const [selectedWindows, setSelectedWindows] = useState<Partial<Record<InterestDriftGranularity, string>>>({});
+  const [refreshing, setRefreshing] = useState(false);
 
-  useEffect(() => { fetchData(); }, []);
+  useEffect(() => {
+    void fetchData();
+  }, []);
 
-  async function fetchData() {
-    prefLoading.value = true;
+  async function fetchData(
+    granularity?: InterestDriftGranularity,
+    windowStart?: string,
+  ) {
+    const isInitialLoad = prefData.value === null;
+    if (isInitialLoad) {
+      prefLoading.value = true;
+    } else {
+      setRefreshing(true);
+    }
     prefError.value = null;
+
     try {
-      prefData.value = await requestSW<typeof prefData.value>('GET_PREFERENCE_DATA');
-      setSelectedGranularity(null);
-    } catch (e) {
-      prefError.value = (e as Error).message;
+      const data = await requestSW<PreferenceAnalytics>('GET_PREFERENCE_DATA', {
+        granularity,
+        windowStart,
+      });
+      prefData.value = data;
+
+      const activeGranularity = data.selectedWindow?.window.granularity ?? granularity ?? data.defaultGranularity;
+      setSelectedGranularity(activeGranularity);
+      if (data.selectedWindow) {
+        setSelectedWindows(prev => ({
+          ...prev,
+          [data.selectedWindow!.window.granularity]: data.selectedWindow!.window.startDate,
+        }));
+      }
+    } catch (error) {
+      prefError.value = (error as Error).message;
     } finally {
       prefLoading.value = false;
+      setRefreshing(false);
     }
   }
 
-  if (prefLoading.value) return <div style={{ padding: '16px' }}><LoadingSkeleton height={400} /></div>;
+  const data = prefData.value;
+  if (prefLoading.value) return <div style={{ padding: '16px' }}><LoadingSkeleton height={420} /></div>;
   if (prefError.value) return <div style={{ padding: '16px', color: '#FF6B6B' }}>{prefError.value}</div>;
-  const d = prefData.value;
-  if (!d) return <EmptyState />;
+  if (!data) return <EmptyState />;
 
-  const activeGranularity = selectedGranularity ?? d.defaultDriftGranularity;
-  const drift = d.driftByGranularity?.[activeGranularity] ?? d.drift;
-  const driftDisplay = buildDriftDisplay(drift, DRIFT_CATEGORY_LIMIT);
-  const hasDriftData = drift.some((period: InterestDrift) => period.recordCount > 0 && period.totalWatchTime > 0);
-  const driftTitle = getDriftTitle(activeGranularity, d.coverage.coveredDays);
-  const driftCaveat = getDriftCaveat(activeGranularity, d.coverage.coveredDays, d.coverage.totalRecords, hasDriftData);
+  const activeGranularity = selectedGranularity ?? data.selectedWindow?.window.granularity ?? data.defaultGranularity;
+  const activeWindows = data.windows[activeGranularity] ?? [];
+  const selectedWindowStart = selectedWindows[activeGranularity]
+    ?? data.selectedWindow?.window.startDate
+    ?? activeWindows[0]?.startDate
+    ?? '';
+  const summary = data.selectedWindow;
+  const summaryWindow = summary?.window ?? null;
+  const coverageCaveat = summary ? buildCoverageCaveat(summary, data.coverage) : '';
+  const currentData = data;
 
-  const pieOption = {
+  const categoryPieOption = summary ? buildCategoryPieOption(summary.categories) : null;
+  const durationBarOption = summary ? buildDurationBarOption(summary.durationBuckets) : null;
+  const wordcloudOption = summary ? buildWordCloudOption(summary.topTags) : null;
+
+  return (
+    <ErrorBoundary>
+      <div style={{ padding: '16px', display: 'flex', flexDirection: 'column', gap: '12px' }}>
+        <div style={{ background: '#222244', borderRadius: '10px', padding: '12px' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '12px', flexWrap: 'wrap', margin: '0 0 10px' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+              <h3 style={{ color: '#EAEAF2', fontSize: '14px', margin: 0 }}>
+                {getWindowTitle(activeGranularity)}
+              </h3>
+              <div style={{ color: '#A0A0B0', fontSize: '12px', lineHeight: 1.6 }}>
+                {summaryWindow ? (
+                  <>
+                    <div>{summaryWindow.label}</div>
+                    <div>{summaryWindow.startDate} 至 {summaryWindow.endDate}</div>
+                  </>
+                ) : (
+                  <div>本地还没有可分析的窗口</div>
+                )}
+              </div>
+            </div>
+            <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
+              <div style={{ display: 'inline-flex', border: '1px solid rgba(160, 160, 176, 0.28)', borderRadius: '8px', overflow: 'hidden' }} aria-label="兴趣窗口粒度选择">
+                {GRANULARITY_OPTIONS.map(option => {
+                  const selected = option.value === activeGranularity;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => void handleGranularityChange(option.value)}
+                      disabled={refreshing}
+                      style={{
+                        minWidth: '42px',
+                        height: '30px',
+                        border: 0,
+                        borderRight: option.value === 'monthly' ? 0 : '1px solid rgba(160, 160, 176, 0.2)',
+                        background: selected ? '#6C5CE7' : 'transparent',
+                        color: selected ? '#FFFFFF' : '#C8C8D8',
+                        cursor: refreshing ? 'wait' : 'pointer',
+                        fontSize: '13px',
+                      }}
+                    >
+                      {option.label}
+                    </button>
+                  );
+                })}
+              </div>
+              <select
+                value={selectedWindowStart}
+                onChange={(event) => void handleWindowChange(event.currentTarget.value)}
+                disabled={refreshing || activeWindows.length === 0}
+                aria-label="兴趣窗口选择"
+                style={{
+                  minWidth: '220px',
+                  height: '32px',
+                  padding: '0 10px',
+                  borderRadius: '8px',
+                  border: '1px solid rgba(160, 160, 176, 0.28)',
+                  background: '#1A1A36',
+                  color: '#EAEAF2',
+                }}
+              >
+                {activeWindows.map(window => (
+                  <option key={window.key} value={window.startDate}>
+                    {formatWindowOption(window)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          {refreshing && (
+            <div style={{ margin: '0 0 10px', color: '#A0A0B0', fontSize: '12px' }}>
+              正在切换窗口…
+            </div>
+          )}
+          {summary ? (
+            <>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: '8px', marginBottom: '10px' }}>
+                <MetricCard label="活跃天数" value={`${summary.window.activeDays} 天`} />
+                <MetricCard label="样本数" value={`${summary.window.recordCount} 条`} />
+                <MetricCard label="观看时长" value={formatWatchTime(summary.window.totalWatchTime)} />
+                <MetricCard label="覆盖范围" value={summary.window.partialCoverage ? '窗口不完整' : '窗口内可算'} />
+              </div>
+              <div style={{ margin: '0 0 12px', padding: '8px 10px', borderRadius: '8px', background: 'rgba(255, 210, 102, 0.1)', color: '#FFD166', fontSize: '12px', lineHeight: 1.6 }}>
+                {coverageCaveat}
+              </div>
+              {summary.state === 'ready' && categoryPieOption ? (
+                <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) minmax(240px, 300px)', gap: '8px', alignItems: 'center' }}>
+                  <ChartContainer option={categoryPieOption} height={300} />
+                  <CategoryList categories={summary.categories.slice(0, 8)} />
+                </div>
+              ) : (
+                <WindowStatePanel summary={summary} />
+              )}
+            </>
+          ) : (
+            <EmptyState message="本地还没有观看历史记录，无法分析某日、某周或某月的兴趣分布。" />
+          )}
+        </div>
+
+        <div style={{ background: '#222244', borderRadius: '10px', padding: '12px' }}>
+          <h3 style={{ color: '#EAEAF2', fontSize: '14px', margin: '0 0 10px' }}>视频时长偏好</h3>
+          {summary ? (
+            summary.state === 'ready' && durationBarOption ? (
+              <ChartContainer option={durationBarOption} height={220} />
+            ) : (
+              <DurationList buckets={summary.durationBuckets} emptyMessage={getDurationEmptyMessage(summary)} />
+            )
+          ) : (
+            <InlineEmpty message="当前没有可显示的时长分布。" />
+          )}
+        </div>
+
+        <div style={{ background: '#222244', borderRadius: '10px', padding: '12px' }}>
+          <h3 style={{ color: '#EAEAF2', fontSize: '14px', margin: '0 0 10px' }}>高频标签</h3>
+          {summary ? (
+            summary.state === 'ready' && summary.topTags.length > 0 && wordcloudOption ? (
+              <ChartContainer option={wordcloudOption} height={280} />
+            ) : summary.topTags.length > 0 ? (
+              <TagList tags={summary.topTags.slice(0, 18)} />
+            ) : (
+              <InlineEmpty message={getTagEmptyMessage(summary)} />
+            )
+          ) : (
+            <InlineEmpty message="当前没有可显示的标签分布。" />
+          )}
+        </div>
+      </div>
+    </ErrorBoundary>
+  );
+
+  async function handleGranularityChange(nextGranularity: InterestDriftGranularity) {
+    if (nextGranularity === activeGranularity) return;
+
+    const nextWindowStart = selectedWindows[nextGranularity] ?? currentData.windows[nextGranularity][0]?.startDate;
+    setSelectedGranularity(nextGranularity);
+    if (!nextWindowStart) return;
+    setSelectedWindows(prev => ({ ...prev, [nextGranularity]: nextWindowStart }));
+    await fetchData(nextGranularity, nextWindowStart);
+  }
+
+  async function handleWindowChange(nextWindowStart: string) {
+    setSelectedWindows(prev => ({ ...prev, [activeGranularity]: nextWindowStart }));
+    await fetchData(activeGranularity, nextWindowStart);
+  }
+}
+
+function MetricCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ borderRadius: '8px', background: 'rgba(26, 26, 54, 0.9)', padding: '10px 12px' }}>
+      <div style={{ color: '#8E8E9E', fontSize: '11px', marginBottom: '4px' }}>{label}</div>
+      <div style={{ color: '#F7F7FB', fontSize: '14px' }}>{value}</div>
+    </div>
+  );
+}
+
+function WindowStatePanel({ summary }: { summary: PreferenceWindowSummary }) {
+  return (
+    <div style={{ minHeight: '240px', borderRadius: '10px', border: '1px dashed rgba(160, 160, 176, 0.28)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '20px' }}>
+      <div style={{ maxWidth: '420px', textAlign: 'center', color: '#C8C8D8' }}>
+        <div style={{ fontSize: '14px', marginBottom: '8px', color: '#F0F0F7' }}>
+          {getWindowStateMessage(summary)}
+        </div>
+        <div style={{ fontSize: '12px', lineHeight: 1.6, color: '#9FA0B4' }}>
+          {summary.state === 'insufficient_sample'
+            ? '样本偏少时只展示摘要，避免把单个视频或单次短观看误当成稳定偏好。'
+            : '切换到相邻日期、周或月后，会按那个自然窗口重新计算。'}
+        </div>
+        {summary.categories.length > 0 && (
+          <div style={{ marginTop: '14px', textAlign: 'left' }}>
+            <CategoryList categories={summary.categories.slice(0, 5)} compact />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CategoryList(
+  { categories, compact = false }: { categories: CategoryDistribution[]; compact?: boolean },
+) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: compact ? '6px' : '8px' }}>
+      {categories.map((category, index) => (
+        <div key={`${category.name}-${index}`} style={{ display: 'grid', gridTemplateColumns: compact ? 'minmax(0, 1fr) auto' : 'minmax(0, 1fr) auto auto', gap: '8px', alignItems: 'center' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 }}>
+            <span style={{ width: '8px', height: '8px', borderRadius: '999px', background: CHART_COLORS[index % CHART_COLORS.length], flex: '0 0 auto' }} />
+            <span style={{ color: '#EAEAF2', fontSize: '13px', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{category.name}</span>
+          </div>
+          {!compact && (
+            <span style={{ color: '#8E8E9E', fontSize: '12px' }}>{formatWatchTime(category.watchTime)}</span>
+          )}
+          <span style={{ color: '#C8C8D8', fontSize: '12px' }}>{formatPercentage(category.percentage)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DurationList({ buckets, emptyMessage }: { buckets: DurationBucket[]; emptyMessage: string }) {
+  const nonZeroBuckets = buckets.filter(bucket => bucket.count > 0);
+  if (nonZeroBuckets.length === 0) {
+    return <InlineEmpty message={emptyMessage} />;
+  }
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: '8px' }}>
+      {nonZeroBuckets.map(bucket => (
+        <div key={bucket.label} style={{ borderRadius: '8px', background: 'rgba(26, 26, 54, 0.9)', padding: '10px 12px' }}>
+          <div style={{ color: '#F2F2F8', fontSize: '13px', marginBottom: '4px' }}>{bucket.label}</div>
+          <div style={{ color: '#9FA0B4', fontSize: '12px' }}>{bucket.count} 条视频</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TagList({ tags }: { tags: Array<{ name: string; count: number }> }) {
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+      {tags.map((tag, index) => (
+        <div
+          key={`${tag.name}-${index}`}
+          style={{
+            padding: '6px 10px',
+            borderRadius: '999px',
+            background: 'rgba(108, 92, 231, 0.14)',
+            border: '1px solid rgba(108, 92, 231, 0.3)',
+            color: '#EAEAF2',
+            fontSize: '12px',
+          }}
+        >
+          {tag.name} · {tag.count}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function InlineEmpty({ message }: { message: string }) {
+  return (
+    <div style={{ minHeight: '180px', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#A0A0B0', fontSize: '13px', textAlign: 'center', padding: '0 16px' }}>
+      {message}
+    </div>
+  );
+}
+
+function buildCategoryPieOption(categories: CategoryDistribution[]) {
+  return {
     tooltip: { trigger: 'item' as const, formatter: '{b}: {d}%' },
     series: [{
       type: 'pie' as const,
-      radius: ['40%', '70%'],
-      data: d.categories.slice(0, 8).map((c: CategoryDistribution) => ({ name: c.name, value: c.watchTime })),
+      radius: ['42%', '72%'],
+      data: categories.slice(0, 8).map(category => ({ name: category.name, value: category.watchTime })),
       label: { color: '#A0A0B0' },
     }],
   };
+}
 
-  const driftOption = {
+function buildDurationBarOption(buckets: DurationBucket[]) {
+  return {
     tooltip: { trigger: 'axis' as const },
-    legend: { type: 'scroll' as const, textStyle: { color: '#A0A0B0' }, top: 0 },
-    grid: { top: 46, right: 10, bottom: 34, left: 40 },
-    xAxis: {
-      type: 'category' as const,
-      data: drift.map((m: InterestDrift) => m.label),
-      axisLabel: { hideOverlap: true, rotate: activeGranularity === 'daily' ? 35 : 0 },
-    },
-    yAxis: { type: 'value' as const, max: 100, axisLabel: { formatter: '{value}%' } },
-    series: driftDisplay.seriesNames.map((cat, i) => ({
-      name: cat,
-      type: 'line' as const,
-      data: driftDisplay.series[cat] ?? [],
-      smooth: true,
-      symbolSize: 5,
-      lineStyle: { width: 2 },
-      itemStyle: { color: CHART_COLORS[i % CHART_COLORS.length] },
-    })),
-  };
-
-  const barOption = {
-    tooltip: { trigger: 'axis' as const },
-    grid: { top: 10, right: 10, bottom: 20, left: 40 },
-    xAxis: { type: 'category' as const, data: d.durationBuckets.map((b: DurationBucket) => b.label) },
+    grid: { top: 12, right: 10, bottom: 20, left: 40 },
+    xAxis: { type: 'category' as const, data: buckets.map(bucket => bucket.label) },
     yAxis: { type: 'value' as const },
     series: [{
       type: 'bar' as const,
-      data: d.durationBuckets.map((b: DurationBucket, i: number) => ({
-        value: b.count,
-        itemStyle: { color: CHART_COLORS[i % CHART_COLORS.length], borderRadius: [4, 4, 0, 0] },
+      data: buckets.map((bucket, index) => ({
+        value: bucket.count,
+        itemStyle: { color: CHART_COLORS[index % CHART_COLORS.length], borderRadius: [4, 4, 0, 0] },
       })),
     }],
   };
+}
 
-  const wordcloudOption = {
+function buildWordCloudOption(tags: Array<{ name: string; count: number }>) {
+  return {
     tooltip: { show: true },
     series: [{
-      type: 'wordCloud' as any,
+      type: 'wordCloud' as const,
       shape: 'circle',
       sizeRange: [12, 40],
       rotationRange: [-45, 45],
@@ -107,145 +372,98 @@ export function PreferencePage() {
         fontFamily: '"Noto Sans SC", sans-serif',
         color: () => CHART_COLORS[Math.floor(Math.random() * CHART_COLORS.length)],
       },
-      data: d.topTags.slice(0, 50).map((t: { name: string; count: number }) => ({ name: t.name, value: t.count })),
+      data: tags.slice(0, 50).map(tag => ({ name: tag.name, value: tag.count })),
     }],
   };
-
-  return (
-    <ErrorBoundary>
-      <div style={{ padding: '16px', display: 'flex', flexDirection: 'column', gap: '12px' }}>
-        <div style={{ background: '#222244', borderRadius: '10px', padding: '12px' }}>
-          <h3 style={{ color: '#A0A0B0', fontSize: '13px', margin: '0 0 4px 12px' }}>分区分布</h3>
-          <ChartContainer option={pieOption} height={280} />
-        </div>
-        <div style={{ background: '#222244', borderRadius: '10px', padding: '12px' }}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', alignItems: 'flex-start', margin: '0 0 8px 12px', flexWrap: 'wrap' }}>
-            <div>
-              <h3 style={{ color: '#EAEAF2', fontSize: '14px', margin: '0 0 4px 0' }}>{driftTitle}</h3>
-              <div style={{ color: '#A0A0B0', fontSize: '12px', lineHeight: 1.6 }}>
-                覆盖 {formatCoverageDate(d.coverage.earliestDate)} 至 {formatCoverageDate(d.coverage.latestDate)}
-                {' · '}活跃 {d.coverage.activeDays} 天
-                {' · '}样本 {d.coverage.totalRecords} 条
-              </div>
-            </div>
-            <div style={{ display: 'inline-flex', border: '1px solid rgba(160, 160, 176, 0.28)', borderRadius: '8px', overflow: 'hidden' }} aria-label="兴趣粒度选择">
-              {GRANULARITY_OPTIONS.map(option => {
-                const selected = option.value === activeGranularity;
-                return (
-                  <button
-                    type="button"
-                    onClick={() => setSelectedGranularity(option.value)}
-                    title={getGranularityHint(option.value, d.coverage.coveredDays, option.value === d.defaultDriftGranularity)}
-                    style={{
-                      minWidth: '42px',
-                      height: '30px',
-                      border: 0,
-                      borderRight: option.value === 'monthly' ? 0 : '1px solid rgba(160, 160, 176, 0.2)',
-                      background: selected ? '#6C5CE7' : 'transparent',
-                      color: selected ? '#FFFFFF' : '#C8C8D8',
-                      cursor: 'pointer',
-                      fontSize: '13px',
-                    }}
-                  >
-                    {option.label}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-          {driftCaveat && (
-            <div style={{ margin: '0 12px 8px', padding: '8px 10px', borderRadius: '8px', background: 'rgba(255, 210, 102, 0.1)', color: '#FFD166', fontSize: '12px', lineHeight: 1.5 }}>
-              {driftCaveat}
-            </div>
-          )}
-          {hasDriftData ? (
-            <ChartContainer option={driftOption} height={270} />
-          ) : (
-            <div style={{ height: '220px', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#A0A0B0', fontSize: '13px', textAlign: 'center', padding: '0 16px' }}>
-              暂无足够观看时长用于生成兴趣分布；同步更多历史后会显示日/周/月视图。
-            </div>
-          )}
-        </div>
-        <div style={{ background: '#222244', borderRadius: '10px', padding: '12px' }}>
-          <h3 style={{ color: '#A0A0B0', fontSize: '13px', margin: '0 0 4px 12px' }}>视频时长偏好</h3>
-          <ChartContainer option={barOption} height={200} />
-        </div>
-        <div style={{ background: '#222244', borderRadius: '10px', padding: '12px' }}>
-          <h3 style={{ color: '#A0A0B0', fontSize: '13px', margin: '0 0 4px 12px' }}>标签兴趣图谱</h3>
-          <ChartContainer option={wordcloudOption} height={280} />
-        </div>
-      </div>
-    </ErrorBoundary>
-  );
 }
 
-function buildDriftDisplay(drift: InterestDrift[], limit: number): {
-  seriesNames: string[];
-  series: Record<string, number[]>;
-} {
-  const totals = new Map<string, number>();
-  for (const period of drift) {
-    for (const [category, value] of Object.entries(period.categories)) {
-      totals.set(category, (totals.get(category) ?? 0) + value);
-    }
+function buildCoverageCaveat(summary: PreferenceWindowSummary, coverage: HistoryCoverage): string {
+  const caveats = ['仅基于本地已同步历史计算，不代表账号完整观看史。'];
+  if (summary.window.partialCoverage && coverage.earliestDate && coverage.latestDate) {
+    const observedStart = maxDate(summary.window.startDate, coverage.earliestDate);
+    const observedEnd = minDate(summary.window.endDate, coverage.latestDate);
+    caveats.push(`这个自然${granularityLabel(summary.window.granularity)}窗口目前只覆盖本地记录中的 ${observedStart} 至 ${observedEnd}。`);
   }
-
-  const topCategories = Array.from(totals.entries())
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, limit)
-    .map(([category]) => category);
-  const hiddenCategories = Array.from(totals.keys()).filter(category => !topCategories.includes(category));
-  const seriesNames = hiddenCategories.length > 0 ? [...topCategories, '其他'] : topCategories;
-  const series: Record<string, number[]> = {};
-
-  for (const category of topCategories) {
-    series[category] = drift.map(period => period.categories[category] ?? 0);
+  if (!summary.window.partialCoverage && coverage.earliestDate && coverage.latestDate) {
+    caveats.push(`当前本地历史覆盖 ${coverage.earliestDate} 至 ${coverage.latestDate}，窗口外的偏好不会纳入这次分析。`);
   }
-  if (hiddenCategories.length > 0) {
-    series['其他'] = drift.map(period => roundOne(
-      hiddenCategories.reduce((sum, category) => sum + (period.categories[category] ?? 0), 0),
-    ));
+  if (summary.stateReason === 'too_few_records' || summary.stateReason === 'too_little_watch_time') {
+    caveats.push('样本偏少，暂不绘制图表，避免把单个视频放大成稳定兴趣。');
   }
-
-  return { seriesNames, series };
+  if (summary.stateReason === 'no_watch_time') {
+    caveats.push('这个窗口只有浏览记录，没有足够的有效观看时长。');
+  }
+  return caveats.join(' ');
 }
 
-function getDriftTitle(granularity: InterestDriftGranularity, coveredDays: number): string {
-  if (granularity === 'monthly' && coveredDays >= 90) return '长期兴趣漂移';
-  if (granularity === 'weekly') return '近期兴趣趋势';
-  return '近期兴趣分布';
+function getWindowStateMessage(summary: PreferenceWindowSummary): string {
+  const noun = windowNoun(summary.window.granularity);
+  switch (summary.stateReason) {
+    case 'no_records':
+      return `${noun}暂无本地观看记录。`;
+    case 'no_watch_time':
+      return `${noun}有历史记录，但缺少有效观看时长，暂不生成兴趣分布。`;
+    case 'too_few_records':
+      return `${noun}样本太少，暂不绘制兴趣图表。`;
+    case 'too_little_watch_time':
+      return `${noun}观看时长太少，暂不绘制兴趣图表。`;
+    default:
+      return '当前窗口可正常生成兴趣分布。';
+  }
 }
 
-function getDriftCaveat(
-  granularity: InterestDriftGranularity,
-  coveredDays: number,
-  totalRecords: number,
-  hasData: boolean,
-): string {
-  if (totalRecords === 0) return '本地还没有观看历史记录，无法计算兴趣分布。';
-  if (!hasData) return '已同步记录缺少有效观看时长，图表暂不计算百分比。';
-  if (totalRecords < 10) return '样本量较少，百分比容易被单个视频放大，请把它作为近期分布参考。';
-  if (granularity === 'monthly' && coveredDays < 90) return '历史覆盖不足 90 天，月粒度只适合粗略查看，不代表长期兴趣漂移。';
-  if (granularity === 'weekly' && coveredDays < 14) return '历史覆盖不足 14 天，周粒度样本不足；默认日粒度更可信。';
-  if (granularity === 'daily' && coveredDays >= 14) return '日粒度适合排查短期波动，覆盖较长时会比周/月视图更碎。';
-  return '';
+function getDurationEmptyMessage(summary: PreferenceWindowSummary): string {
+  if (summary.stateReason === 'no_records') return `${windowNoun(summary.window.granularity)}暂无本地观看记录。`;
+  if (summary.stateReason === 'no_watch_time') return '这个窗口没有可统计的有效观看时长。';
+  return '样本偏少，仅保留简化的时长摘要。';
 }
 
-function getGranularityHint(
-  granularity: InterestDriftGranularity,
-  coveredDays: number,
-  isDefault: boolean,
-): string {
-  const prefix = isDefault ? '当前默认：' : '';
-  if (granularity === 'daily') return `${prefix}少于 14 天历史时最可信`;
-  if (granularity === 'weekly') return `${prefix}14 至 90 天历史时最可信`;
-  return `${prefix}90 天以上历史时最适合观察长期漂移`;
+function getTagEmptyMessage(summary: PreferenceWindowSummary): string {
+  if (summary.stateReason === 'no_records') return `${windowNoun(summary.window.granularity)}暂无标签记录。`;
+  if (summary.stateReason === 'no_watch_time') return '这个窗口没有足够的标签样本。';
+  return '样本偏少，仅保留简化的标签摘要。';
 }
 
-function formatCoverageDate(value: string | null): string {
-  return value ?? '暂无';
+function getWindowTitle(granularity: InterestDriftGranularity): string {
+  if (granularity === 'weekly') return '当周兴趣分布';
+  if (granularity === 'monthly') return '当月兴趣分布';
+  return '当天兴趣分布';
 }
 
-function roundOne(value: number): number {
-  return Math.round(value * 10) / 10;
+function formatWindowOption(window: PreferenceWindowOption): string {
+  const flags = [];
+  if (window.recordCount === 0) flags.push('空窗口');
+  if (window.partialCoverage) flags.push('覆盖不完整');
+  const suffix = flags.length > 0 ? `（${flags.join('，')}）` : '';
+  return `${window.label}${suffix}`;
+}
+
+function granularityLabel(granularity: InterestDriftGranularity): string {
+  if (granularity === 'weekly') return '周';
+  if (granularity === 'monthly') return '月';
+  return '日';
+}
+
+function windowNoun(granularity: InterestDriftGranularity): string {
+  if (granularity === 'weekly') return '当周';
+  if (granularity === 'monthly') return '当月';
+  return '当天';
+}
+
+function formatWatchTime(seconds: number): string {
+  if (seconds <= 0) return '0 分钟';
+  if (seconds < 3600) return `${Math.max(1, Math.round(seconds / 60))} 分钟`;
+  return `${Math.round((seconds / 3600) * 10) / 10} 小时`;
+}
+
+function formatPercentage(value: number): string {
+  return `${Math.round(value * 1000) / 10}%`;
+}
+
+function maxDate(a: string, b: string): string {
+  return a > b ? a : b;
+}
+
+function minDate(a: string, b: string): string {
+  return a < b ? a : b;
 }

--- a/src/background/analytics/category.ts
+++ b/src/background/analytics/category.ts
@@ -1,140 +1,41 @@
-import type { WatchHistoryRecord } from '../../shared/types/watch-event';
-import type {
-  CategoryDistribution,
-  HistoryCoverage,
-  InterestDrift,
-  InterestDriftGranularity,
-  DurationBucket,
-  PreferenceAnalytics,
-} from '../../shared/types/analytics';
-import { DURATION_BUCKETS } from '../../shared/constants';
+import type { PreferenceAnalytics } from '../../shared/types/analytics';
 import {
   getNewestRecord,
   getOldestRecord,
   getRecordsByDateRange,
   getTotalCount,
 } from '../storage/watch-history-repo';
-import { dateKey, daysBetween, startOfMonth, startOfWeek } from '../../shared/utils/time';
+import {
+  buildHistoryCoverage,
+  buildPreferenceWindowOptions,
+  buildPreferenceWindowSummary,
+  computeCategoryDistribution,
+  computeDurationBuckets,
+  computeTopTags,
+  getDefaultInterestDriftGranularity,
+  normalizePreferenceGranularity,
+  resolveSelectedPreferenceWindow,
+} from './preference-windows';
 
-export function computeCategoryDistribution(records: WatchHistoryRecord[]): CategoryDistribution[] {
-  const map = new Map<string, number>();
-  let total = 0;
-  for (const r of records) {
-    const tag = r.tagName || '其他';
-    const watchTime = r.progress > 0 ? r.progress : 0;
-    map.set(tag, (map.get(tag) ?? 0) + watchTime);
-    total += watchTime;
-  }
-
-  const result: CategoryDistribution[] = [];
-  for (const [name, watchTime] of map) {
-    result.push({ name, watchTime, percentage: total > 0 ? watchTime / total : 0 });
-  }
-  result.sort((a, b) => b.watchTime - a.watchTime);
-  return result;
+interface PreferenceWindowRequest {
+  granularity?: unknown;
+  windowStart?: unknown;
 }
 
-export function computeDurationBuckets(records: WatchHistoryRecord[]): DurationBucket[] {
-  const map = new Map<string, number>();
-  for (const b of DURATION_BUCKETS) map.set(b.label, 0);
+export {
+  buildHistoryCoverage,
+  buildPreferenceWindowOptions,
+  buildPreferenceWindowSummary,
+  computeCategoryDistribution,
+  computeDurationBuckets,
+  computeTopTags,
+  getDefaultInterestDriftGranularity,
+} from './preference-windows';
 
-  for (const r of records) {
-    const d = r.duration || 0;
-    for (const b of DURATION_BUCKETS) {
-      if (d >= b.min && d < b.max) {
-        map.set(b.label, (map.get(b.label) ?? 0) + 1);
-        break;
-      }
-    }
-  }
-
-  return DURATION_BUCKETS.map(b => ({
-    label: b.label,
-    min: b.min,
-    max: b.max,
-    count: map.get(b.label) ?? 0,
-  }));
-}
-
-export function computeTopTags(records: WatchHistoryRecord[], limit = 30): { name: string; count: number }[] {
-  const map = new Map<string, number>();
-  for (const r of records) {
-    for (const tag of r.tags ?? []) {
-      if (!tag) continue;
-      map.set(tag, (map.get(tag) ?? 0) + 1);
-    }
-    // Also count the primary tag
-    if (r.tagName) {
-      map.set(r.tagName, (map.get(r.tagName) ?? 0) + 1);
-    }
-  }
-
-  return Array.from(map.entries())
-    .map(([name, count]) => ({ name, count }))
-    .sort((a, b) => b.count - a.count)
-    .slice(0, limit);
-}
-
-export function getDefaultInterestDriftGranularity(coverage: HistoryCoverage): InterestDriftGranularity {
-  if (coverage.coveredDays < 14) return 'daily';
-  if (coverage.coveredDays < 90) return 'weekly';
-  return 'monthly';
-}
-
-export function computeInterestDrift(
-  records: WatchHistoryRecord[],
-  coverage: HistoryCoverage,
-  granularity: InterestDriftGranularity,
-): InterestDrift[] {
-  if (!coverage.earliestDate || !coverage.latestDate) return [];
-
-  const periods = buildPeriods(coverage.earliestDate, coverage.latestDate, granularity);
-  const byPeriod = new Map(periods.map(period => [period.period, period]));
-
-  for (const record of records) {
-    const recordDate = dateKeyFromRecord(record);
-    const period = byPeriod.get(periodKey(recordDate, granularity));
-    if (!period) continue;
-
-    const category = record.tagName || '其他';
-    const watchTime = Math.max(0, record.progress || 0);
-    period.recordCount++;
-    period.totalWatchTime += watchTime;
-    period.activeDates.add(recordDate);
-    period.merged[category] = (period.merged[category] ?? 0) + watchTime;
-  }
-
-  return periods.map((period) => {
-    const totalSec = Object.values(period.merged).reduce((sum, value) => sum + value, 0);
-    const categories: Record<string, number> = {};
-    for (const [category, seconds] of Object.entries(period.merged)) {
-      categories[category] = totalSec > 0 ? Math.round((seconds / totalSec) * 1000) / 10 : 0;
-    }
-
-    return {
-      month: period.period,
-      period: period.period,
-      label: period.label,
-      granularity,
-      startDate: period.startDate,
-      endDate: period.endDate,
-      categories,
-      recordCount: period.recordCount,
-      activeDays: period.activeDates.size,
-      totalWatchTime: Math.round(period.totalWatchTime),
-    };
-  });
-}
-
-export async function getPreferenceData(): Promise<PreferenceAnalytics> {
-  const now = new Date();
-  const thirtyDaysAgo = new Date(now);
-  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-  const startKey = dateKey(thirtyDaysAgo);
-  const endKey = dateKey(now);
-
-  const [records, oldest, newest, totalRecords] = await Promise.all([
-    getRecordsByDateRange(startKey, endKey),
+export async function getPreferenceData(
+  request: PreferenceWindowRequest = {},
+): Promise<PreferenceAnalytics> {
+  const [oldest, newest, totalRecords] = await Promise.all([
     getOldestRecord(),
     getNewestRecord(),
     getTotalCount(),
@@ -145,133 +46,27 @@ export async function getPreferenceData(): Promise<PreferenceAnalytics> {
     ? await getRecordsByDateRange(earliestDate, latestDate)
     : [];
   const coverage = buildHistoryCoverage(oldest, newest, totalRecords, allRecords);
-  const defaultDriftGranularity = getDefaultInterestDriftGranularity(coverage);
-  const driftByGranularity: Record<InterestDriftGranularity, InterestDrift[]> = {
-    daily: computeInterestDrift(allRecords, coverage, 'daily'),
-    weekly: computeInterestDrift(allRecords, coverage, 'weekly'),
-    monthly: computeInterestDrift(allRecords, coverage, 'monthly'),
+  const windows = {
+    daily: buildPreferenceWindowOptions(allRecords, coverage, 'daily'),
+    weekly: buildPreferenceWindowOptions(allRecords, coverage, 'weekly'),
+    monthly: buildPreferenceWindowOptions(allRecords, coverage, 'monthly'),
   };
+  const defaultGranularity = getDefaultInterestDriftGranularity(coverage);
+  const selectedGranularity = normalizePreferenceGranularity(request.granularity) ?? defaultGranularity;
+  const selectedWindow = resolveSelectedPreferenceWindow(windows[selectedGranularity], request.windowStart);
 
   return {
-    categories: computeCategoryDistribution(records),
-    drift: driftByGranularity[defaultDriftGranularity],
-    driftByGranularity,
-    defaultDriftGranularity,
+    windows,
+    selectedWindow: selectedWindow ? buildPreferenceWindowSummary(allRecords, selectedWindow) : null,
+    defaultGranularity,
     coverage,
-    durationBuckets: computeDurationBuckets(records),
-    topTags: computeTopTags(records),
   };
 }
 
-function buildHistoryCoverage(
-  oldest: WatchHistoryRecord | undefined,
-  newest: WatchHistoryRecord | undefined,
-  totalRecords: number,
-  records: WatchHistoryRecord[],
-): HistoryCoverage {
-  if (!oldest || !newest || totalRecords === 0) {
-    return {
-      earliestDate: null,
-      latestDate: null,
-      activeDays: 0,
-      totalRecords,
-      coveredDays: 0,
-    };
-  }
-
-  const earliestDate = dateKeyFromRecord(oldest);
-  const latestDate = dateKeyFromRecord(newest);
-  const activeDates = new Set(records.map(dateKeyFromRecord));
-
-  return {
-    earliestDate,
-    latestDate,
-    activeDays: activeDates.size,
-    totalRecords,
-    coveredDays: daysBetween(parseDateKey(earliestDate), parseDateKey(latestDate)) + 1,
-  };
-}
-
-interface InterestPeriod {
-  period: string;
-  label: string;
-  startDate: string;
-  endDate: string;
-  merged: Record<string, number>;
-  recordCount: number;
-  activeDates: Set<string>;
-  totalWatchTime: number;
-}
-
-function buildPeriods(
-  earliestDate: string,
-  latestDate: string,
-  granularity: InterestDriftGranularity,
-): InterestPeriod[] {
-  const periods: InterestPeriod[] = [];
-  const end = parseDateKey(latestDate);
-  let cursor = periodStart(parseDateKey(earliestDate), granularity);
-
-  while (cursor.getTime() <= end.getTime()) {
-    const start = new Date(cursor);
-    const next = addPeriod(start, granularity);
-    const periodEnd = new Date(Math.min(next.getTime() - 1, end.getTime()));
-    const period = dateKey(start);
-    periods.push({
-      period,
-      label: periodLabel(start, periodEnd, granularity),
-      startDate: period,
-      endDate: dateKey(periodEnd),
-      merged: {},
-      recordCount: 0,
-      activeDates: new Set<string>(),
-      totalWatchTime: 0,
-    });
-    cursor = next;
-  }
-
-  return periods;
-}
-
-function periodKey(recordDate: string, granularity: InterestDriftGranularity): string {
-  return dateKey(periodStart(parseDateKey(recordDate), granularity));
-}
-
-function periodStart(date: Date, granularity: InterestDriftGranularity): Date {
-  if (granularity === 'weekly') return startOfWeek(date);
-  if (granularity === 'monthly') return startOfMonth(date);
-  return parseDateKey(dateKey(date));
-}
-
-function addPeriod(date: Date, granularity: InterestDriftGranularity): Date {
-  const next = new Date(date);
-  if (granularity === 'monthly') {
-    next.setMonth(next.getMonth() + 1);
-  } else {
-    next.setDate(next.getDate() + (granularity === 'weekly' ? 7 : 1));
-  }
-  return next;
-}
-
-function periodLabel(start: Date, end: Date, granularity: InterestDriftGranularity): string {
-  if (granularity === 'monthly') {
-    return `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}`;
-  }
-
-  const startLabel = shortDateLabel(start);
-  if (granularity === 'daily') return startLabel;
-  return `${startLabel}~${shortDateLabel(end)}`;
-}
-
-function shortDateLabel(date: Date): string {
-  return `${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
-}
-
-function parseDateKey(value: string): Date {
-  const [year, month, day] = value.split('-').map(Number);
-  return new Date(year, month - 1, day);
-}
-
-function dateKeyFromRecord(record: WatchHistoryRecord): string {
-  return dateKey(new Date(record.viewAt * 1000));
+function dateKeyFromRecord(record: { viewAt: number }): string {
+  const date = new Date(record.viewAt * 1000);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }

--- a/src/background/analytics/preference-windows.ts
+++ b/src/background/analytics/preference-windows.ts
@@ -1,0 +1,288 @@
+import type { WatchHistoryRecord } from '../../shared/types/watch-event';
+import type {
+  CategoryDistribution,
+  DurationBucket,
+  HistoryCoverage,
+  InterestDriftGranularity,
+  PreferenceWindowOption,
+  PreferenceWindowStateReason,
+  PreferenceWindowSummary,
+} from '../../shared/types/analytics';
+import { DURATION_BUCKETS } from '../../shared/constants.ts';
+import { dateKey, daysBetween, startOfMonth, startOfWeek } from '../../shared/utils/time.ts';
+
+const MIN_WINDOW_RECORDS_FOR_VISUALS = 3;
+const MIN_WINDOW_WATCH_SECONDS_FOR_VISUALS = 600;
+
+interface PreferencePeriodBucket {
+  key: string;
+  label: string;
+  startDate: string;
+  endDate: string;
+  recordCount: number;
+  activeDates: Set<string>;
+  totalWatchTime: number;
+}
+
+export function computeCategoryDistribution(records: WatchHistoryRecord[]): CategoryDistribution[] {
+  const map = new Map<string, number>();
+  let total = 0;
+  for (const record of records) {
+    const category = record.tagName || '其他';
+    const watchTime = Math.max(0, record.progress || 0);
+    map.set(category, (map.get(category) ?? 0) + watchTime);
+    total += watchTime;
+  }
+
+  return Array.from(map.entries())
+    .map(([name, watchTime]) => ({
+      name,
+      watchTime,
+      percentage: total > 0 ? watchTime / total : 0,
+    }))
+    .sort((a, b) => b.watchTime - a.watchTime);
+}
+
+export function computeDurationBuckets(records: WatchHistoryRecord[]): DurationBucket[] {
+  const map = new Map<string, number>();
+  for (const bucket of DURATION_BUCKETS) map.set(bucket.label, 0);
+
+  for (const record of records) {
+    const duration = record.duration || 0;
+    for (const bucket of DURATION_BUCKETS) {
+      if (duration >= bucket.min && duration < bucket.max) {
+        map.set(bucket.label, (map.get(bucket.label) ?? 0) + 1);
+        break;
+      }
+    }
+  }
+
+  return DURATION_BUCKETS.map(bucket => ({
+    label: bucket.label,
+    min: bucket.min,
+    max: bucket.max,
+    count: map.get(bucket.label) ?? 0,
+  }));
+}
+
+export function computeTopTags(records: WatchHistoryRecord[], limit = 30): { name: string; count: number }[] {
+  const map = new Map<string, number>();
+  for (const record of records) {
+    for (const tag of record.tags ?? []) {
+      if (!tag) continue;
+      map.set(tag, (map.get(tag) ?? 0) + 1);
+    }
+    if (record.tagName) {
+      map.set(record.tagName, (map.get(record.tagName) ?? 0) + 1);
+    }
+  }
+
+  return Array.from(map.entries())
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, limit);
+}
+
+export function getDefaultInterestDriftGranularity(coverage: HistoryCoverage): InterestDriftGranularity {
+  if (coverage.coveredDays < 14) return 'daily';
+  if (coverage.coveredDays < 90) return 'weekly';
+  return 'monthly';
+}
+
+export function buildHistoryCoverage(
+  oldest: WatchHistoryRecord | undefined,
+  newest: WatchHistoryRecord | undefined,
+  totalRecords: number,
+  records: WatchHistoryRecord[],
+): HistoryCoverage {
+  if (!oldest || !newest || totalRecords === 0) {
+    return {
+      earliestDate: null,
+      latestDate: null,
+      activeDays: 0,
+      totalRecords,
+      coveredDays: 0,
+    };
+  }
+
+  const earliestDate = dateKeyFromRecord(oldest);
+  const latestDate = dateKeyFromRecord(newest);
+  const activeDates = new Set(records.map(dateKeyFromRecord));
+
+  return {
+    earliestDate,
+    latestDate,
+    activeDays: activeDates.size,
+    totalRecords,
+    coveredDays: daysBetween(parseDateKey(earliestDate), parseDateKey(latestDate)) + 1,
+  };
+}
+
+export function buildPreferenceWindowOptions(
+  records: WatchHistoryRecord[],
+  coverage: HistoryCoverage,
+  granularity: InterestDriftGranularity,
+): PreferenceWindowOption[] {
+  if (!coverage.earliestDate || !coverage.latestDate) return [];
+  const earliestDate = coverage.earliestDate;
+  const latestDate = coverage.latestDate;
+
+  const periods = buildPeriods(earliestDate, latestDate, granularity);
+  const byPeriod = new Map(periods.map(period => [period.key, period]));
+
+  for (const record of records) {
+    const recordDate = dateKeyFromRecord(record);
+    const period = byPeriod.get(periodKey(recordDate, granularity));
+    if (!period) continue;
+
+    period.recordCount++;
+    period.activeDates.add(recordDate);
+    period.totalWatchTime += Math.max(0, record.progress || 0);
+  }
+
+  return periods
+    .map((period) => ({
+      key: period.key,
+      label: period.label,
+      startDate: period.startDate,
+      endDate: period.endDate,
+      granularity,
+      recordCount: period.recordCount,
+      activeDays: period.activeDates.size,
+      totalWatchTime: Math.round(period.totalWatchTime),
+      partialCoverage: period.startDate < earliestDate || period.endDate > latestDate,
+    }))
+    .sort((a, b) => b.startDate.localeCompare(a.startDate));
+}
+
+export function buildPreferenceWindowSummary(
+  records: WatchHistoryRecord[],
+  window: PreferenceWindowOption,
+): PreferenceWindowSummary {
+  const windowRecords = records.filter((record) => {
+    const recordDate = dateKeyFromRecord(record);
+    return recordDate >= window.startDate && recordDate <= window.endDate;
+  });
+  const categories = computeCategoryDistribution(windowRecords);
+  const durationBuckets = computeDurationBuckets(windowRecords);
+  const topTags = computeTopTags(windowRecords, 50);
+  const stateReason = getPreferenceWindowStateReason(window.recordCount, window.totalWatchTime);
+
+  return {
+    window,
+    state: stateReason === null ? 'ready' : stateReason === 'too_few_records' || stateReason === 'too_little_watch_time'
+      ? 'insufficient_sample'
+      : 'empty',
+    stateReason,
+    categories,
+    durationBuckets,
+    topTags,
+  };
+}
+
+export function resolveSelectedPreferenceWindow(
+  windows: PreferenceWindowOption[],
+  requestedStart: unknown,
+): PreferenceWindowOption | null {
+  const requested = typeof requestedStart === 'string' ? requestedStart : null;
+  if (requested) {
+    const matched = windows.find(window => window.startDate === requested);
+    if (matched) return matched;
+  }
+
+  return windows[0] ?? null;
+}
+
+export function normalizePreferenceGranularity(value: unknown): InterestDriftGranularity | null {
+  if (value === 'daily' || value === 'weekly' || value === 'monthly') return value;
+  return null;
+}
+
+function getPreferenceWindowStateReason(
+  recordCount: number,
+  totalWatchTime: number,
+): PreferenceWindowStateReason | null {
+  if (recordCount === 0) return 'no_records';
+  if (totalWatchTime <= 0) return 'no_watch_time';
+  if (recordCount < MIN_WINDOW_RECORDS_FOR_VISUALS) return 'too_few_records';
+  if (totalWatchTime < MIN_WINDOW_WATCH_SECONDS_FOR_VISUALS) return 'too_little_watch_time';
+  return null;
+}
+
+function buildPeriods(
+  earliestDate: string,
+  latestDate: string,
+  granularity: InterestDriftGranularity,
+): PreferencePeriodBucket[] {
+  const periods: PreferencePeriodBucket[] = [];
+  let cursor = periodStart(parseDateKey(earliestDate), granularity);
+  const lastStart = periodStart(parseDateKey(latestDate), granularity);
+
+  while (cursor.getTime() <= lastStart.getTime()) {
+    const start = new Date(cursor);
+    const next = addPeriod(start, granularity);
+    const end = addDays(next, -1);
+    const startDate = dateKey(start);
+    periods.push({
+      key: startDate,
+      label: periodLabel(start, end, granularity),
+      startDate,
+      endDate: dateKey(end),
+      recordCount: 0,
+      activeDates: new Set<string>(),
+      totalWatchTime: 0,
+    });
+    cursor = next;
+  }
+
+  return periods;
+}
+
+function periodKey(recordDate: string, granularity: InterestDriftGranularity): string {
+  return dateKey(periodStart(parseDateKey(recordDate), granularity));
+}
+
+function periodStart(date: Date, granularity: InterestDriftGranularity): Date {
+  if (granularity === 'weekly') return startOfWeek(date);
+  if (granularity === 'monthly') return startOfMonth(date);
+  return parseDateKey(dateKey(date));
+}
+
+function addPeriod(date: Date, granularity: InterestDriftGranularity): Date {
+  const next = new Date(date);
+  if (granularity === 'monthly') {
+    next.setMonth(next.getMonth() + 1);
+  } else {
+    next.setDate(next.getDate() + (granularity === 'weekly' ? 7 : 1));
+  }
+  return next;
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function periodLabel(start: Date, end: Date, granularity: InterestDriftGranularity): string {
+  if (granularity === 'monthly') {
+    return `${start.getFullYear()}年${String(start.getMonth() + 1).padStart(2, '0')}月`;
+  }
+  if (granularity === 'daily') {
+    return `${dateKey(start)} ${weekdayLabel(start)}`;
+  }
+  return `${dateKey(start)} 至 ${dateKey(end)}`;
+}
+
+function weekdayLabel(date: Date): string {
+  return ['周日', '周一', '周二', '周三', '周四', '周五', '周六'][date.getDay()] ?? '';
+}
+
+function parseDateKey(value: string): Date {
+  const [year, month, day] = value.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+function dateKeyFromRecord(record: WatchHistoryRecord): string {
+  return dateKey(new Date(record.viewAt * 1000));
+}

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -154,7 +154,7 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
     case 'GET_DASHBOARD_DATA':
       return { success: true, data: await getDashboardOverview() as T };
     case 'GET_PREFERENCE_DATA':
-      return { success: true, data: await getPreferenceData() as T };
+      return { success: true, data: await getPreferenceData(request.params) as T };
     case 'GET_CREATOR_DATA':
       return { success: true, data: await getCreatorData() as T };
     case 'GET_BEHAVIOR_DATA':

--- a/src/shared/types/analytics.ts
+++ b/src/shared/types/analytics.ts
@@ -50,6 +50,26 @@ export interface CategoryDistribution {
 
 export type InterestDriftGranularity = 'daily' | 'weekly' | 'monthly';
 
+export interface PreferenceWindowOption {
+  key: string;
+  label: string;
+  startDate: string;
+  endDate: string;
+  granularity: InterestDriftGranularity;
+  recordCount: number;
+  activeDays: number;
+  totalWatchTime: number;
+  partialCoverage: boolean;
+}
+
+export type PreferenceWindowState = 'empty' | 'insufficient_sample' | 'ready';
+
+export type PreferenceWindowStateReason =
+  | 'no_records'
+  | 'no_watch_time'
+  | 'too_few_records'
+  | 'too_little_watch_time';
+
 export interface HistoryCoverage {
   earliestDate: string | null;
   latestDate: string | null;
@@ -58,17 +78,13 @@ export interface HistoryCoverage {
   coveredDays: number;
 }
 
-export interface InterestDrift {
-  month: string;
-  period: string;
-  label: string;
-  granularity: InterestDriftGranularity;
-  startDate: string;
-  endDate: string;
-  categories: Record<string, number>;
-  recordCount: number;
-  activeDays: number;
-  totalWatchTime: number;
+export interface PreferenceWindowSummary {
+  window: PreferenceWindowOption;
+  state: PreferenceWindowState;
+  stateReason: PreferenceWindowStateReason | null;
+  categories: CategoryDistribution[];
+  durationBuckets: DurationBucket[];
+  topTags: { name: string; count: number }[];
 }
 
 export interface DurationBucket {
@@ -79,13 +95,10 @@ export interface DurationBucket {
 }
 
 export interface PreferenceAnalytics {
-  categories: CategoryDistribution[];
-  drift: InterestDrift[];
-  driftByGranularity: Record<InterestDriftGranularity, InterestDrift[]>;
-  defaultDriftGranularity: InterestDriftGranularity;
+  windows: Record<InterestDriftGranularity, PreferenceWindowOption[]>;
+  selectedWindow: PreferenceWindowSummary | null;
+  defaultGranularity: InterestDriftGranularity;
   coverage: HistoryCoverage;
-  durationBuckets: DurationBucket[];
-  topTags: { name: string; count: number }[];
 }
 
 export interface CreatorRanking {

--- a/tests/preference-windows.test.ts
+++ b/tests/preference-windows.test.ts
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { WatchHistoryRecord } from '../src/shared/types/watch-event.ts';
+import {
+  buildHistoryCoverage,
+  buildPreferenceWindowOptions,
+  buildPreferenceWindowSummary,
+} from '../src/background/analytics/preference-windows.ts';
+
+test('daily windows keep empty dates between earliest and latest records', () => {
+  const records = [
+    makeRecord('2026-06-10', 1800, '动画', ['番剧']),
+    makeRecord('2026-06-13', 1200, '音乐', ['翻唱']),
+  ];
+  const coverage = buildHistoryCoverage(records[0], records[1], records.length, records);
+
+  const dailyWindows = buildPreferenceWindowOptions(records, coverage, 'daily');
+
+  assert.equal(dailyWindows.length, 4);
+  const emptyDay = dailyWindows.find(window => window.startDate === '2026-06-11');
+  assert.ok(emptyDay);
+  assert.equal(emptyDay.recordCount, 0);
+  assert.equal(emptyDay.totalWatchTime, 0);
+});
+
+test('weekly and monthly windows use natural boundaries and mark partial local coverage', () => {
+  const records = [
+    makeRecord('2026-06-10', 1800, '动画', ['番剧']),
+    makeRecord('2026-06-13', 1200, '音乐', ['翻唱']),
+  ];
+  const coverage = buildHistoryCoverage(records[0], records[1], records.length, records);
+
+  const weeklyWindow = buildPreferenceWindowOptions(records, coverage, 'weekly')[0];
+  const monthlyWindow = buildPreferenceWindowOptions(records, coverage, 'monthly')[0];
+
+  assert.equal(weeklyWindow.startDate, '2026-06-08');
+  assert.equal(weeklyWindow.endDate, '2026-06-14');
+  assert.equal(weeklyWindow.partialCoverage, true);
+  assert.equal(monthlyWindow.startDate, '2026-06-01');
+  assert.equal(monthlyWindow.endDate, '2026-06-30');
+  assert.equal(monthlyWindow.partialCoverage, true);
+});
+
+test('empty windows return explicit no-record state', () => {
+  const records = [
+    makeRecord('2026-06-10', 1800, '动画', ['番剧']),
+    makeRecord('2026-06-13', 1200, '音乐', ['翻唱']),
+  ];
+  const coverage = buildHistoryCoverage(records[0], records[1], records.length, records);
+  const emptyWindow = buildPreferenceWindowOptions(records, coverage, 'daily')
+    .find(window => window.startDate === '2026-06-11');
+
+  assert.ok(emptyWindow);
+  const summary = buildPreferenceWindowSummary(records, emptyWindow);
+
+  assert.equal(summary.state, 'empty');
+  assert.equal(summary.stateReason, 'no_records');
+  assert.deepEqual(summary.categories, []);
+  assert.deepEqual(summary.topTags, []);
+});
+
+test('low-sample windows stay available but do not become ready charts', () => {
+  const records = [
+    makeRecord('2026-06-10', 1800, '动画', ['番剧']),
+    makeRecord('2026-06-13', 1200, '音乐', ['翻唱']),
+  ];
+  const coverage = buildHistoryCoverage(records[0], records[1], records.length, records);
+  const weeklyWindow = buildPreferenceWindowOptions(records, coverage, 'weekly')[0];
+
+  const summary = buildPreferenceWindowSummary(records, weeklyWindow);
+
+  assert.equal(summary.window.recordCount, 2);
+  assert.equal(summary.state, 'insufficient_sample');
+  assert.equal(summary.stateReason, 'too_few_records');
+  assert.equal(summary.categories.length, 2);
+});
+
+test('records without effective watch time stay in empty state', () => {
+  const records = [
+    makeRecord('2026-06-12', 0, '游戏', ['实况']),
+    makeRecord('2026-06-12', 0, '游戏', ['攻略']),
+    makeRecord('2026-06-12', 0, '知识', ['科普']),
+  ];
+  const coverage = buildHistoryCoverage(records[0], records[2], records.length, records);
+  const dailyWindow = buildPreferenceWindowOptions(records, coverage, 'daily')[0];
+
+  const summary = buildPreferenceWindowSummary(records, dailyWindow);
+
+  assert.equal(summary.window.recordCount, 3);
+  assert.equal(summary.window.totalWatchTime, 0);
+  assert.equal(summary.state, 'empty');
+  assert.equal(summary.stateReason, 'no_watch_time');
+});
+
+function makeRecord(
+  day: string,
+  progress: number,
+  tagName: string,
+  tags: string[],
+): WatchHistoryRecord {
+  const [year, month, date] = day.split('-').map(Number);
+  return {
+    sessionKey: `${day}-${tagName}`,
+    kid: year * 10000 + month * 100 + date,
+    avid: year * 10000 + month * 100 + date,
+    bvid: `BV${year}${month}${date}${tagName}`,
+    cid: month * 100 + date,
+    title: `${tagName} ${day}`,
+    authorName: '测试UP',
+    authorMid: 42,
+    tagName,
+    tags,
+    cover: '',
+    viewAt: Math.floor(new Date(year, month - 1, date, 12, 0, 0, 0).getTime() / 1000),
+    progress,
+    duration: Math.max(progress, 600),
+    actualCompletion: 1,
+    deviceType: 1,
+    isFavorite: false,
+    business: 'archive',
+    dt: 0,
+    syncedAt: Date.now(),
+  };
+}


### PR DESCRIPTION
﻿## Summary
- redesign preference analytics around selected natural day/week/month windows instead of full-history bucket trend lines
- add per-window coverage, sample, active-day, and watch-time summaries with explicit empty / low-sample states
- keep category distribution, duration buckets, and top tags available for the selected window

## Root cause
The old preference panel switched only the bucket granularity while still plotting the entire locally covered history range. That made the daily view look like a three-month trend, which misled users who expected a single selected day. The fix changes the contract to return natural window options plus one selected-window summary, so the UI now answers “what did I watch in this day/week/month window?” instead of “how did buckets change across all coverage?”.

## Validation
- `git diff --check`
- `node --test tests/preference-windows.test.ts`
- `npm run typecheck`
- `npm run build`
- mock QA via Edge headless against a temporary local harness covering daily empty state, daily low-sample state, weekly ready state, and monthly ready state

## Notes
- local-history caveats remain explicit; the UI does not claim full account coverage
- no Smart Favorites, Dynamic Bill, AI assistant, or Video Knowledge behavior was changed
- refs #80


## Main-agent review
- Scope verified: preference analytics/window contract and preference page UI only; no Smart Favorites, Dynamic Bill, AI assistant, or Video Knowledge behavior changed.
- Re-ran validation in clean review worktree: `npm ci`, `node --test tests/preference-windows.test.ts`, `npm run typecheck`, `npm run build`, `git diff --check`, and forbidden-copy scan for `未消费|猜你喜欢`.
- Product judgment accepted: old daily/weekly/monthly view changed only bucket granularity over the whole coverage range; new contract uses selected natural day/week/month windows with explicit coverage, empty, and low-sample states.

Closes #80
