### PR TITLE
[codex] Probe current-video subtitle source state

### DIFF
--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -5,7 +5,10 @@ import type { QuickStats } from '../src/shared/types/analytics';
 import type { SyncNowResult } from '../src/shared/types/messages';
 import type { HistoryTailProbeReport } from '../src/shared/types/history-tail-probe';
 import type { HistorySyncProgress, HistorySyncStatus } from '../src/shared/types/history-sync';
-import type { CurrentVideoContextResult } from '../src/shared/types/current-video-context';
+import type {
+  CurrentVideoContextResult,
+  CurrentVideoSubtitleSourceState,
+} from '../src/shared/types/current-video-context';
 import type { CurrentVideoSummaryResult } from '../src/shared/types/current-video-summary';
 import type { VideoKnowledgeJumpResponse, VideoKnowledgeNode, VideoKnowledgeResult } from '../src/shared/types/video-knowledge';
 import { cancelledCurrentVideoSummary, loadingCurrentVideoSummary } from '../src/shared/current-video-summary';
@@ -551,6 +554,12 @@ function CurrentVideoAssistantStatus({
             BVID {context.bvid} / CID {context.cid ?? '未知'}
             <br />
             简介 {availabilityLabel(context.sources.description)}；字幕 {availabilityLabel(context.sources.transcript)}；正文文本 {availabilityLabel(context.sources.contentText)}
+            {context.subtitleProbe && (
+              <>
+                <br />
+                {subtitleProbeDetail(context.subtitleProbe)}
+              </>
+            )}
           </div>
           {summary && (
             <div style={{
@@ -825,6 +834,22 @@ function availabilityLabel(value: string): string {
     default:
       return '未知';
   }
+}
+
+function subtitleProbeDetail(probe: CurrentVideoSubtitleSourceState): string {
+  if (!probe.available) return probe.message;
+  const languages = probe.languages.length > 0 ? `；语言 ${probe.languages.join(', ')}` : '';
+  const coverage = typeof probe.coverageEndSeconds === 'number'
+    ? `；覆盖至 ${formatSeconds(probe.coverageEndSeconds)}`
+    : '';
+  return `${probe.message}（track ${probe.trackCount}${languages}${coverage}）`;
+}
+
+function formatSeconds(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(safe / 60);
+  const rest = safe % 60;
+  return `${minutes}:${String(rest).padStart(2, '0')}`;
 }
 
 function summaryStatusLabel(status: CurrentVideoSummaryResult['status']): string {

--- a/src/background/current-video-subtitle-probe.ts
+++ b/src/background/current-video-subtitle-probe.ts
@@ -1,0 +1,39 @@
+import type { CurrentVideoContextResult } from "../shared/types/current-video-context";
+import { biliGet } from "./api/client";
+import {
+  probeCurrentVideoSubtitleSourceWithFetcher,
+  type CurrentVideoSubtitlePlayerInfoFetcher,
+} from "../shared/current-video-subtitle-state";
+
+export { withSubtitleSourceState } from "../shared/current-video-subtitle-state";
+
+export interface ProbeCurrentVideoSubtitleOptions {
+  now?: number;
+  fetchPlayerInfo?: CurrentVideoSubtitlePlayerInfoFetcher;
+}
+
+export async function probeCurrentVideoSubtitleSource(
+  context: CurrentVideoContextResult,
+  options: ProbeCurrentVideoSubtitleOptions = {},
+) {
+  return await probeCurrentVideoSubtitleSourceWithFetcher(
+    context,
+    options.fetchPlayerInfo ?? fetchBilibiliPlayerInfo,
+    options.now,
+  );
+}
+
+const fetchBilibiliPlayerInfo: CurrentVideoSubtitlePlayerInfoFetcher = async (
+  target,
+  options,
+) => {
+  return await biliGet<unknown>(
+    options.sourcePath,
+    {
+      bvid: target.bvid,
+      cid: String(target.cid),
+    },
+    2,
+    options.sourceType === "bilibili_player_wbi_v2",
+  );
+};

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -1,6 +1,11 @@
 import type { BiliVizRequest, BiliVizContentMessage, BiliVizResponse, PlayerActionPayload, PlayerHeartbeatPayload, SyncNowResult } from '../../shared/types/messages';
 import type { HistorySyncStatus } from '../../shared/types/history-sync';
-import type { CurrentVideoContextResult, CurrentVideoNoContext } from '../../shared/types/current-video-context';
+import type {
+  CurrentVideoContext,
+  CurrentVideoContextResult,
+  CurrentVideoNoContext,
+  CurrentVideoSubtitleSourceState,
+} from '../../shared/types/current-video-context';
 import type { VideoKnowledgeJumpResponse } from '../../shared/types/video-knowledge';
 import type { DynamicBillFeedbackScope, DynamicBillStatusFilter } from '../../shared/types/dynamic-bill';
 import { normalizePageLimit, runInitialBackfill } from '../sync/initial-backfill';
@@ -19,6 +24,10 @@ import {
 import { db } from '../storage/db';
 import type { UserConfig } from '../../shared/types/config';
 import { generateCurrentVideoSummary } from '../current-video-summary';
+import {
+  probeCurrentVideoSubtitleSource,
+  withSubtitleSourceState,
+} from '../current-video-subtitle-probe';
 import { buildVideoKnowledgeResult, findVideoKnowledgeNode } from '../../shared/video-knowledge';
 import {
   getQuickStats,
@@ -56,7 +65,9 @@ import {
 } from '../storage/dynamic-bill-repo';
 
 const EXPORT_PAGE_LIMIT_MAX = 1000;
+const SUBTITLE_PROBE_CACHE_MS = 5 * 60 * 1000;
 const currentVideoContexts = new Map<number, CurrentVideoContextResult>();
+const currentVideoSubtitleProbes = new Map<string, CurrentVideoSubtitleSourceState>();
 
 export function setupMessageHandlers(): void {
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -276,6 +287,8 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
     }
     case 'GET_CURRENT_VIDEO_CONTEXT':
       return { success: true, data: await getCurrentVideoContextForActiveTab() as T };
+    case 'PROBE_CURRENT_VIDEO_SUBTITLE_SOURCE':
+      return { success: true, data: await probeSubtitleSourceForActiveTab() as T };
     case 'GET_CURRENT_VIDEO_SUMMARY':
       return { success: true, data: await generateCurrentVideoSummary(await getCurrentVideoContextForActiveTab()) as T };
     case 'GET_VIDEO_KNOWLEDGE':
@@ -428,6 +441,12 @@ async function markConsumedFromPlayerEvent(
 }
 
 async function getCurrentVideoContextForActiveTab(): Promise<CurrentVideoContextResult> {
+  const context = await getRawCurrentVideoContextForActiveTab();
+  if (context.kind !== 'video') return context;
+  return await enrichCurrentVideoContextWithSubtitleProbe(context);
+}
+
+async function getRawCurrentVideoContextForActiveTab(): Promise<CurrentVideoContextResult> {
   const { tab, context } = await resolveCurrentVideoLookupState();
   const url = tab?.url ?? null;
 
@@ -440,6 +459,41 @@ async function getCurrentVideoContextForActiveTab(): Promise<CurrentVideoContext
   }
 
   return buildNoContext(url, 'video_context_unavailable', 'video');
+}
+
+async function probeSubtitleSourceForActiveTab(): Promise<CurrentVideoSubtitleSourceState> {
+  const context = await getCurrentVideoContextForActiveTab();
+  if (context.kind === 'video' && context.subtitleProbe) {
+    return context.subtitleProbe;
+  }
+  return await probeCurrentVideoSubtitleSource(context);
+}
+
+async function enrichCurrentVideoContextWithSubtitleProbe(
+  context: CurrentVideoContext,
+): Promise<CurrentVideoContext> {
+  const existing = context.subtitleProbe;
+  if (existing && Date.now() - existing.checkedAt < SUBTITLE_PROBE_CACHE_MS) {
+    return withSubtitleSourceState(context, existing);
+  }
+
+  const cacheKey = subtitleProbeCacheKey(context);
+  const cached = currentVideoSubtitleProbes.get(cacheKey);
+  if (cached && Date.now() - cached.checkedAt < SUBTITLE_PROBE_CACHE_MS) {
+    return withSubtitleSourceState(context, cached);
+  }
+
+  const probe = await probeCurrentVideoSubtitleSource(context);
+  currentVideoSubtitleProbes.set(cacheKey, probe);
+  return withSubtitleSourceState(context, probe);
+}
+
+function subtitleProbeCacheKey(context: CurrentVideoContext): string {
+  return [
+    context.bvid,
+    context.cid ?? 'cid-unknown',
+    context.currentPart.page,
+  ].join(':');
 }
 
 async function resolveCurrentVideoLookupState(): Promise<{

--- a/src/content/player-monitor/assistant-status.ts
+++ b/src/content/player-monitor/assistant-status.ts
@@ -1,4 +1,7 @@
-import type { CurrentVideoContextResult } from '../../shared/types/current-video-context';
+import type {
+  CurrentVideoContext,
+  CurrentVideoContextResult,
+} from '../../shared/types/current-video-context';
 import { buildLocalCurrentVideoSummary } from '../../shared/current-video-summary';
 
 const CARD_ID = 'bdc-current-video-assistant';
@@ -152,9 +155,7 @@ export function renderCurrentVideoAssistant(context: CurrentVideoContextResult):
       card,
       'div',
       'bdc-assistant-warning',
-      context.sources.description === 'available'
-        ? '简介可用，但字幕和完整正文文本不可用；这不是完整视频总结。'
-        : '当前没有可用字幕、简介或完整正文文本；这不是完整视频总结。',
+      subtitleStatusMessage(context),
     );
   } else {
     appendText(card, 'div', 'bdc-assistant-video', '没有当前视频上下文');
@@ -212,4 +213,15 @@ function availabilityLabel(value: string): string {
     default:
       return '未知';
   }
+}
+
+function subtitleStatusMessage(context: CurrentVideoContext): string {
+  if (context.subtitleProbe) return context.subtitleProbe.message;
+  if (context.sources.transcript === 'unknown') {
+    return '字幕来源等待后台探测；当前只使用元数据/简介 fallback，不能做完整视频总结。';
+  }
+  if (context.sources.description === 'available') {
+    return '简介可用，但字幕和完整正文文本不可用；这不是完整视频总结。';
+  }
+  return '当前没有可用字幕、简介或完整正文文本；这不是完整视频总结。';
 }

--- a/src/content/player-monitor/current-video-context.ts
+++ b/src/content/player-monitor/current-video-context.ts
@@ -78,7 +78,7 @@ export function collectCurrentVideoContext(): CurrentVideoContext | CurrentVideo
   if (!authorName && !authorMid) warnings.push('author_unknown');
   if (!durationSeconds) warnings.push('duration_unknown');
   if (!descriptionText) warnings.push('description_unavailable');
-  warnings.push('transcript_unavailable');
+  warnings.push('transcript_probe_pending');
 
   return {
     kind: 'video',
@@ -107,9 +107,10 @@ export function collectCurrentVideoContext(): CurrentVideoContext | CurrentVideo
       description: descriptionAvailability,
       pages: pagesAvailability,
       chapters: chaptersAvailability,
-      transcript: 'unavailable',
+      transcript: 'unknown',
       contentText: 'unavailable',
     },
+    subtitleProbe: null,
     warnings,
   };
 }

--- a/src/shared/current-video-subtitle-state.ts
+++ b/src/shared/current-video-subtitle-state.ts
@@ -1,0 +1,402 @@
+import type {
+  CurrentVideoContext,
+  CurrentVideoContextResult,
+  CurrentVideoSubtitleSourceState,
+  CurrentVideoSubtitleSourceStatus,
+  CurrentVideoSubtitleSourceType,
+  CurrentVideoSubtitleTrackDiagnostic,
+} from "./types/current-video-context";
+
+const BILIBILI_API_BASE = "https://api.bilibili.com";
+
+interface SubtitleProbeTarget {
+  bvid: string | null;
+  cid: number | null;
+  page: number | null;
+}
+
+export interface PlayerInfoFetchOptions {
+  sourceType: CurrentVideoSubtitleSourceType;
+  sourcePath: string;
+}
+
+export type CurrentVideoSubtitlePlayerInfoFetcher = (
+  target: { bvid: string; cid: number; page: number | null },
+  options: PlayerInfoFetchOptions,
+) => Promise<unknown>;
+
+export async function probeCurrentVideoSubtitleSourceWithFetcher(
+  context: CurrentVideoContextResult,
+  fetchPlayerInfo: CurrentVideoSubtitlePlayerInfoFetcher,
+  now = Date.now(),
+): Promise<CurrentVideoSubtitleSourceState> {
+  if (context.kind !== "video") {
+    return buildCurrentVideoSubtitleSourceState({
+      status: "unsupported",
+      target: { bvid: null, cid: null, page: null },
+      now,
+      reason: "no_current_video_context",
+      message:
+        "当前没有可探测的 B 站视频上下文；只能保留元数据/简介 fallback。",
+      warnings: ["no_current_video_context"],
+    });
+  }
+
+  const target = {
+    bvid: context.bvid,
+    cid: context.cid,
+    page: context.currentPart.page,
+  };
+
+  if (!context.cid) {
+    return buildCurrentVideoSubtitleSourceState({
+      status: "unsupported",
+      target,
+      now,
+      reason: "missing_cid",
+      message:
+        "当前视频缺少 CID，暂时无法探测 B 站字幕来源；只能保留元数据/简介 fallback。",
+      warnings: ["cid_unknown"],
+    });
+  }
+
+  let sawLoginRequired = false;
+  let lastError: string | null = null;
+
+  for (const attempt of [
+    {
+      sourceType: "bilibili_player_wbi_v2" as const,
+      sourcePath: "/x/player/wbi/v2",
+    },
+    { sourceType: "bilibili_player_v2" as const, sourcePath: "/x/player/v2" },
+  ]) {
+    try {
+      const data = await fetchPlayerInfo(
+        {
+          bvid: context.bvid,
+          cid: context.cid,
+          page: context.currentPart.page,
+        },
+        attempt,
+      );
+      return normalizeBilibiliSubtitleSourceState(data, {
+        target,
+        now,
+        sourceType: attempt.sourceType,
+        sourcePath: attempt.sourcePath,
+      });
+    } catch (error) {
+      const message = errorMessage(error);
+      lastError = message;
+      if (isLoginRequiredError(message)) {
+        sawLoginRequired = true;
+        continue;
+      }
+      if (attempt.sourceType === "bilibili_player_wbi_v2") {
+        continue;
+      }
+    }
+  }
+
+  if (sawLoginRequired) {
+    return buildCurrentVideoSubtitleSourceState({
+      status: "login_required",
+      target,
+      now,
+      sourceType: "bilibili_player_v2",
+      sourcePath: "/x/player/v2",
+      reason: "login_required",
+      message:
+        "B 站字幕接口要求当前浏览器会话具备访问权限；当前只能保留元数据/简介 fallback。",
+      warnings: ["subtitle_login_required"],
+    });
+  }
+
+  return buildCurrentVideoSubtitleSourceState({
+    status: "endpoint_failed",
+    target,
+    now,
+    sourceType: "bilibili_player_v2",
+    sourcePath: "/x/player/v2",
+    reason: lastError ?? "endpoint_failed",
+    message: "B 站字幕接口请求失败；当前只能保留元数据/简介 fallback。",
+    warnings: ["subtitle_endpoint_failed"],
+  });
+}
+
+export function withSubtitleSourceState(
+  context: CurrentVideoContext,
+  subtitleProbe: CurrentVideoSubtitleSourceState,
+): CurrentVideoContext {
+  const transcript = subtitleProbe.available ? "available" : "unavailable";
+  const warnings = new Set(
+    context.warnings.filter(
+      (warning) => warning !== "transcript_probe_pending",
+    ),
+  );
+
+  if (subtitleProbe.available) {
+    warnings.add("transcript_source_available");
+    warnings.add("transcript_text_not_cached");
+  } else {
+    warnings.add(`transcript_${subtitleProbe.status}`);
+  }
+
+  return {
+    ...context,
+    sources: {
+      ...context.sources,
+      transcript,
+      contentText: "unavailable",
+    },
+    subtitleProbe,
+    warnings: Array.from(warnings),
+  };
+}
+
+export function normalizeBilibiliSubtitleSourceState(
+  data: unknown,
+  options: {
+    target: SubtitleProbeTarget;
+    now: number;
+    sourceType: CurrentVideoSubtitleSourceType;
+    sourcePath: string;
+  },
+): CurrentVideoSubtitleSourceState {
+  const root = asRecord(data);
+  const subtitle = asRecord(root?.subtitle);
+
+  if (!subtitle) {
+    return buildCurrentVideoSubtitleSourceState({
+      status: "unsupported",
+      target: options.target,
+      now: options.now,
+      sourceType: options.sourceType,
+      sourcePath: options.sourcePath,
+      reason: "subtitle_field_missing",
+      message:
+        "B 站播放器接口没有返回字幕字段；当前只能保留元数据/简介 fallback。",
+      warnings: ["subtitle_field_missing"],
+    });
+  }
+
+  const rawTracks = subtitle.subtitles;
+  if (!Array.isArray(rawTracks)) {
+    return buildCurrentVideoSubtitleSourceState({
+      status: "malformed",
+      target: options.target,
+      now: options.now,
+      sourceType: options.sourceType,
+      sourcePath: options.sourcePath,
+      reason: "subtitle_tracks_not_array",
+      message: "B 站字幕接口返回结构异常；当前不会把它当作可用 transcript。",
+      warnings: ["subtitle_malformed"],
+    });
+  }
+
+  if (rawTracks.length === 0) {
+    return buildCurrentVideoSubtitleSourceState({
+      status: "unavailable",
+      target: options.target,
+      now: options.now,
+      sourceType: options.sourceType,
+      sourcePath: options.sourcePath,
+      reason: "subtitle_tracks_empty",
+      message:
+        "当前视频没有可用字幕来源；只能基于元数据/简介，不能做完整视频总结。",
+      warnings: ["transcript_unavailable"],
+    });
+  }
+
+  const tracks = rawTracks
+    .map((track) => normalizeSubtitleTrack(track, options.sourceType))
+    .filter((track): track is CurrentVideoSubtitleTrackDiagnostic =>
+      Boolean(track),
+    );
+
+  if (tracks.length === 0) {
+    return buildCurrentVideoSubtitleSourceState({
+      status: "malformed",
+      target: options.target,
+      now: options.now,
+      sourceType: options.sourceType,
+      sourcePath: options.sourcePath,
+      reason: "subtitle_tracks_unusable",
+      message:
+        "B 站字幕接口返回了字幕列表，但没有可识别的语言或 track 信息；当前不会把它当作可用 transcript。",
+      warnings: ["subtitle_malformed"],
+    });
+  }
+
+  const segmentCounts = tracks
+    .map((track) => track.segmentCount)
+    .filter((value): value is number => typeof value === "number");
+  const coverageStarts = tracks
+    .map((track) => track.coverageStartSeconds)
+    .filter((value): value is number => typeof value === "number");
+  const coverageEnds = tracks
+    .map((track) => track.coverageEndSeconds)
+    .filter((value): value is number => typeof value === "number");
+  const languages = Array.from(
+    new Set(
+      tracks
+        .map((track) => track.language)
+        .filter((value): value is string => Boolean(value)),
+    ),
+  );
+
+  return buildCurrentVideoSubtitleSourceState({
+    status: "available",
+    target: options.target,
+    now: options.now,
+    sourceType: options.sourceType,
+    sourcePath: options.sourcePath,
+    reason: "subtitle_tracks_available",
+    message: `已探测到 ${tracks.length} 条字幕 track；本版本只记录来源状态，不缓存字幕正文，也不会据此生成完整视频总结。`,
+    warnings: ["transcript_source_available", "transcript_text_not_cached"],
+    tracks,
+    trackCount: tracks.length,
+    segmentCount: sumOrNull(segmentCounts),
+    coverageStartSeconds:
+      coverageStarts.length > 0 ? Math.min(...coverageStarts) : null,
+    coverageEndSeconds:
+      coverageEnds.length > 0 ? Math.max(...coverageEnds) : null,
+    languages,
+  });
+}
+
+export function buildCurrentVideoSubtitleSourceState(input: {
+  status: CurrentVideoSubtitleSourceStatus;
+  target: SubtitleProbeTarget;
+  now: number;
+  sourceType?: CurrentVideoSubtitleSourceType;
+  sourcePath?: string | null;
+  reason: string;
+  message: string;
+  warnings: string[];
+  tracks?: CurrentVideoSubtitleTrackDiagnostic[];
+  trackCount?: number;
+  segmentCount?: number | null;
+  coverageStartSeconds?: number | null;
+  coverageEndSeconds?: number | null;
+  languages?: string[];
+}): CurrentVideoSubtitleSourceState {
+  const sourcePath = input.sourcePath ?? null;
+  return {
+    status: input.status,
+    available: input.status === "available",
+    checkedAt: input.now,
+    bvid: input.target.bvid,
+    cid: input.target.cid,
+    page: input.target.page,
+    sourceType: input.sourceType ?? "none",
+    sourceDomain: sourcePath
+      ? new URL(sourcePath, BILIBILI_API_BASE).hostname
+      : null,
+    sourcePath,
+    trackCount: input.trackCount ?? input.tracks?.length ?? 0,
+    segmentCount: input.segmentCount ?? null,
+    coverageStartSeconds: input.coverageStartSeconds ?? null,
+    coverageEndSeconds: input.coverageEndSeconds ?? null,
+    languages: input.languages ?? [],
+    tracks: input.tracks ?? [],
+    reason: input.reason,
+    message: input.message,
+    warnings: input.warnings,
+  };
+}
+
+function normalizeSubtitleTrack(
+  value: unknown,
+  sourceType: CurrentVideoSubtitleSourceType,
+): CurrentVideoSubtitleTrackDiagnostic | null {
+  const track = asRecord(value);
+  if (!track) return null;
+
+  const language = normalizeString(track.lan ?? track.lang ?? track.language);
+  const languageLabel = normalizeString(
+    track.lan_doc ?? track.language_label ?? track.label,
+  );
+  const id = normalizeString(track.id ?? track.ai_type ?? track.type);
+  const urlHost = subtitleUrlHost(
+    normalizeString(track.subtitle_url ?? track.url),
+  );
+  const segments = Array.isArray(track.body)
+    ? track.body.map(asRecord).filter(Boolean)
+    : [];
+  const segmentTimes = segments
+    .map((segment) => ({
+      from: normalizeNonNegativeNumber(
+        segment?.from ?? segment?.start ?? segment?.start_time,
+      ),
+      to: normalizeNonNegativeNumber(
+        segment?.to ?? segment?.end ?? segment?.end_time,
+      ),
+    }))
+    .filter((segment) => segment.from !== null || segment.to !== null);
+
+  if (!language && !languageLabel && !id && !urlHost) return null;
+
+  return {
+    id,
+    language,
+    languageLabel,
+    sourceType,
+    urlHost,
+    segmentCount: segments.length > 0 ? segments.length : null,
+    coverageStartSeconds:
+      segmentTimes.length > 0
+        ? Math.min(
+            ...segmentTimes.map((segment) => segment.from ?? segment.to ?? 0),
+          )
+        : null,
+    coverageEndSeconds:
+      segmentTimes.length > 0
+        ? Math.max(
+            ...segmentTimes.map((segment) => segment.to ?? segment.from ?? 0),
+          )
+        : null,
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== "string" && typeof value !== "number") return null;
+  const text = String(value).replace(/\s+/g, " ").trim();
+  return text || null;
+}
+
+function normalizeNonNegativeNumber(value: unknown): number | null {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) return null;
+  return Math.round(numeric * 1000) / 1000;
+}
+
+function subtitleUrlHost(value: string | null): string | null {
+  if (!value) return null;
+  try {
+    const withProtocol = value.startsWith("//") ? `https:${value}` : value;
+    return new URL(withProtocol).hostname;
+  } catch {
+    return null;
+  }
+}
+
+function sumOrNull(values: number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((sum, value) => sum + value, 0);
+}
+
+function isLoginRequiredError(message: string): boolean {
+  return message === "NOT_LOGGED_IN" || /-101/.test(message);
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/src/shared/current-video-summary.ts
+++ b/src/shared/current-video-summary.ts
@@ -215,7 +215,8 @@ export function buildCurrentVideoSummaryAiPayload(
     sourceTier: payloadSourceTierLabel(tier),
     warnings: Array.from(new Set(context.warnings)).slice(0, 12),
     safetyRules: [
-      'Do not claim a full-video summary because transcript and content text are unavailable.',
+      'Do not claim a full-video summary because this payload does not contain transcript segments or content text.',
+      'If availableSources.transcript is available, treat it only as source availability metadata; no transcript text was provided.',
       'Do not infer body content beyond visible metadata, description, page titles, or chapter titles.',
       'Return the same source tier provided in sourceTier.',
     ],
@@ -308,14 +309,27 @@ function buildEvidence(
     label: '来源边界',
     value: '简介和正文文本是不同来源层级；当前正文文本不可用。',
   });
+  if (context.subtitleProbe) {
+    evidence.push({
+      source: 'local_fallback',
+      label: '字幕来源探测',
+      value: context.subtitleProbe.message,
+    });
+  }
   return evidence;
 }
 
 function buildMissingSources(context: CurrentVideoContext): string[] {
   const missing: string[] = [];
   if (context.sources.description !== 'available') missing.push('简介');
-  if (context.sources.transcript !== 'available') missing.push('字幕');
-  if (context.sources.contentText !== 'available') missing.push('正文文本');
+  if (context.sources.transcript === 'unknown') {
+    missing.push('字幕来源探测');
+  } else if (context.sources.transcript !== 'available') {
+    missing.push('字幕');
+  }
+  if (context.sources.contentText !== 'available') {
+    missing.push(context.sources.transcript === 'available' ? '字幕正文/正文文本' : '正文文本');
+  }
   if (context.sources.pages !== 'available') missing.push('分 P 标题');
   if (context.sources.chapters !== 'available') missing.push('章节');
   return missing;
@@ -326,7 +340,7 @@ function buildLimitations(
   tier: CurrentVideoSummarySourceTier,
 ): string[] {
   const limitations = [
-    '没有可用字幕，因此这不是完整视频总结，也不会声称理解了完整视频正文。',
+    transcriptLimitation(context),
     '完整正文文本不可用；简介不会被当作正文内容。',
   ];
   if (tier === 'metadata_summary') {
@@ -338,6 +352,22 @@ function buildLimitations(
     limitations.push('章节标题只能说明结构，不会被扩展成正文内容判断。');
   }
   return limitations;
+}
+
+function transcriptLimitation(context: CurrentVideoContext): string {
+  if (context.sources.transcript === 'available') {
+    return '已探测到字幕来源，但当前版本只记录来源状态，尚未读取、缓存或总结 transcript 正文；因此这仍不是完整视频总结。';
+  }
+
+  if (context.sources.transcript === 'unknown') {
+    return '字幕来源尚未完成探测；当前只能使用元数据/简介 fallback，不能做完整视频总结。';
+  }
+
+  if (context.subtitleProbe?.message) {
+    return `${context.subtitleProbe.message} 因此这不是完整视频总结，也不会声称理解了完整视频正文。`;
+  }
+
+  return '没有可用字幕，因此这不是完整视频总结，也不会声称理解了完整视频正文。';
 }
 
 function buildNextQuestions(tier: CurrentVideoSummarySourceTier): string[] {

--- a/src/shared/types/current-video-context.ts
+++ b/src/shared/types/current-video-context.ts
@@ -1,4 +1,17 @@
 export type CurrentVideoAvailability = 'available' | 'unavailable' | 'unknown';
+export type CurrentVideoSubtitleSourceStatus =
+  | 'available'
+  | 'unavailable'
+  | 'login_required'
+  | 'endpoint_failed'
+  | 'malformed'
+  | 'unsupported';
+
+export type CurrentVideoSubtitleSourceType =
+  | 'bilibili_player_wbi_v2'
+  | 'bilibili_player_v2'
+  | 'none'
+  | 'unknown';
 
 export interface CurrentVideoPart {
   page: number;
@@ -19,6 +32,38 @@ export interface CurrentVideoSourceAvailability {
   chapters: CurrentVideoAvailability;
   transcript: CurrentVideoAvailability;
   contentText: CurrentVideoAvailability;
+}
+
+export interface CurrentVideoSubtitleTrackDiagnostic {
+  id: string | null;
+  language: string | null;
+  languageLabel: string | null;
+  sourceType: CurrentVideoSubtitleSourceType;
+  urlHost: string | null;
+  segmentCount: number | null;
+  coverageStartSeconds: number | null;
+  coverageEndSeconds: number | null;
+}
+
+export interface CurrentVideoSubtitleSourceState {
+  status: CurrentVideoSubtitleSourceStatus;
+  available: boolean;
+  checkedAt: number;
+  bvid: string | null;
+  cid: number | null;
+  page: number | null;
+  sourceType: CurrentVideoSubtitleSourceType;
+  sourceDomain: string | null;
+  sourcePath: string | null;
+  trackCount: number;
+  segmentCount: number | null;
+  coverageStartSeconds: number | null;
+  coverageEndSeconds: number | null;
+  languages: string[];
+  tracks: CurrentVideoSubtitleTrackDiagnostic[];
+  reason: string;
+  message: string;
+  warnings: string[];
 }
 
 export interface CurrentVideoContext {
@@ -44,6 +89,7 @@ export interface CurrentVideoContext {
     length: number | null;
   };
   sources: CurrentVideoSourceAvailability;
+  subtitleProbe?: CurrentVideoSubtitleSourceState | null;
   warnings: string[];
 }
 

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -27,7 +27,7 @@ import type {
   SmartFavoriteSearchResponse,
   SmartIndexResult,
 } from './favorite';
-import type { CurrentVideoContextResult } from './current-video-context';
+import type { CurrentVideoContextResult, CurrentVideoSubtitleSourceState } from './current-video-context';
 import type { CurrentVideoSummaryResult } from './current-video-summary';
 import type { VideoKnowledgeJumpResponse, VideoKnowledgeResult } from './video-knowledge';
 import type { HistoryTailProbeReport } from './history-tail-probe';
@@ -51,6 +51,7 @@ export type RequestAction =
   | 'GET_SYNC_STATUS'
   | 'PROBE_HISTORY_TAIL'
   | 'GET_CURRENT_VIDEO_CONTEXT'
+  | 'PROBE_CURRENT_VIDEO_SUBTITLE_SOURCE'
   | 'GET_CURRENT_VIDEO_SUMMARY'
   | 'GET_VIDEO_KNOWLEDGE'
   | 'REQUEST_VIDEO_KNOWLEDGE_JUMP'
@@ -170,6 +171,7 @@ export type SmartFavoriteSearchMessageResponse = BiliVizResponse<SmartFavoriteSe
 export type SmartFavoriteQaMessageResponse = BiliVizResponse<SmartFavoriteQaResponse>;
 export type SmartFavoritePathResponse = BiliVizResponse<SmartFavoriteResult[]>;
 export type CurrentVideoContextResponse = BiliVizResponse<CurrentVideoContextResult>;
+export type CurrentVideoSubtitleSourceResponse = BiliVizResponse<CurrentVideoSubtitleSourceState>;
 export type CurrentVideoSummaryResponse = BiliVizResponse<CurrentVideoSummaryResult>;
 export type VideoKnowledgeResponse = BiliVizResponse<VideoKnowledgeResult>;
 export type VideoKnowledgeJumpMessageResponse = BiliVizResponse<VideoKnowledgeJumpResponse>;

--- a/src/shared/video-knowledge.ts
+++ b/src/shared/video-knowledge.ts
@@ -50,16 +50,12 @@ export function buildVideoKnowledgeResult(
       description: context.sources.description === 'available',
       pages: context.sources.pages === 'available',
       chapters: context.sources.chapters === 'available',
-      transcript: false,
+      transcript: context.sources.transcript === 'available',
       contentText: false,
     },
     nodes,
-    warnings: Array.from(new Set([...context.warnings, 'transcript_unavailable'])),
-    limitations: [
-      '没有可用字幕，因此元数据和简介节点不代表完整视频理解。',
-      '元数据和简介节点不会生成推测时间戳。',
-      '跳转动作是手动预览动作，改变播放位置前必须由用户明确确认。',
-    ],
+    warnings: buildVideoKnowledgeWarnings(context),
+    limitations: buildVideoKnowledgeLimitations(context),
   };
 }
 
@@ -178,6 +174,33 @@ function buildChapterNodes(context: CurrentVideoContext, now: number): VideoKnow
         now,
       });
     });
+}
+
+function buildVideoKnowledgeWarnings(context: CurrentVideoContext): string[] {
+  const warnings = new Set(context.warnings);
+  if (context.sources.transcript === 'available') {
+    warnings.add('transcript_source_available');
+    warnings.add('transcript_nodes_not_generated');
+  } else if (context.sources.transcript === 'unknown') {
+    warnings.add('transcript_probe_pending');
+  } else {
+    warnings.add('transcript_unavailable');
+  }
+  return Array.from(warnings);
+}
+
+function buildVideoKnowledgeLimitations(context: CurrentVideoContext): string[] {
+  const transcriptLimitation = context.sources.transcript === 'available'
+    ? '已探测到字幕来源，但当前版本只记录来源状态，尚未生成 transcript 节点或完整视频总结。'
+    : context.sources.transcript === 'unknown'
+      ? '字幕来源尚未完成探测；当前节点只基于元数据、简介、分 P 或章节。'
+      : '没有可用字幕，因此元数据和简介节点不代表完整视频理解。';
+
+  return [
+    transcriptLimitation,
+    '元数据和简介节点不会生成推测时间戳。',
+    '跳转动作是手动预览动作，改变播放位置前必须由用户明确确认。',
+  ];
 }
 
 function node(input: {

--- a/tests/current-video-context.test.ts
+++ b/tests/current-video-context.test.ts
@@ -30,8 +30,9 @@ test('collects Bilibili video metadata and source availability from page runtime
   assert.equal(context.sources.metadata, 'available');
   assert.equal(context.sources.description, 'available');
   assert.equal(context.sources.pages, 'available');
-  assert.equal(context.sources.transcript, 'unavailable');
+  assert.equal(context.sources.transcript, 'unknown');
   assert.equal(context.sources.contentText, 'unavailable');
+  assert.equal(context.subtitleProbe, null);
   assert.equal(context.description.text, 'Visible description text');
 });
 
@@ -49,9 +50,9 @@ test('marks missing description and transcript as unavailable without summary cl
   assert.equal(context.kind, 'video');
   assert.equal(context.sources.description, 'unavailable');
   assert.equal(context.sources.contentText, 'unavailable');
-  assert.equal(context.sources.transcript, 'unavailable');
+  assert.equal(context.sources.transcript, 'unknown');
   assert.equal(context.description.text, null);
-  assert.deepEqual(context.warnings.includes('transcript_unavailable'), true);
+  assert.deepEqual(context.warnings.includes('transcript_probe_pending'), true);
 });
 
 test('returns no-context fallback outside Bilibili video pages', () => {

--- a/tests/current-video-subtitle-probe.test.ts
+++ b/tests/current-video-subtitle-probe.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  normalizeBilibiliSubtitleSourceState,
+  probeCurrentVideoSubtitleSourceWithFetcher as probeCurrentVideoSubtitleSource,
+  withSubtitleSourceState,
+} from "../src/shared/current-video-subtitle-state.ts";
+import {
+  assertAssistantPayloadAudit,
+  auditAssistantPayload,
+  currentVideoSummaryPayloadContract,
+} from "../src/shared/assistant-payload-audit.ts";
+import { buildCurrentVideoSummaryAiPayload } from "../src/shared/current-video-summary.ts";
+import type {
+  CurrentVideoContext,
+  CurrentVideoContextResult,
+} from "../src/shared/types/current-video-context.ts";
+
+test("normalizes available Bilibili subtitle metadata without storing raw track URLs", () => {
+  const probe = normalizeBilibiliSubtitleSourceState(
+    {
+      subtitle: {
+        subtitles: [
+          {
+            id: 101,
+            lan: "zh-CN",
+            lan_doc: "中文（自动生成）",
+            subtitle_url:
+              "//aisubtitle.hdslb.com/bfs/ai_subtitle/mock-track.json?token=redacted",
+          },
+          {
+            id: 102,
+            lan: "en-US",
+            lan_doc: "English",
+            subtitle_url:
+              "https://aisubtitle.hdslb.com/bfs/ai_subtitle/mock-track-en.json",
+          },
+        ],
+      },
+    },
+    {
+      target: { bvid: "BV1Subtitle99", cid: 9901, page: 1 },
+      now: 1000,
+      sourceType: "bilibili_player_wbi_v2",
+      sourcePath: "/x/player/wbi/v2",
+    },
+  );
+
+  assert.equal(probe.status, "available");
+  assert.equal(probe.available, true);
+  assert.equal(probe.trackCount, 2);
+  assert.deepEqual(probe.languages, ["zh-CN", "en-US"]);
+  assert.equal(probe.sourceDomain, "api.bilibili.com");
+  assert.equal(probe.sourcePath, "/x/player/wbi/v2");
+  assert.equal(probe.tracks[0].urlHost, "aisubtitle.hdslb.com");
+  assert.equal(probe.segmentCount, null);
+  assert.equal(probe.coverageEndSeconds, null);
+  assert.doesNotMatch(
+    JSON.stringify(probe),
+    /mock-track\.json|token=redacted|subtitle_url/,
+  );
+});
+
+test("enriches current video context with available subtitle source state but no content text", async () => {
+  const context = videoContext();
+  const probe = await probeCurrentVideoSubtitleSource(
+    context,
+    async () => ({
+      subtitle: {
+        subtitles: [
+          {
+            id: 1,
+            lan: "zh-Hans",
+            lan_doc: "中文",
+            subtitle_url: "//aisubtitle.hdslb.com/subtitle.json",
+          },
+        ],
+      },
+    }),
+    2000,
+  );
+  const enriched = withSubtitleSourceState(context, probe);
+
+  assert.equal(enriched.sources.transcript, "available");
+  assert.equal(enriched.sources.contentText, "unavailable");
+  assert.equal(enriched.subtitleProbe?.status, "available");
+  assert.ok(enriched.warnings.includes("transcript_source_available"));
+  assert.ok(enriched.warnings.includes("transcript_text_not_cached"));
+});
+
+test("reports unavailable when player subtitle track list is empty", async () => {
+  const probe = await probeCurrentVideoSubtitleSource(
+    videoContext(),
+    async () => ({ subtitle: { subtitles: [] } }),
+    3000,
+  );
+
+  assert.equal(probe.status, "unavailable");
+  assert.equal(probe.available, false);
+  assert.equal(probe.trackCount, 0);
+  assert.match(probe.message, /没有可用字幕来源/);
+});
+
+test("reports endpoint failure after player subtitle endpoints fail", async () => {
+  const probe = await probeCurrentVideoSubtitleSource(
+    videoContext(),
+    async () => {
+      throw new Error("REQUEST_TIMEOUT");
+    },
+    4000,
+  );
+
+  assert.equal(probe.status, "endpoint_failed");
+  assert.equal(probe.available, false);
+  assert.equal(probe.reason, "REQUEST_TIMEOUT");
+  assert.doesNotMatch(
+    JSON.stringify(probe),
+    /SESSDATA|bili_jct|Key\.txt|Chrome\\User Data/i,
+  );
+});
+
+test("reports login required only when both player endpoints require session access", async () => {
+  const probe = await probeCurrentVideoSubtitleSource(
+    videoContext(),
+    async () => {
+      throw new Error("NOT_LOGGED_IN");
+    },
+    5000,
+  );
+
+  assert.equal(probe.status, "login_required");
+  assert.equal(probe.available, false);
+  assert.ok(probe.warnings.includes("subtitle_login_required"));
+});
+
+test("reports malformed player subtitle response without treating it as transcript evidence", async () => {
+  const probe = await probeCurrentVideoSubtitleSource(
+    videoContext(),
+    async () => ({ subtitle: { subtitles: { lan: "zh-CN" } } }),
+    6000,
+  );
+
+  assert.equal(probe.status, "malformed");
+  assert.equal(probe.available, false);
+  assert.equal(probe.trackCount, 0);
+  assert.match(probe.message, /返回结构异常/);
+});
+
+test("reports unsupported when there is no current video context", async () => {
+  const context: CurrentVideoContextResult = {
+    kind: "no_context",
+    url: "https://www.bilibili.com/",
+    collectedAt: 7000,
+    reason: "non_video_page",
+    pageType: "non_video",
+  };
+  const probe = await probeCurrentVideoSubtitleSource(
+    context,
+    async () => {
+      throw new Error("SHOULD_NOT_FETCH_WITHOUT_CONTEXT");
+    },
+    7000,
+  );
+
+  assert.equal(probe.status, "unsupported");
+  assert.equal(probe.available, false);
+  assert.equal(probe.reason, "no_current_video_context");
+});
+
+test("keeps subtitle source diagnostics out of current video AI payload", async () => {
+  const probe = await probeCurrentVideoSubtitleSource(
+    videoContext(),
+    async () => ({
+      subtitle: {
+        subtitles: [
+          {
+            id: 1,
+            lan: "zh-CN",
+            lan_doc: "中文",
+            subtitle_url: "//aisubtitle.hdslb.com/private-track.json",
+          },
+        ],
+      },
+    }),
+    8000,
+  );
+  const enriched = withSubtitleSourceState(videoContext(), probe);
+  const payload = buildCurrentVideoSummaryAiPayload(enriched);
+  const audit = auditAssistantPayload(
+    payload,
+    currentVideoSummaryPayloadContract,
+  );
+  const rawPayload = JSON.stringify(payload);
+
+  assert.equal(payload.availableSources.transcript, "available");
+  assert.equal(payload.availableSources.contentText, "unavailable");
+  assert.equal(audit.passed, true, JSON.stringify(audit.violations));
+  assertAssistantPayloadAudit(payload, currentVideoSummaryPayloadContract);
+  assert.doesNotMatch(
+    rawPayload,
+    /subtitleProbe|tracks|subtitle_url|aisubtitle|watchHistory|favorites|following|feedback|SESSDATA|Key\.txt/i,
+  );
+});
+
+function videoContext(): CurrentVideoContext {
+  return {
+    kind: "video",
+    url: "https://www.bilibili.com/video/BV1Subtitle99?p=1",
+    collectedAt: 1000,
+    bvid: "BV1Subtitle99",
+    cid: 9901,
+    title: "Subtitle probe video",
+    authorName: "Probe UP",
+    authorMid: 42,
+    durationSeconds: 600,
+    currentPart: {
+      page: 1,
+      title: "Main",
+      total: 1,
+    },
+    parts: [{ page: 1, cid: 9901, title: "Main", durationSeconds: 600 }],
+    chapters: [],
+    description: {
+      availability: "available",
+      text: "Visible description used as fallback.",
+      length: 37,
+    },
+    sources: {
+      metadata: "available",
+      description: "available",
+      pages: "available",
+      chapters: "unknown",
+      transcript: "unknown",
+      contentText: "unavailable",
+    },
+    subtitleProbe: null,
+    warnings: ["transcript_probe_pending"],
+  };
+}

--- a/tests/current-video-summary.test.ts
+++ b/tests/current-video-summary.test.ts
@@ -43,6 +43,45 @@ test('builds description summary while keeping contentText unavailable', () => {
   assert.ok(summary.limitations.some(item => item.includes('简介不会被当作正文内容')));
 });
 
+test('keeps available subtitle source state separate from transcript summary', () => {
+  const context = videoContext({
+    descriptionText: 'This description is still the only text supplied to the summary payload.',
+    descriptionAvailable: true,
+  });
+  context.sources.transcript = 'available';
+  context.subtitleProbe = {
+    status: 'available',
+    available: true,
+    checkedAt: 1000,
+    bvid: context.bvid,
+    cid: context.cid,
+    page: context.currentPart.page,
+    sourceType: 'bilibili_player_wbi_v2',
+    sourceDomain: 'api.bilibili.com',
+    sourcePath: '/x/player/wbi/v2',
+    trackCount: 1,
+    segmentCount: null,
+    coverageStartSeconds: null,
+    coverageEndSeconds: null,
+    languages: ['zh-CN'],
+    tracks: [],
+    reason: 'subtitle_tracks_available',
+    message: '已探测到 1 条字幕 track；本版本只记录来源状态，不缓存字幕正文，也不会据此生成完整视频总结。',
+    warnings: ['transcript_source_available', 'transcript_text_not_cached'],
+  };
+
+  const summary = buildLocalCurrentVideoSummary(context);
+  const payload = buildCurrentVideoSummaryAiPayload(context);
+
+  assert.equal(summary.sourceTier, 'description_summary');
+  assert.equal(payload.sourceTier, 'description summary');
+  assert.equal(payload.availableSources.transcript, 'available');
+  assert.equal(payload.availableSources.contentText, 'unavailable');
+  assert.ok(summary.missingSources.includes('字幕正文/正文文本'));
+  assert.ok(summary.limitations.some(item => item.includes('只记录来源状态')));
+  assert.doesNotMatch(JSON.stringify(payload), /subtitleProbe|track|aisubtitle|subtitle_url/i);
+});
+
 test('marks AI disabled fallback without changing source tier', () => {
   const summary = buildLocalCurrentVideoSummary(videoContext({}), {
     aiStatus: 'disabled',

--- a/tests/video-knowledge.test.ts
+++ b/tests/video-knowledge.test.ts
@@ -37,6 +37,58 @@ test('builds description helper without jump target', () => {
   assert.ok(description.evidence?.textSpan?.includes('visible description'));
 });
 
+test('exposes available subtitle source state without generating transcript nodes', () => {
+  const context = videoContext({
+    descriptionText: 'Description fallback remains visible.',
+    parts: [],
+    chapters: [],
+  });
+  context.sources.transcript = 'available';
+  context.subtitleProbe = {
+    status: 'available',
+    available: true,
+    checkedAt: 1000,
+    bvid: context.bvid,
+    cid: context.cid,
+    page: context.currentPart.page,
+    sourceType: 'bilibili_player_wbi_v2',
+    sourceDomain: 'api.bilibili.com',
+    sourcePath: '/x/player/wbi/v2',
+    trackCount: 1,
+    segmentCount: null,
+    coverageStartSeconds: null,
+    coverageEndSeconds: null,
+    languages: ['zh-CN'],
+    tracks: [],
+    reason: 'subtitle_tracks_available',
+    message: '已探测到 1 条字幕 track；本版本只记录来源状态，不缓存字幕正文，也不会据此生成完整视频总结。',
+    warnings: ['transcript_source_available', 'transcript_text_not_cached'],
+  };
+
+  const result = buildVideoKnowledgeResult(context, 1000);
+
+  assert.equal(result.sourceState.transcript, true);
+  assert.equal(result.sourceState.contentText, false);
+  assert.equal(result.nodes.some(node => node.source === 'transcript'), false);
+  assert.ok(result.warnings.includes('transcript_nodes_not_generated'));
+  assert.ok(result.limitations.some(item => item.includes('尚未生成 transcript 节点')));
+});
+
+test('marks pending subtitle probe as unknown source state', () => {
+  const context = videoContext({
+    descriptionText: null,
+    parts: [],
+    chapters: [],
+  });
+  context.sources.transcript = 'unknown';
+  context.warnings = ['transcript_probe_pending'];
+  const result = buildVideoKnowledgeResult(context, 1000);
+
+  assert.equal(result.sourceState.transcript, false);
+  assert.ok(result.warnings.includes('transcript_probe_pending'));
+  assert.ok(result.limitations.some(item => item.includes('字幕来源尚未完成探测')));
+});
+
 test('builds page and chapter nodes with confirmed manual jump previews', () => {
   const result = buildVideoKnowledgeResult(videoContext({
     descriptionText: null,


### PR DESCRIPTION
## Scope

- Adds a current-video subtitle source probe for Bilibili player metadata using `/x/player/wbi/v2` with fallback to `/x/player/v2` through the existing extension API client.
- Extends current-video context with `subtitleProbe` source state: `available`, `unavailable`, `login_required`, `endpoint_failed`, `malformed`, and `unsupported`.
- Surfaces safe Chinese source-state copy in popup/current-video assistant and keeps Current Video Summary plus Video Knowledge on metadata/description fallback unless transcript text is implemented later.
- Adds focused tests for available subtitle metadata, no subtitle, endpoint failure, malformed response, login required, no current video, and AI payload privacy.

## Root Cause / Product Judgment

Bili-Bill previously hardcoded `sources.transcript = unavailable`, so Current Video Assistant and Video Knowledge could not distinguish “not checked yet” from “Bilibili has no subtitles” or “the endpoint failed.” This slice establishes the source-state tracer bullet first: Bilibili player subtitle metadata can tell us whether subtitle tracks exist, but track availability is not transcript text and must not be treated as a full-video summary source.

The LongCut-style lesson applied here is evidence gating: first prove source availability and expose diagnostics, then later slices can cache transcript text, summarize, search, or jump. This PR deliberately does not implement transcript cache, summary pipeline, fuzzy retrieval, jump behavior, or AI rerank.

## Validation

- `node --test tests/current-video-context.test.ts tests/current-video-subtitle-probe.test.ts tests/current-video-context-resolver.test.ts`
- `npm run test:current-video-summary`
- `npm run test:video-knowledge`
- `npm run typecheck`
- `npm run build` (passes with the existing Vite large chunk warning for `chunks/theme-*.js`)
- `git diff --check` (only Windows LF/CRLF normalization warnings)
- `rg -n 未消费|猜你喜欢 dashboard popup public src README.md tests` (no matches)
- Safe live API shape probe without local browser/session files: public `BV1xx411c7mD` returned `data.subtitle.subtitles` as an array with `subtitleCount=0` from `/x/player/v2`.
- Mock QA: focused unit tests cover available-track, unavailable, failed, malformed, login-required, no-context, and payload-audit states.

## Blocker / Must Fix / Follow-up

- Blockers: none.
- Must fix: none known.
- Follow-up: #100 can decide whether/how to cache bounded transcript segments; #101 can build transcript-grounded summary only after text evidence exists; #83 can use source state plus future transcript/key-node evidence for fuzzy timestamp search and manual jump.

## Privacy Boundary

- Does not read local key files, browser profile files, Bilibili login-state files, or copied credentials.
- Uses extension runtime requests with `credentials: include` only through the existing API client.
- Does not send transcript text to AI, does not upload full history/favorites/following/feedback/local DB, and does not write back to Bilibili.

Closes #99