### PR TITLE
[codex] Cache current-video transcript evidence

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit",
     "test:experiments": "node --test tests/experiment-blind-boxes.test.ts",
     "test:favorites": "node --test tests/favorite-sync-audit.test.ts tests/favorite-folder-gap-probe.test.ts tests/favorite-itemkey-persistence.test.ts tests/smart-favorite-index.test.ts tests/smart-favorites-qa.test.ts",
+    "test:current-video-transcript": "node --test tests/current-video-transcript-cache.test.ts",
     "test:current-video-summary": "node --test tests/current-video-summary.test.ts",
     "test:video-knowledge": "node --test tests/video-knowledge.test.ts"
   },

--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -851,7 +851,7 @@ function subtitleProbeDetail(probe: CurrentVideoSubtitleSourceState): string {
   const coverage = typeof probe.coverageEndSeconds === 'number'
     ? `；覆盖至 ${formatSeconds(probe.coverageEndSeconds)}`
     : '';
-  return `${probe.message}（track ${probe.trackCount}${languages}${coverage}）`;
+  return `${probe.message}（字幕轨道 ${probe.trackCount}${languages}${coverage}）`;
 }
 
 function transcriptEvidenceDetail(evidence: CurrentVideoTranscriptEvidenceState): string {

--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -9,6 +9,7 @@ import type {
   CurrentVideoContextResult,
   CurrentVideoSubtitleSourceState,
 } from '../src/shared/types/current-video-context';
+import type { CurrentVideoTranscriptEvidenceState } from '../src/shared/types/current-video-transcript';
 import type { CurrentVideoSummaryResult } from '../src/shared/types/current-video-summary';
 import type { VideoKnowledgeJumpResponse, VideoKnowledgeNode, VideoKnowledgeResult } from '../src/shared/types/video-knowledge';
 import { cancelledCurrentVideoSummary, loadingCurrentVideoSummary } from '../src/shared/current-video-summary';
@@ -101,8 +102,10 @@ export function App() {
           pages: false,
           chapters: false,
           transcript: false,
+          transcriptEvidence: false,
           contentText: false,
         },
+        transcriptEvidence: null,
         nodes: [],
         warnings: ['video_knowledge_request_failed'],
         limitations: [(e as Error).message],
@@ -560,6 +563,12 @@ function CurrentVideoAssistantStatus({
                 {subtitleProbeDetail(context.subtitleProbe)}
               </>
             )}
+            {context.transcriptEvidence && context.transcriptEvidence.status !== 'missing' && (
+              <>
+                <br />
+                {transcriptEvidenceDetail(context.transcriptEvidence)}
+              </>
+            )}
           </div>
           {summary && (
             <div style={{
@@ -843,6 +852,11 @@ function subtitleProbeDetail(probe: CurrentVideoSubtitleSourceState): string {
     ? `；覆盖至 ${formatSeconds(probe.coverageEndSeconds)}`
     : '';
   return `${probe.message}（track ${probe.trackCount}${languages}${coverage}）`;
+}
+
+function transcriptEvidenceDetail(evidence: CurrentVideoTranscriptEvidenceState): string {
+  if (!evidence.active) return evidence.message;
+  return `${evidence.message} 已缓存片段=${evidence.segmentCount}`;
 }
 
 function formatSeconds(seconds: number): string {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -20,6 +20,7 @@
   "host_permissions": [
     "*://*.bilibili.com/*",
     "*://bilibili.com/*",
+    "https://*.hdslb.com/*",
     "https://api.deepseek.com/*",
     "https://api.openai.com/*"
   ],

--- a/src/background/current-video-transcript-cache.ts
+++ b/src/background/current-video-transcript-cache.ts
@@ -49,7 +49,7 @@ export async function cacheCurrentVideoTranscriptEvidence(
       target: { bvid: null, cid: null, page: null, language: options.requestedLanguage ?? null },
       now,
       reason: 'no_current_video_context',
-      message: '当前没有可缓存 transcript 的 B 站视频上下文；仍使用元数据/简介 fallback。',
+      message: '当前没有可缓存字幕正文证据的 B 站视频上下文；仍使用元数据和简介作为本地证据结果。',
       warnings: ['no_current_video_context'],
     });
   }
@@ -65,7 +65,7 @@ export async function cacheCurrentVideoTranscriptEvidence(
       },
       now,
       reason: 'missing_cid',
-      message: '当前视频缺少 CID，无法读取字幕正文证据；仍使用元数据/简介 fallback。',
+      message: '当前视频缺少 CID，无法读取字幕正文证据；仍使用元数据和简介作为本地证据结果。',
       warnings: ['cid_unknown'],
     });
   }
@@ -137,7 +137,7 @@ async function cacheCurrentVideoTranscriptEvidenceInner(
           now: options.now,
           sourceType: attempt.sourceType,
           reason: 'requested_language_not_found',
-          message: '当前字幕来源没有匹配请求语言的 track；不会把其他语言字幕缓存为 active 证据。',
+          message: '当前字幕来源没有匹配请求语言的字幕轨道；不会把其他语言字幕缓存为当前有效证据。',
           warnings: ['transcript_language_mismatch'],
         });
       }
@@ -150,7 +150,7 @@ async function cacheCurrentVideoTranscriptEvidenceInner(
           now: options.now,
           sourceType: attempt.sourceType,
           reason: 'subtitle_url_host_unsupported',
-          message: '字幕 track 地址不可用或不属于受限的 B 站字幕域名；未读取正文。',
+          message: '字幕轨道地址不可用或不属于受限的 B 站字幕域名；未读取正文。',
           warnings: ['subtitle_track_url_unavailable'],
         });
       }
@@ -189,7 +189,7 @@ async function cacheCurrentVideoTranscriptEvidenceInner(
       now: options.now,
       sourceType: 'bilibili_player_v2',
       reason: 'login_required',
-      message: 'B 站字幕正文接口需要当前浏览器会话权限；未读取本地 Cookie 或登录态文件，当前仍使用元数据/简介 fallback。',
+      message: 'B 站字幕正文接口需要当前浏览器会话权限；未读取本地 Cookie 或登录态文件，当前仍使用元数据和简介作为本地证据结果。',
       warnings: ['transcript_login_required'],
     });
   }
@@ -200,7 +200,7 @@ async function cacheCurrentVideoTranscriptEvidenceInner(
     now: options.now,
     sourceType: 'bilibili_player_v2',
     reason: lastError ?? 'endpoint_failed',
-    message: 'B 站字幕正文请求失败；当前仍使用元数据/简介 fallback。',
+    message: 'B 站字幕正文请求失败；当前仍使用元数据和简介作为本地证据结果。',
     warnings: ['transcript_endpoint_failed'],
   });
 }
@@ -282,7 +282,7 @@ function extractSubtitleTrackCandidates(
     return {
       status: 'unsupported',
       reason: 'subtitle_field_missing',
-      message: '播放器接口没有返回字幕字段；无法缓存 transcript 证据。',
+      message: '播放器接口没有返回字幕字段；无法缓存字幕正文证据。',
       warnings: ['subtitle_field_missing'],
     };
   }
@@ -291,7 +291,7 @@ function extractSubtitleTrackCandidates(
     return {
       status: 'malformed',
       reason: 'subtitle_tracks_not_array',
-      message: '播放器字幕列表结构异常；未读取或缓存 transcript 证据。',
+      message: '播放器字幕列表结构异常；未读取或缓存字幕正文证据。',
       warnings: ['subtitle_malformed'],
     };
   }
@@ -300,7 +300,7 @@ function extractSubtitleTrackCandidates(
     return {
       status: 'track_unavailable',
       reason: 'subtitle_tracks_empty',
-      message: '当前视频没有可用字幕 track；仍使用元数据/简介 fallback。',
+      message: '当前视频没有可用字幕轨道；仍使用元数据和简介作为本地证据结果。',
       warnings: ['transcript_unavailable'],
     };
   }
@@ -325,7 +325,7 @@ function extractSubtitleTrackCandidates(
     return {
       status: 'track_unavailable',
       reason: 'subtitle_track_url_missing',
-      message: '播放器返回了字幕 track，但没有可读取的字幕正文地址；未缓存 transcript 证据。',
+      message: '播放器返回了字幕轨道，但没有可读取的字幕正文地址；未缓存字幕正文证据。',
       warnings: ['subtitle_track_url_unavailable'],
     };
   }

--- a/src/background/current-video-transcript-cache.ts
+++ b/src/background/current-video-transcript-cache.ts
@@ -1,0 +1,396 @@
+import type {
+  CurrentVideoContext,
+  CurrentVideoContextResult,
+  CurrentVideoSubtitleSourceType,
+} from '../shared/types/current-video-context';
+import type {
+  CurrentVideoTranscriptEvidenceState,
+  CurrentVideoTranscriptEvidenceWrite,
+} from '../shared/types/current-video-transcript';
+import {
+  buildCurrentVideoTranscriptEvidenceState,
+  normalizeBilibiliTranscriptEvidence,
+} from '../shared/current-video-transcript-cache.ts';
+import type {
+  CurrentVideoSubtitlePlayerInfoFetcher,
+  PlayerInfoFetchOptions,
+} from '../shared/current-video-subtitle-state';
+
+const SUBTITLE_FETCH_TIMEOUT_MS = 30_000;
+const PLAYER_INFO_ATTEMPTS: Array<PlayerInfoFetchOptions> = [
+  {
+    sourceType: 'bilibili_player_wbi_v2',
+    sourcePath: '/x/player/wbi/v2',
+  },
+  {
+    sourceType: 'bilibili_player_v2',
+    sourcePath: '/x/player/v2',
+  },
+];
+
+const inFlightTranscriptCaches = new Map<string, Promise<CurrentVideoTranscriptEvidenceState>>();
+
+export interface CacheCurrentVideoTranscriptOptions {
+  now?: number;
+  requestedLanguage?: string | null;
+  fetchPlayerInfo?: CurrentVideoSubtitlePlayerInfoFetcher;
+  fetchSubtitleJson?: (url: string) => Promise<unknown>;
+  upsertEvidence?: (evidence: CurrentVideoTranscriptEvidenceWrite) => Promise<CurrentVideoTranscriptEvidenceState>;
+}
+
+export async function cacheCurrentVideoTranscriptEvidence(
+  context: CurrentVideoContextResult,
+  options: CacheCurrentVideoTranscriptOptions = {},
+): Promise<CurrentVideoTranscriptEvidenceState> {
+  const now = options.now ?? Date.now();
+  if (context.kind !== 'video') {
+    return buildCurrentVideoTranscriptEvidenceState({
+      status: 'unsupported',
+      target: { bvid: null, cid: null, page: null, language: options.requestedLanguage ?? null },
+      now,
+      reason: 'no_current_video_context',
+      message: '当前没有可缓存 transcript 的 B 站视频上下文；仍使用元数据/简介 fallback。',
+      warnings: ['no_current_video_context'],
+    });
+  }
+
+  if (!context.cid) {
+    return buildCurrentVideoTranscriptEvidenceState({
+      status: 'unsupported',
+      target: {
+        bvid: context.bvid,
+        cid: context.cid,
+        page: context.currentPart.page,
+        language: options.requestedLanguage ?? null,
+      },
+      now,
+      reason: 'missing_cid',
+      message: '当前视频缺少 CID，无法读取字幕正文证据；仍使用元数据/简介 fallback。',
+      warnings: ['cid_unknown'],
+    });
+  }
+
+  const key = [
+    context.bvid,
+    context.cid,
+    context.currentPart.page,
+    normalizeLanguage(options.requestedLanguage) ?? 'auto',
+  ].join(':');
+  const existing = inFlightTranscriptCaches.get(key);
+  if (existing) return existing;
+
+  const request = cacheCurrentVideoTranscriptEvidenceInner(context, {
+    ...options,
+    now,
+  }).finally(() => {
+    inFlightTranscriptCaches.delete(key);
+  });
+  inFlightTranscriptCaches.set(key, request);
+  return request;
+}
+
+async function cacheCurrentVideoTranscriptEvidenceInner(
+  context: CurrentVideoContext,
+  options: CacheCurrentVideoTranscriptOptions & { now: number },
+): Promise<CurrentVideoTranscriptEvidenceState> {
+  const target = {
+    bvid: context.bvid,
+    cid: context.cid as number,
+    page: context.currentPart.page,
+    language: options.requestedLanguage ?? null,
+  };
+  const fetchPlayerInfo = options.fetchPlayerInfo ?? fetchBilibiliPlayerInfo;
+  const fetchSubtitleJson = options.fetchSubtitleJson ?? defaultFetchSubtitleJson;
+  const upsertEvidence = options.upsertEvidence ?? defaultUpsertEvidence;
+  let sawLoginRequired = false;
+  let lastError: string | null = null;
+
+  for (const attempt of PLAYER_INFO_ATTEMPTS) {
+    try {
+      const data = await fetchPlayerInfo(
+        {
+          bvid: context.bvid,
+          cid: context.cid as number,
+          page: context.currentPart.page,
+        },
+        attempt,
+      );
+      const tracks = extractSubtitleTrackCandidates(data, attempt);
+
+      if (tracks.status !== 'ok') {
+        return buildCurrentVideoTranscriptEvidenceState({
+          status: tracks.status,
+          target,
+          now: options.now,
+          sourceType: attempt.sourceType,
+          reason: tracks.reason,
+          message: tracks.message,
+          warnings: tracks.warnings,
+        });
+      }
+
+      const selected = selectSubtitleTrack(tracks.tracks, options.requestedLanguage);
+      if (!selected) {
+        return buildCurrentVideoTranscriptEvidenceState({
+          status: 'language_mismatch',
+          target,
+          now: options.now,
+          sourceType: attempt.sourceType,
+          reason: 'requested_language_not_found',
+          message: '当前字幕来源没有匹配请求语言的 track；不会把其他语言字幕缓存为 active 证据。',
+          warnings: ['transcript_language_mismatch'],
+        });
+      }
+
+      const url = normalizeSubtitleUrl(selected.url);
+      if (!url || !isAllowedSubtitleHost(url.hostname)) {
+        return buildCurrentVideoTranscriptEvidenceState({
+          status: 'track_unavailable',
+          target,
+          now: options.now,
+          sourceType: attempt.sourceType,
+          reason: 'subtitle_url_host_unsupported',
+          message: '字幕 track 地址不可用或不属于受限的 B 站字幕域名；未读取正文。',
+          warnings: ['subtitle_track_url_unavailable'],
+        });
+      }
+
+      const subtitleJson = await fetchSubtitleJson(url.toString());
+      return await upsertEvidence(normalizeBilibiliTranscriptEvidence(
+        subtitleJson,
+        {
+          bvid: context.bvid,
+          cid: context.cid as number,
+          page: context.currentPart.page,
+          language: selected.language,
+          sourceType: selected.sourceType,
+          trackId: selected.id,
+          trackUrlHost: url.hostname,
+          fetchedAt: options.now,
+        },
+      ));
+    } catch (error) {
+      const message = errorMessage(error);
+      lastError = message;
+      if (isLoginRequiredError(message)) {
+        sawLoginRequired = true;
+        continue;
+      }
+      if (attempt.sourceType === 'bilibili_player_wbi_v2') {
+        continue;
+      }
+    }
+  }
+
+  if (sawLoginRequired) {
+    return buildCurrentVideoTranscriptEvidenceState({
+      status: 'login_required',
+      target,
+      now: options.now,
+      sourceType: 'bilibili_player_v2',
+      reason: 'login_required',
+      message: 'B 站字幕正文接口需要当前浏览器会话权限；未读取本地 Cookie 或登录态文件，当前仍使用元数据/简介 fallback。',
+      warnings: ['transcript_login_required'],
+    });
+  }
+
+  return buildCurrentVideoTranscriptEvidenceState({
+    status: 'endpoint_failed',
+    target,
+    now: options.now,
+    sourceType: 'bilibili_player_v2',
+    reason: lastError ?? 'endpoint_failed',
+    message: 'B 站字幕正文请求失败；当前仍使用元数据/简介 fallback。',
+    warnings: ['transcript_endpoint_failed'],
+  });
+}
+
+async function defaultUpsertEvidence(
+  evidence: CurrentVideoTranscriptEvidenceWrite,
+): Promise<CurrentVideoTranscriptEvidenceState> {
+  const repo = await import('./storage/current-video-transcript-repo.ts');
+  return await repo.upsertCurrentVideoTranscriptEvidence(evidence);
+}
+
+const fetchBilibiliPlayerInfo: CurrentVideoSubtitlePlayerInfoFetcher = async (
+  target,
+  options,
+) => {
+  const { biliGet } = await import('./api/client.ts');
+  return await biliGet<unknown>(
+    options.sourcePath,
+    {
+      bvid: target.bvid,
+      cid: String(target.cid),
+    },
+    2,
+    options.sourceType === 'bilibili_player_wbi_v2',
+  );
+};
+
+async function defaultFetchSubtitleJson(url: string): Promise<unknown> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), SUBTITLE_FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      credentials: 'include',
+      referrer: 'https://www.bilibili.com/',
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/json, text/plain, */*',
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`SUBTITLE_HTTP_${response.status}`);
+    }
+    return await response.json();
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new Error('REQUEST_TIMEOUT');
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+interface SubtitleTrackCandidate {
+  id: string | null;
+  language: string | null;
+  languageLabel: string | null;
+  url: string;
+  sourceType: CurrentVideoSubtitleSourceType;
+}
+
+type TrackExtractionResult =
+  | { status: 'ok'; tracks: SubtitleTrackCandidate[] }
+  | {
+      status: 'malformed' | 'track_unavailable' | 'unsupported';
+      reason: string;
+      message: string;
+      warnings: string[];
+    };
+
+function extractSubtitleTrackCandidates(
+  data: unknown,
+  options: PlayerInfoFetchOptions,
+): TrackExtractionResult {
+  const root = asRecord(data);
+  const subtitle = asRecord(root?.subtitle);
+  if (!subtitle) {
+    return {
+      status: 'unsupported',
+      reason: 'subtitle_field_missing',
+      message: '播放器接口没有返回字幕字段；无法缓存 transcript 证据。',
+      warnings: ['subtitle_field_missing'],
+    };
+  }
+
+  if (!Array.isArray(subtitle.subtitles)) {
+    return {
+      status: 'malformed',
+      reason: 'subtitle_tracks_not_array',
+      message: '播放器字幕列表结构异常；未读取或缓存 transcript 证据。',
+      warnings: ['subtitle_malformed'],
+    };
+  }
+
+  if (subtitle.subtitles.length === 0) {
+    return {
+      status: 'track_unavailable',
+      reason: 'subtitle_tracks_empty',
+      message: '当前视频没有可用字幕 track；仍使用元数据/简介 fallback。',
+      warnings: ['transcript_unavailable'],
+    };
+  }
+
+  const tracks = subtitle.subtitles
+    .map((item): SubtitleTrackCandidate | null => {
+      const track = asRecord(item);
+      if (!track) return null;
+      const url = normalizeText(track.subtitle_url ?? track.url);
+      if (!url) return null;
+      return {
+        id: normalizeText(track.id ?? track.ai_type ?? track.type),
+        language: normalizeText(track.lan ?? track.lang ?? track.language),
+        languageLabel: normalizeText(track.lan_doc ?? track.language_label ?? track.label),
+        url,
+        sourceType: options.sourceType,
+      };
+    })
+    .filter((track): track is SubtitleTrackCandidate => Boolean(track));
+
+  if (tracks.length === 0) {
+    return {
+      status: 'track_unavailable',
+      reason: 'subtitle_track_url_missing',
+      message: '播放器返回了字幕 track，但没有可读取的字幕正文地址；未缓存 transcript 证据。',
+      warnings: ['subtitle_track_url_unavailable'],
+    };
+  }
+
+  return { status: 'ok', tracks };
+}
+
+function selectSubtitleTrack(
+  tracks: SubtitleTrackCandidate[],
+  requestedLanguage: string | null | undefined,
+): SubtitleTrackCandidate | null {
+  const normalizedRequest = normalizeLanguage(requestedLanguage);
+  if (normalizedRequest) {
+    return tracks.find(track => normalizeLanguage(track.language) === normalizedRequest) ?? null;
+  }
+
+  return tracks.find(track => {
+    const language = normalizeLanguage(track.language);
+    return language === 'zh-cn'
+      || language === 'zh-hans'
+      || language === 'zh'
+      || language?.startsWith('zh-');
+  }) ?? tracks[0] ?? null;
+}
+
+function normalizeSubtitleUrl(value: string): URL | null {
+  try {
+    const withProtocol = value.startsWith('//') ? `https:${value}` : value;
+    const url = new URL(withProtocol);
+    if (url.protocol !== 'https:') return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+function isAllowedSubtitleHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return host === 'bilibili.com'
+    || host.endsWith('.bilibili.com')
+    || host === 'hdslb.com'
+    || host.endsWith('.hdslb.com');
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function normalizeText(value: unknown): string | null {
+  if (typeof value !== 'string' && typeof value !== 'number') return null;
+  const text = String(value).replace(/\s+/g, ' ').trim();
+  return text || null;
+}
+
+function normalizeLanguage(value: unknown): string | null {
+  return normalizeText(value)?.toLowerCase() ?? null;
+}
+
+function isLoginRequiredError(message: string): boolean {
+  return message === 'NOT_LOGGED_IN' || /-101/.test(message);
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -6,6 +6,7 @@ import type {
   CurrentVideoNoContext,
   CurrentVideoSubtitleSourceState,
 } from '../../shared/types/current-video-context';
+import type { CurrentVideoTranscriptEvidenceState } from '../../shared/types/current-video-transcript';
 import type { VideoKnowledgeJumpResponse } from '../../shared/types/video-knowledge';
 import type { DynamicBillFeedbackScope, DynamicBillStatusFilter } from '../../shared/types/dynamic-bill';
 import { normalizePageLimit, runInitialBackfill } from '../sync/initial-backfill';
@@ -28,6 +29,11 @@ import {
   probeCurrentVideoSubtitleSource,
   withSubtitleSourceState,
 } from '../current-video-subtitle-probe';
+import { cacheCurrentVideoTranscriptEvidence } from '../current-video-transcript-cache';
+import {
+  buildCurrentVideoTranscriptEvidenceState,
+  withTranscriptEvidenceState,
+} from '../../shared/current-video-transcript-cache';
 import { buildVideoKnowledgeResult, findVideoKnowledgeNode } from '../../shared/video-knowledge';
 import {
   getQuickStats,
@@ -63,11 +69,13 @@ import {
   markDynamicBillItemsConsumedByBvid,
   setDynamicBillFilterPreference,
 } from '../storage/dynamic-bill-repo';
+import { getCurrentVideoTranscriptEvidenceState } from '../storage/current-video-transcript-repo';
 
 const EXPORT_PAGE_LIMIT_MAX = 1000;
 const SUBTITLE_PROBE_CACHE_MS = 5 * 60 * 1000;
 const currentVideoContexts = new Map<number, CurrentVideoContextResult>();
 const currentVideoSubtitleProbes = new Map<string, CurrentVideoSubtitleSourceState>();
+const currentVideoSubtitleProbeRequests = new Map<string, Promise<CurrentVideoSubtitleSourceState>>();
 
 export function setupMessageHandlers(): void {
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -289,6 +297,8 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
       return { success: true, data: await getCurrentVideoContextForActiveTab() as T };
     case 'PROBE_CURRENT_VIDEO_SUBTITLE_SOURCE':
       return { success: true, data: await probeSubtitleSourceForActiveTab() as T };
+    case 'GET_CURRENT_VIDEO_TRANSCRIPT_EVIDENCE':
+      return { success: true, data: await getTranscriptEvidenceForActiveTab(request.params) as T };
     case 'GET_CURRENT_VIDEO_SUMMARY':
       return { success: true, data: await generateCurrentVideoSummary(await getCurrentVideoContextForActiveTab()) as T };
     case 'GET_VIDEO_KNOWLEDGE':
@@ -443,7 +453,8 @@ async function markConsumedFromPlayerEvent(
 async function getCurrentVideoContextForActiveTab(): Promise<CurrentVideoContextResult> {
   const context = await getRawCurrentVideoContextForActiveTab();
   if (context.kind !== 'video') return context;
-  return await enrichCurrentVideoContextWithSubtitleProbe(context);
+  const withSubtitle = await enrichCurrentVideoContextWithSubtitleProbe(context);
+  return await enrichCurrentVideoContextWithTranscriptEvidence(withSubtitle);
 }
 
 async function getRawCurrentVideoContextForActiveTab(): Promise<CurrentVideoContextResult> {
@@ -469,6 +480,16 @@ async function probeSubtitleSourceForActiveTab(): Promise<CurrentVideoSubtitleSo
   return await probeCurrentVideoSubtitleSource(context);
 }
 
+async function getTranscriptEvidenceForActiveTab(
+  params: Record<string, unknown> | undefined,
+): Promise<CurrentVideoTranscriptEvidenceState> {
+  const context = await getCurrentVideoContextForActiveTab();
+  const requestedLanguage = typeof params?.language === 'string'
+    ? params.language
+    : null;
+  return await cacheCurrentVideoTranscriptEvidence(context, { requestedLanguage });
+}
+
 async function enrichCurrentVideoContextWithSubtitleProbe(
   context: CurrentVideoContext,
 ): Promise<CurrentVideoContext> {
@@ -483,9 +504,45 @@ async function enrichCurrentVideoContextWithSubtitleProbe(
     return withSubtitleSourceState(context, cached);
   }
 
-  const probe = await probeCurrentVideoSubtitleSource(context);
+  const existingRequest = currentVideoSubtitleProbeRequests.get(cacheKey);
+  if (existingRequest) {
+    const probe = await existingRequest;
+    return withSubtitleSourceState(context, probe);
+  }
+
+  const request = probeCurrentVideoSubtitleSource(context).finally(() => {
+    currentVideoSubtitleProbeRequests.delete(cacheKey);
+  });
+  currentVideoSubtitleProbeRequests.set(cacheKey, request);
+  const probe = await request;
   currentVideoSubtitleProbes.set(cacheKey, probe);
   return withSubtitleSourceState(context, probe);
+}
+
+async function enrichCurrentVideoContextWithTranscriptEvidence(
+  context: CurrentVideoContext,
+): Promise<CurrentVideoContext> {
+  if (!context.cid) {
+    return withTranscriptEvidenceState(context, buildCurrentVideoTranscriptEvidenceState({
+      status: 'unsupported',
+      target: {
+        bvid: context.bvid,
+        cid: context.cid,
+        page: context.currentPart.page,
+      },
+      now: Date.now(),
+      reason: 'missing_cid',
+      message: '当前视频缺少 CID，无法读取本地 transcript 证据状态。',
+      warnings: ['cid_unknown'],
+    }));
+  }
+
+  const state = await getCurrentVideoTranscriptEvidenceState({
+    bvid: context.bvid,
+    cid: context.cid,
+    page: context.currentPart.page,
+  });
+  return withTranscriptEvidenceState(context, state);
 }
 
 function subtitleProbeCacheKey(context: CurrentVideoContext): string {

--- a/src/background/storage/current-video-transcript-repo.ts
+++ b/src/background/storage/current-video-transcript-repo.ts
@@ -1,0 +1,58 @@
+import {
+  buildTranscriptEvidenceStateFromCache,
+  planTranscriptEvidenceUpsert,
+} from '../../shared/current-video-transcript-cache';
+import type {
+  CurrentVideoTranscriptEvidenceState,
+  CurrentVideoTranscriptEvidenceWrite,
+  CurrentVideoTranscriptIdentity,
+} from '../../shared/types/current-video-transcript';
+import { db } from './db';
+
+export async function upsertCurrentVideoTranscriptEvidence(
+  evidence: CurrentVideoTranscriptEvidenceWrite,
+): Promise<CurrentVideoTranscriptEvidenceState> {
+  let state: CurrentVideoTranscriptEvidenceState | null = null;
+
+  await db.transaction(
+    'rw',
+    db.currentVideoTranscriptSources,
+    db.currentVideoTranscriptSegments,
+    async () => {
+      const [sources, segments] = await Promise.all([
+        db.currentVideoTranscriptSources
+          .where('bvid')
+          .equals(evidence.sourceRecord.bvid)
+          .toArray(),
+        db.currentVideoTranscriptSegments
+          .where('bvid')
+          .equals(evidence.sourceRecord.bvid)
+          .toArray(),
+      ]);
+      const plan = planTranscriptEvidenceUpsert(sources, segments, evidence);
+
+      await db.currentVideoTranscriptSources.bulkPut(plan.sourcesToPut);
+      if (plan.segmentsToPut.length > 0) {
+        await db.currentVideoTranscriptSegments.bulkPut(plan.segmentsToPut);
+      }
+      state = plan.state;
+    },
+  );
+
+  if (!state) {
+    throw new Error('TRANSCRIPT_CACHE_WRITE_FAILED');
+  }
+  return state;
+}
+
+export async function getCurrentVideoTranscriptEvidenceState(
+  identity: CurrentVideoTranscriptIdentity,
+  now = Date.now(),
+): Promise<CurrentVideoTranscriptEvidenceState> {
+  const [sources, segments] = await Promise.all([
+    db.currentVideoTranscriptSources.where('bvid').equals(identity.bvid).toArray(),
+    db.currentVideoTranscriptSegments.where('bvid').equals(identity.bvid).toArray(),
+  ]);
+
+  return buildTranscriptEvidenceStateFromCache(identity, sources, segments, now);
+}

--- a/src/background/storage/db.ts
+++ b/src/background/storage/db.ts
@@ -8,6 +8,10 @@ import type {
   FollowedCreator,
   FollowedVideoUpdate,
 } from '../../shared/types/dynamic-bill.ts';
+import type {
+  CurrentVideoTranscriptSegment,
+  CurrentVideoTranscriptSourceRecord,
+} from '../../shared/types/current-video-transcript.ts';
 
 export class BiliAnalyticsDB extends Dexie {
   watchHistory!: Table<WatchHistoryRecord, number>;
@@ -21,6 +25,8 @@ export class BiliAnalyticsDB extends Dexie {
   dynamicBillItems!: Table<DynamicBillItem, number>;
   dynamicBillExplanations!: Table<DynamicBillExplanation, number>;
   dynamicBillFeedback!: Table<DynamicBillFeedbackRecord, number>;
+  currentVideoTranscriptSources!: Table<CurrentVideoTranscriptSourceRecord, number>;
+  currentVideoTranscriptSegments!: Table<CurrentVideoTranscriptSegment, number>;
 
   constructor() {
     super('BiliAnalyticsDB');
@@ -152,6 +158,35 @@ export class BiliAnalyticsDB extends Dexie {
         '++id, [scope+key], scope, key, creatorMid, billKey, column, createdAt',
       dynamicBillExplanations:
         '++id, &billKey, status, generatedAt, model, contentHash',
+    });
+
+    this.version(8).stores({
+      watchHistory:
+        '++id, kid, &sessionKey, avid, bvid, [avid+cid+viewAt], authorMid, tagName, viewAt, dt',
+      playerEvents:
+        '++id, [bvid+cid], eventType, timestamp, tabId',
+      dailyAggregates:
+        '++id, &date',
+      favoriteFolders:
+        '++id, &mediaId, title, syncedAt',
+      favoriteItems:
+        '++id, &itemKey, mediaId, avid, bvid, authorMid, tagName, favTime, syncedAt',
+      smartFavoriteIndex:
+        '++id, &itemKey, status, indexedAt, contentHash',
+      followedCreators:
+        '++id, &mid, followedAt, followAgeKnown, isActive, syncedAt, lastSeenAt',
+      followedVideoUpdates:
+        '++id, &updateKey, dynamicId, bvid, authorMid, dynamicTime, pubtime, syncedAt',
+      dynamicBillItems:
+        '++id, &billKey, column, status, creatorMid, updateKey, generatedAt, localRank',
+      dynamicBillFeedback:
+        '++id, [scope+key], scope, key, creatorMid, billKey, column, createdAt',
+      dynamicBillExplanations:
+        '++id, &billKey, status, generatedAt, model, contentHash',
+      currentVideoTranscriptSources:
+        '++id, &identityKey, bvid, [bvid+cid+page], [bvid+cid+page+language], sourceHash, stale, updatedAt',
+      currentVideoTranscriptSegments:
+        '++id, &segmentId, bvid, [bvid+cid+page], [bvid+cid+page+language], sourceHash, stale, updatedAt',
     });
   }
 }

--- a/src/content/player-monitor/assistant-status.ts
+++ b/src/content/player-monitor/assistant-status.ts
@@ -222,7 +222,7 @@ function subtitleStatusMessage(context: CurrentVideoContext): string {
   }
   if (context.subtitleProbe) return context.subtitleProbe.message;
   if (context.sources.transcript === 'unknown') {
-    return '字幕来源等待后台探测；当前只使用元数据/简介 fallback，不能做完整视频总结。';
+    return '字幕来源等待后台探测；当前只使用元数据和简介作为本地证据兜底，不能做完整视频总结。';
   }
   if (context.sources.description === 'available') {
     return '简介可用，但字幕和完整正文文本不可用；这不是完整视频总结。';

--- a/src/content/player-monitor/assistant-status.ts
+++ b/src/content/player-monitor/assistant-status.ts
@@ -216,6 +216,10 @@ function availabilityLabel(value: string): string {
 }
 
 function subtitleStatusMessage(context: CurrentVideoContext): string {
+  if (context.transcriptEvidence?.active) return context.transcriptEvidence.message;
+  if (context.transcriptEvidence && context.transcriptEvidence.status !== 'missing') {
+    return context.transcriptEvidence.message;
+  }
   if (context.subtitleProbe) return context.subtitleProbe.message;
   if (context.sources.transcript === 'unknown') {
     return '字幕来源等待后台探测；当前只使用元数据/简介 fallback，不能做完整视频总结。';

--- a/src/shared/current-video-subtitle-state.ts
+++ b/src/shared/current-video-subtitle-state.ts
@@ -37,7 +37,7 @@ export async function probeCurrentVideoSubtitleSourceWithFetcher(
       now,
       reason: "no_current_video_context",
       message:
-        "当前没有可探测的 B 站视频上下文；只能保留元数据/简介 fallback。",
+        "当前没有可探测的 B 站视频上下文；只能保留元数据和简介作为本地证据结果。",
       warnings: ["no_current_video_context"],
     });
   }
@@ -55,7 +55,7 @@ export async function probeCurrentVideoSubtitleSourceWithFetcher(
       now,
       reason: "missing_cid",
       message:
-        "当前视频缺少 CID，暂时无法探测 B 站字幕来源；只能保留元数据/简介 fallback。",
+        "当前视频缺少 CID，暂时无法探测 B 站字幕来源；只能保留元数据和简介作为本地证据结果。",
       warnings: ["cid_unknown"],
     });
   }
@@ -107,7 +107,7 @@ export async function probeCurrentVideoSubtitleSourceWithFetcher(
       sourcePath: "/x/player/v2",
       reason: "login_required",
       message:
-        "B 站字幕接口要求当前浏览器会话具备访问权限；当前只能保留元数据/简介 fallback。",
+        "B 站字幕接口要求当前浏览器会话具备访问权限；当前只能保留元数据和简介作为本地证据结果。",
       warnings: ["subtitle_login_required"],
     });
   }
@@ -119,7 +119,7 @@ export async function probeCurrentVideoSubtitleSourceWithFetcher(
     sourceType: "bilibili_player_v2",
     sourcePath: "/x/player/v2",
     reason: lastError ?? "endpoint_failed",
-    message: "B 站字幕接口请求失败；当前只能保留元数据/简介 fallback。",
+    message: "B 站字幕接口请求失败；当前只能保留元数据和简介作为本地证据结果。",
     warnings: ["subtitle_endpoint_failed"],
   });
 }
@@ -175,7 +175,7 @@ export function normalizeBilibiliSubtitleSourceState(
       sourcePath: options.sourcePath,
       reason: "subtitle_field_missing",
       message:
-        "B 站播放器接口没有返回字幕字段；当前只能保留元数据/简介 fallback。",
+        "B 站播放器接口没有返回字幕字段；当前只能保留元数据和简介作为本地证据结果。",
       warnings: ["subtitle_field_missing"],
     });
   }
@@ -189,7 +189,7 @@ export function normalizeBilibiliSubtitleSourceState(
       sourceType: options.sourceType,
       sourcePath: options.sourcePath,
       reason: "subtitle_tracks_not_array",
-      message: "B 站字幕接口返回结构异常；当前不会把它当作可用 transcript。",
+      message: "B 站字幕接口返回结构异常；当前不会把它当作可用字幕正文证据。",
       warnings: ["subtitle_malformed"],
     });
   }
@@ -223,7 +223,7 @@ export function normalizeBilibiliSubtitleSourceState(
       sourcePath: options.sourcePath,
       reason: "subtitle_tracks_unusable",
       message:
-        "B 站字幕接口返回了字幕列表，但没有可识别的语言或 track 信息；当前不会把它当作可用 transcript。",
+        "B 站字幕接口返回了字幕列表，但没有可识别的语言或字幕轨道信息；当前不会把它当作可用字幕正文证据。",
       warnings: ["subtitle_malformed"],
     });
   }
@@ -252,7 +252,7 @@ export function normalizeBilibiliSubtitleSourceState(
     sourceType: options.sourceType,
     sourcePath: options.sourcePath,
     reason: "subtitle_tracks_available",
-    message: `已探测到 ${tracks.length} 条字幕 track；本版本只记录来源状态，不缓存字幕正文，也不会据此生成完整视频总结。`,
+    message: `已探测到 ${tracks.length} 条字幕轨道；本版本只记录来源状态，不缓存字幕正文，也不会据此生成完整视频总结。`,
     warnings: ["transcript_source_available", "transcript_text_not_cached"],
     tracks,
     trackCount: tracks.length,

--- a/src/shared/current-video-summary.ts
+++ b/src/shared/current-video-summary.ts
@@ -319,7 +319,7 @@ function buildEvidence(
   if (context.transcriptEvidence && context.transcriptEvidence.status !== 'missing') {
     evidence.push({
       source: 'local_fallback',
-      label: 'Transcript evidence cache',
+      label: '字幕正文证据缓存',
       value: context.transcriptEvidence.message,
     });
   }
@@ -363,15 +363,15 @@ function buildLimitations(
 
 function transcriptLimitation(context: CurrentVideoContext): string {
   if (context.transcriptEvidence?.active) {
-    return '已缓存本地 transcript 证据，但当前摘要 slice 仍不读取或发送字幕正文，不会生成完整视频总结；#101 才会接入 transcript summary pipeline。';
+    return '已缓存本地字幕正文证据，但当前版本仍不读取或发送字幕正文，不会生成完整视频总结；后续摘要能力再接入。';
   }
 
   if (context.sources.transcript === 'available') {
-    return '已探测到字幕来源，但当前版本只记录来源状态，尚未读取、缓存或总结 transcript 正文；因此这仍不是完整视频总结。';
+    return '已探测到字幕来源，但当前版本只记录来源状态，尚未读取、缓存或总结字幕正文；因此这仍不是完整视频总结。';
   }
 
   if (context.sources.transcript === 'unknown') {
-    return '字幕来源尚未完成探测；当前只能使用元数据/简介 fallback，不能做完整视频总结。';
+    return '字幕来源尚未完成探测；当前只能使用元数据和简介作为本地证据兜底，不能做完整视频总结。';
   }
 
   if (context.subtitleProbe?.message) {

--- a/src/shared/current-video-summary.ts
+++ b/src/shared/current-video-summary.ts
@@ -316,6 +316,13 @@ function buildEvidence(
       value: context.subtitleProbe.message,
     });
   }
+  if (context.transcriptEvidence && context.transcriptEvidence.status !== 'missing') {
+    evidence.push({
+      source: 'local_fallback',
+      label: 'Transcript evidence cache',
+      value: context.transcriptEvidence.message,
+    });
+  }
   return evidence;
 }
 
@@ -355,6 +362,10 @@ function buildLimitations(
 }
 
 function transcriptLimitation(context: CurrentVideoContext): string {
+  if (context.transcriptEvidence?.active) {
+    return '已缓存本地 transcript 证据，但当前摘要 slice 仍不读取或发送字幕正文，不会生成完整视频总结；#101 才会接入 transcript summary pipeline。';
+  }
+
   if (context.sources.transcript === 'available') {
     return '已探测到字幕来源，但当前版本只记录来源状态，尚未读取、缓存或总结 transcript 正文；因此这仍不是完整视频总结。';
   }

--- a/src/shared/current-video-transcript-cache.ts
+++ b/src/shared/current-video-transcript-cache.ts
@@ -1,0 +1,531 @@
+import type { CurrentVideoContext } from './types/current-video-context';
+import type {
+  CurrentVideoTranscriptEvidenceState,
+  CurrentVideoTranscriptEvidenceStatus,
+  CurrentVideoTranscriptEvidenceWrite,
+  CurrentVideoTranscriptIdentity,
+  CurrentVideoTranscriptSegment,
+  CurrentVideoTranscriptSourceRecord,
+} from './types/current-video-transcript';
+import type { CurrentVideoSubtitleSourceType } from './types/current-video-context';
+
+export interface NormalizeBilibiliTranscriptEvidenceOptions {
+  bvid: string;
+  cid: number;
+  page: number;
+  language: string | null;
+  sourceType: CurrentVideoSubtitleSourceType;
+  trackId?: string | null;
+  trackUrlHost?: string | null;
+  fetchedAt: number;
+}
+
+export interface TranscriptEvidenceUpsertPlan {
+  sourcesToPut: CurrentVideoTranscriptSourceRecord[];
+  segmentsToPut: CurrentVideoTranscriptSegment[];
+  state: CurrentVideoTranscriptEvidenceState;
+}
+
+export function normalizeBilibiliTranscriptEvidence(
+  data: unknown,
+  options: NormalizeBilibiliTranscriptEvidenceOptions,
+): CurrentVideoTranscriptEvidenceWrite {
+  const root = asRecord(data);
+  const nestedData = asRecord(root?.data);
+  const body: unknown[] | null = Array.isArray(data)
+    ? data
+    : Array.isArray(root?.body)
+      ? root.body
+      : Array.isArray(nestedData?.body)
+        ? nestedData.body
+        : null;
+  const language = normalizeNullableText(options.language);
+  const base = {
+    bvid: options.bvid,
+    cid: options.cid,
+    page: options.page,
+    language,
+    source: 'bilibili_subtitle' as const,
+    sourceType: options.sourceType,
+    trackId: normalizeNullableText(options.trackId),
+    trackUrlHost: normalizeNullableText(options.trackUrlHost),
+    fetchedAt: options.fetchedAt,
+    updatedAt: options.fetchedAt,
+  };
+
+  if (!body) {
+    const sourceHash = hashText([
+      options.bvid,
+      options.cid,
+      options.page,
+      language ?? '',
+      options.sourceType,
+      'malformed',
+    ].join('|'));
+    return {
+      sourceRecord: sourceRecord({
+        ...base,
+        sourceHash,
+        status: 'malformed',
+        segmentCount: 0,
+        coverageStartSeconds: null,
+        coverageEndSeconds: null,
+        reason: 'subtitle_body_not_array',
+        message: '字幕正文返回结构异常，未写入可引用 transcript 片段；当前仍使用元数据/简介 fallback。',
+        warnings: ['transcript_malformed'],
+      }),
+      segments: [],
+    };
+  }
+
+  const normalized = body
+    .map((row, index) => normalizeSegmentRow(row, index))
+    .filter((row): row is NormalizedSegmentRow => Boolean(row))
+    .sort((a, b) => a.startSeconds - b.startSeconds || a.endSeconds - b.endSeconds || a.index - b.index);
+
+  const malformedCount = body.length - normalized.length;
+  const sourceHash = hashTranscriptSource({
+    bvid: options.bvid,
+    cid: options.cid,
+    page: options.page,
+    language,
+    sourceType: options.sourceType,
+    rows: normalized,
+  });
+
+  if (body.length === 0) {
+    return {
+      sourceRecord: sourceRecord({
+        ...base,
+        sourceHash,
+        status: 'empty',
+        segmentCount: 0,
+        coverageStartSeconds: null,
+        coverageEndSeconds: null,
+        reason: 'subtitle_body_empty',
+        message: '字幕 track 可读取，但没有返回正文片段；当前仍使用元数据/简介 fallback。',
+        warnings: ['transcript_empty'],
+      }),
+      segments: [],
+    };
+  }
+
+  if (normalized.length === 0) {
+    return {
+      sourceRecord: sourceRecord({
+        ...base,
+        sourceHash,
+        status: 'malformed',
+        segmentCount: 0,
+        coverageStartSeconds: null,
+        coverageEndSeconds: null,
+        reason: 'subtitle_segments_unusable',
+        message: '字幕正文片段缺少有效时间轴或文本，未作为 transcript 证据缓存。',
+        warnings: ['transcript_malformed'],
+      }),
+      segments: [],
+    };
+  }
+
+  const warnings = malformedCount > 0
+    ? ['transcript_segments_filtered']
+    : [];
+  const segments = normalized.map((row, index) => ({
+    segmentId: transcriptSegmentId({
+      bvid: options.bvid,
+      cid: options.cid,
+      page: options.page,
+      language,
+      sourceHash,
+      index,
+      startSeconds: row.startSeconds,
+      endSeconds: row.endSeconds,
+      text: row.text,
+    }),
+    bvid: options.bvid,
+    cid: options.cid,
+    page: options.page,
+    startSeconds: row.startSeconds,
+    endSeconds: row.endSeconds,
+    text: row.text,
+    language,
+    source: 'bilibili_subtitle' as const,
+    sourceType: options.sourceType,
+    sourceHash,
+    stale: false,
+    fetchedAt: options.fetchedAt,
+    updatedAt: options.fetchedAt,
+  }));
+
+  return {
+    sourceRecord: sourceRecord({
+      ...base,
+      sourceHash,
+      status: 'cached',
+      segmentCount: segments.length,
+      coverageStartSeconds: segments[0]?.startSeconds ?? null,
+      coverageEndSeconds: segments.reduce(
+        (max, segment) => Math.max(max, segment.endSeconds),
+        0,
+      ),
+      reason: 'transcript_segments_cached',
+      message: `已缓存字幕正文证据 ${segments.length} 段${language ? `（${language}）` : ''}；本版本仅作为本地证据，不会默认发送给 AI 或生成完整视频总结。`,
+      warnings,
+    }),
+    segments,
+  };
+}
+
+export function planTranscriptEvidenceUpsert(
+  existingSources: CurrentVideoTranscriptSourceRecord[],
+  existingSegments: CurrentVideoTranscriptSegment[],
+  evidence: CurrentVideoTranscriptEvidenceWrite,
+): TranscriptEvidenceUpsertPlan {
+  const source = evidence.sourceRecord;
+  const sameIdentity = (segment: CurrentVideoTranscriptSegment) =>
+    segment.bvid === source.bvid
+    && segment.cid === source.cid
+    && segment.page === source.page
+    && languageKey(segment.language) === languageKey(source.language);
+  const existingSource = existingSources.find(item => item.identityKey === source.identityKey);
+  const existingSegmentsById = new Map(existingSegments.map(segment => [segment.segmentId, segment]));
+  const staleSegments = existingSegments
+    .filter(segment =>
+      sameIdentity(segment)
+      && !segment.stale
+      && source.sourceHash !== null
+      && segment.sourceHash !== source.sourceHash,
+    )
+    .map(segment => ({
+      ...segment,
+      stale: true,
+      updatedAt: source.updatedAt,
+    }));
+  const nextSegments = evidence.segments.map(segment => ({
+    ...segment,
+    id: existingSegmentsById.get(segment.segmentId)?.id,
+    stale: false,
+  }));
+  const sourceToPut = {
+    ...source,
+    id: existingSource?.id,
+    stale: false,
+  };
+  const mergedSources = [
+    ...existingSources.filter(item => item.identityKey !== source.identityKey),
+    sourceToPut,
+  ];
+  const touchedSegmentIds = new Set([
+    ...staleSegments.map(segment => segment.segmentId),
+    ...nextSegments.map(segment => segment.segmentId),
+  ]);
+  const mergedSegments = [
+    ...existingSegments.filter(segment => !touchedSegmentIds.has(segment.segmentId)),
+    ...staleSegments,
+    ...nextSegments,
+  ];
+
+  return {
+    sourcesToPut: [sourceToPut],
+    segmentsToPut: [...staleSegments, ...nextSegments],
+    state: buildTranscriptEvidenceStateFromCache(
+      {
+        bvid: source.bvid,
+        cid: source.cid,
+        page: source.page,
+        language: source.language,
+      },
+      mergedSources,
+      mergedSegments,
+      source.updatedAt,
+    ),
+  };
+}
+
+export function buildTranscriptEvidenceStateFromCache(
+  identity: CurrentVideoTranscriptIdentity,
+  sources: CurrentVideoTranscriptSourceRecord[],
+  segments: CurrentVideoTranscriptSegment[],
+  now = Date.now(),
+): CurrentVideoTranscriptEvidenceState {
+  const exactSources = sources
+    .filter(sourceMatchesIdentity(identity))
+    .sort((a, b) => b.updatedAt - a.updatedAt);
+  const activeSource = exactSources.find(source => !source.stale);
+
+  if (activeSource) {
+    const exactSegments = segments.filter(segment =>
+      segment.bvid === activeSource.bvid
+      && segment.cid === activeSource.cid
+      && segment.page === activeSource.page
+      && languageKey(segment.language) === languageKey(activeSource.language),
+    );
+    const activeSegments = activeSource.sourceHash
+      ? exactSegments.filter(segment => !segment.stale && segment.sourceHash === activeSource.sourceHash)
+      : [];
+    const staleSegmentCount = exactSegments.filter(segment => segment.stale).length;
+    const warnings = new Set(activeSource.warnings);
+
+    if (activeSource.status === 'cached' && activeSegments.length !== activeSource.segmentCount) {
+      warnings.add('transcript_cache_segment_count_mismatch');
+    }
+
+    return {
+      status: activeSource.status,
+      active: activeSource.status === 'cached' && activeSegments.length > 0,
+      checkedAt: now,
+      bvid: activeSource.bvid,
+      cid: activeSource.cid,
+      page: activeSource.page,
+      language: activeSource.language,
+      source: activeSource.source,
+      sourceType: activeSource.sourceType,
+      sourceHash: activeSource.sourceHash,
+      segmentCount: activeSource.status === 'cached'
+        ? activeSegments.length
+        : activeSource.segmentCount,
+      staleSegmentCount,
+      coverageStartSeconds: activeSource.coverageStartSeconds,
+      coverageEndSeconds: activeSource.coverageEndSeconds,
+      fetchedAt: activeSource.fetchedAt,
+      updatedAt: activeSource.updatedAt,
+      reason: activeSource.reason,
+      message: activeSource.message,
+      warnings: Array.from(warnings),
+    };
+  }
+
+  const sameVideoSources = sources.filter(source => source.bvid === identity.bvid);
+  const samePartSources = sameVideoSources.filter(source =>
+    source.cid === identity.cid && source.page === identity.page,
+  );
+
+  if (identity.language && samePartSources.length > 0) {
+    return buildCurrentVideoTranscriptEvidenceState({
+      status: 'language_mismatch',
+      target: identity,
+      now,
+      reason: 'language_not_cached',
+      message: '本地 transcript 证据没有匹配当前请求的字幕语言；不会把其他语言当作 active 证据。',
+      warnings: ['transcript_language_mismatch'],
+    });
+  }
+
+  if (sameVideoSources.length > 0) {
+    const staleSegmentCount = segments.filter(segment => segment.bvid === identity.bvid).length;
+    return buildCurrentVideoTranscriptEvidenceState({
+      status: 'stale',
+      target: identity,
+      now,
+      staleSegmentCount,
+      reason: 'current_video_identity_changed',
+      message: '本地 transcript 证据与当前 CID、分 P 或语言不匹配；不会作为当前视频 active 证据。',
+      warnings: ['transcript_cache_stale'],
+    });
+  }
+
+  return buildCurrentVideoTranscriptEvidenceState({
+    status: 'missing',
+    target: identity,
+    now,
+    reason: 'transcript_not_cached',
+    message: '尚未缓存当前视频的字幕正文证据；当前仍使用元数据/简介 fallback。',
+    warnings: ['transcript_not_cached'],
+  });
+}
+
+export function buildCurrentVideoTranscriptEvidenceState(input: {
+  status: CurrentVideoTranscriptEvidenceStatus;
+  target: {
+    bvid: string | null;
+    cid: number | null;
+    page: number | null;
+    language?: string | null;
+  };
+  now: number;
+  sourceType?: CurrentVideoSubtitleSourceType;
+  sourceHash?: string | null;
+  segmentCount?: number;
+  staleSegmentCount?: number;
+  coverageStartSeconds?: number | null;
+  coverageEndSeconds?: number | null;
+  fetchedAt?: number | null;
+  updatedAt?: number | null;
+  reason: string;
+  message: string;
+  warnings: string[];
+}): CurrentVideoTranscriptEvidenceState {
+  return {
+    status: input.status,
+    active: input.status === 'cached' && (input.segmentCount ?? 0) > 0,
+    checkedAt: input.now,
+    bvid: input.target.bvid,
+    cid: input.target.cid,
+    page: input.target.page,
+    language: normalizeNullableText(input.target.language),
+    source: input.status === 'cached' ? 'bilibili_subtitle' : null,
+    sourceType: input.sourceType ?? 'none',
+    sourceHash: input.sourceHash ?? null,
+    segmentCount: input.segmentCount ?? 0,
+    staleSegmentCount: input.staleSegmentCount ?? 0,
+    coverageStartSeconds: input.coverageStartSeconds ?? null,
+    coverageEndSeconds: input.coverageEndSeconds ?? null,
+    fetchedAt: input.fetchedAt ?? null,
+    updatedAt: input.updatedAt ?? null,
+    reason: input.reason,
+    message: input.message,
+    warnings: input.warnings,
+  };
+}
+
+export function withTranscriptEvidenceState(
+  context: CurrentVideoContext,
+  transcriptEvidence: CurrentVideoTranscriptEvidenceState,
+): CurrentVideoContext {
+  const warnings = new Set(context.warnings);
+  if (transcriptEvidence.active) {
+    warnings.delete('transcript_text_not_cached');
+    warnings.add('transcript_evidence_cached');
+    warnings.add('transcript_summary_not_generated');
+  } else if (transcriptEvidence.status !== 'missing') {
+    warnings.add(`transcript_evidence_${transcriptEvidence.status}`);
+  }
+
+  return {
+    ...context,
+    transcriptEvidence,
+    warnings: Array.from(warnings),
+  };
+}
+
+export function buildTranscriptIdentityKey(identity: CurrentVideoTranscriptIdentity): string {
+  return [
+    identity.bvid,
+    identity.cid,
+    identity.page,
+    languageKey(identity.language ?? null),
+  ].join(':');
+}
+
+interface NormalizedSegmentRow {
+  index: number;
+  startSeconds: number;
+  endSeconds: number;
+  text: string;
+}
+
+function sourceRecord(input: Omit<CurrentVideoTranscriptSourceRecord, 'identityKey' | 'stale'>): CurrentVideoTranscriptSourceRecord {
+  return {
+    ...input,
+    identityKey: buildTranscriptIdentityKey(input),
+    stale: false,
+  };
+}
+
+function normalizeSegmentRow(row: unknown, index: number): NormalizedSegmentRow | null {
+  const record = asRecord(row);
+  if (!record) return null;
+
+  const startSeconds = normalizeTimestamp(
+    record.from ?? record.start ?? record.start_time ?? record.startSeconds,
+  );
+  const endSeconds = normalizeTimestamp(
+    record.to ?? record.end ?? record.end_time ?? record.endSeconds,
+  );
+  const text = normalizeNullableText(
+    record.content ?? record.text ?? record.subtitle ?? record.line,
+  );
+
+  if (startSeconds === null || endSeconds === null || endSeconds <= startSeconds || !text) {
+    return null;
+  }
+
+  return {
+    index,
+    startSeconds,
+    endSeconds,
+    text,
+  };
+}
+
+function hashTranscriptSource(input: {
+  bvid: string;
+  cid: number;
+  page: number;
+  language: string | null;
+  sourceType: CurrentVideoSubtitleSourceType;
+  rows: NormalizedSegmentRow[];
+}): string {
+  return hashText([
+    input.bvid,
+    String(input.cid),
+    String(input.page),
+    input.language ?? '',
+    input.sourceType,
+    ...input.rows.map(row => `${row.startSeconds}:${row.endSeconds}:${row.text}`),
+  ].join('\n'));
+}
+
+function transcriptSegmentId(input: {
+  bvid: string;
+  cid: number;
+  page: number;
+  language: string | null;
+  sourceHash: string;
+  index: number;
+  startSeconds: number;
+  endSeconds: number;
+  text: string;
+}): string {
+  return [
+    'transcript',
+    input.bvid,
+    input.cid,
+    input.page,
+    languageKey(input.language),
+    input.sourceHash,
+    input.index,
+    Math.round(input.startSeconds * 1000),
+    Math.round(input.endSeconds * 1000),
+    hashText(input.text).slice(0, 8),
+  ].join(':');
+}
+
+function sourceMatchesIdentity(identity: CurrentVideoTranscriptIdentity) {
+  return (source: CurrentVideoTranscriptSourceRecord) =>
+    source.bvid === identity.bvid
+    && source.cid === identity.cid
+    && source.page === identity.page
+    && (!identity.language || languageKey(source.language) === languageKey(identity.language));
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function normalizeNullableText(value: unknown): string | null {
+  if (typeof value !== 'string' && typeof value !== 'number') return null;
+  const text = String(value).replace(/\s+/g, ' ').trim();
+  return text || null;
+}
+
+function normalizeTimestamp(value: unknown): number | null {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) return null;
+  return Math.round(numeric * 1000) / 1000;
+}
+
+function languageKey(value: string | null | undefined): string {
+  return (value ?? 'unknown').trim().toLowerCase() || 'unknown';
+}
+
+function hashText(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}

--- a/src/shared/current-video-transcript-cache.ts
+++ b/src/shared/current-video-transcript-cache.ts
@@ -71,7 +71,7 @@ export function normalizeBilibiliTranscriptEvidence(
         coverageStartSeconds: null,
         coverageEndSeconds: null,
         reason: 'subtitle_body_not_array',
-        message: '字幕正文返回结构异常，未写入可引用 transcript 片段；当前仍使用元数据/简介 fallback。',
+        message: '字幕正文返回结构异常，未写入可引用字幕片段；当前仍使用元数据和简介作为本地证据结果。',
         warnings: ['transcript_malformed'],
       }),
       segments: [],
@@ -103,7 +103,7 @@ export function normalizeBilibiliTranscriptEvidence(
         coverageStartSeconds: null,
         coverageEndSeconds: null,
         reason: 'subtitle_body_empty',
-        message: '字幕 track 可读取，但没有返回正文片段；当前仍使用元数据/简介 fallback。',
+        message: '字幕轨道可读取，但没有返回正文片段；当前仍使用元数据和简介作为本地证据结果。',
         warnings: ['transcript_empty'],
       }),
       segments: [],
@@ -120,7 +120,7 @@ export function normalizeBilibiliTranscriptEvidence(
         coverageStartSeconds: null,
         coverageEndSeconds: null,
         reason: 'subtitle_segments_unusable',
-        message: '字幕正文片段缺少有效时间轴或文本，未作为 transcript 证据缓存。',
+        message: '字幕正文片段缺少有效时间轴或文本，未作为字幕正文证据缓存。',
         warnings: ['transcript_malformed'],
       }),
       segments: [],
@@ -306,7 +306,7 @@ export function buildTranscriptEvidenceStateFromCache(
       target: identity,
       now,
       reason: 'language_not_cached',
-      message: '本地 transcript 证据没有匹配当前请求的字幕语言；不会把其他语言当作 active 证据。',
+      message: '本地字幕正文证据没有匹配当前请求的字幕语言；不会把其他语言当作当前有效证据。',
       warnings: ['transcript_language_mismatch'],
     });
   }
@@ -319,7 +319,7 @@ export function buildTranscriptEvidenceStateFromCache(
       now,
       staleSegmentCount,
       reason: 'current_video_identity_changed',
-      message: '本地 transcript 证据与当前 CID、分 P 或语言不匹配；不会作为当前视频 active 证据。',
+      message: '本地字幕正文证据与当前 CID、分 P 或语言不匹配；不会作为当前视频的当前有效证据。',
       warnings: ['transcript_cache_stale'],
     });
   }
@@ -329,7 +329,7 @@ export function buildTranscriptEvidenceStateFromCache(
     target: identity,
     now,
     reason: 'transcript_not_cached',
-    message: '尚未缓存当前视频的字幕正文证据；当前仍使用元数据/简介 fallback。',
+    message: '尚未缓存当前视频的字幕正文证据；当前仍使用元数据和简介作为本地证据结果。',
     warnings: ['transcript_not_cached'],
   });
 }

--- a/src/shared/types/current-video-context.ts
+++ b/src/shared/types/current-video-context.ts
@@ -1,3 +1,5 @@
+import type { CurrentVideoTranscriptEvidenceState } from './current-video-transcript';
+
 export type CurrentVideoAvailability = 'available' | 'unavailable' | 'unknown';
 export type CurrentVideoSubtitleSourceStatus =
   | 'available'
@@ -90,6 +92,7 @@ export interface CurrentVideoContext {
   };
   sources: CurrentVideoSourceAvailability;
   subtitleProbe?: CurrentVideoSubtitleSourceState | null;
+  transcriptEvidence?: CurrentVideoTranscriptEvidenceState | null;
   warnings: string[];
 }
 

--- a/src/shared/types/current-video-transcript.ts
+++ b/src/shared/types/current-video-transcript.ts
@@ -1,0 +1,91 @@
+import type { CurrentVideoSubtitleSourceType } from './current-video-context';
+
+export type CurrentVideoTranscriptEvidenceStatus =
+  | 'cached'
+  | 'missing'
+  | 'stale'
+  | 'empty'
+  | 'malformed'
+  | 'track_unavailable'
+  | 'language_mismatch'
+  | 'login_required'
+  | 'endpoint_failed'
+  | 'unsupported';
+
+export type CurrentVideoTranscriptSource = 'bilibili_subtitle';
+
+export interface CurrentVideoTranscriptIdentity {
+  bvid: string;
+  cid: number;
+  page: number;
+  language?: string | null;
+}
+
+export interface CurrentVideoTranscriptSegment {
+  id?: number;
+  segmentId: string;
+  bvid: string;
+  cid: number;
+  page: number;
+  startSeconds: number;
+  endSeconds: number;
+  text: string;
+  language: string | null;
+  source: CurrentVideoTranscriptSource;
+  sourceType: CurrentVideoSubtitleSourceType;
+  sourceHash: string;
+  stale: boolean;
+  fetchedAt: number;
+  updatedAt: number;
+}
+
+export interface CurrentVideoTranscriptSourceRecord {
+  id?: number;
+  identityKey: string;
+  bvid: string;
+  cid: number;
+  page: number;
+  language: string | null;
+  source: CurrentVideoTranscriptSource;
+  sourceType: CurrentVideoSubtitleSourceType;
+  sourceHash: string | null;
+  trackId: string | null;
+  trackUrlHost: string | null;
+  segmentCount: number;
+  coverageStartSeconds: number | null;
+  coverageEndSeconds: number | null;
+  status: CurrentVideoTranscriptEvidenceStatus;
+  stale: boolean;
+  fetchedAt: number;
+  updatedAt: number;
+  reason: string;
+  message: string;
+  warnings: string[];
+}
+
+export interface CurrentVideoTranscriptEvidenceState {
+  status: CurrentVideoTranscriptEvidenceStatus;
+  active: boolean;
+  checkedAt: number;
+  bvid: string | null;
+  cid: number | null;
+  page: number | null;
+  language: string | null;
+  source: CurrentVideoTranscriptSource | null;
+  sourceType: CurrentVideoSubtitleSourceType;
+  sourceHash: string | null;
+  segmentCount: number;
+  staleSegmentCount: number;
+  coverageStartSeconds: number | null;
+  coverageEndSeconds: number | null;
+  fetchedAt: number | null;
+  updatedAt: number | null;
+  reason: string;
+  message: string;
+  warnings: string[];
+}
+
+export interface CurrentVideoTranscriptEvidenceWrite {
+  sourceRecord: CurrentVideoTranscriptSourceRecord;
+  segments: CurrentVideoTranscriptSegment[];
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,6 +1,7 @@
 export * from './watch-event';
 export * from './video-info';
 export * from './current-video-context';
+export * from './current-video-transcript';
 export * from './analytics';
 export * from './messages';
 export * from './config';

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -28,6 +28,7 @@ import type {
   SmartIndexResult,
 } from './favorite';
 import type { CurrentVideoContextResult, CurrentVideoSubtitleSourceState } from './current-video-context';
+import type { CurrentVideoTranscriptEvidenceState } from './current-video-transcript';
 import type { CurrentVideoSummaryResult } from './current-video-summary';
 import type { VideoKnowledgeJumpResponse, VideoKnowledgeResult } from './video-knowledge';
 import type { HistoryTailProbeReport } from './history-tail-probe';
@@ -52,6 +53,7 @@ export type RequestAction =
   | 'PROBE_HISTORY_TAIL'
   | 'GET_CURRENT_VIDEO_CONTEXT'
   | 'PROBE_CURRENT_VIDEO_SUBTITLE_SOURCE'
+  | 'GET_CURRENT_VIDEO_TRANSCRIPT_EVIDENCE'
   | 'GET_CURRENT_VIDEO_SUMMARY'
   | 'GET_VIDEO_KNOWLEDGE'
   | 'REQUEST_VIDEO_KNOWLEDGE_JUMP'
@@ -172,6 +174,7 @@ export type SmartFavoriteQaMessageResponse = BiliVizResponse<SmartFavoriteQaResp
 export type SmartFavoritePathResponse = BiliVizResponse<SmartFavoriteResult[]>;
 export type CurrentVideoContextResponse = BiliVizResponse<CurrentVideoContextResult>;
 export type CurrentVideoSubtitleSourceResponse = BiliVizResponse<CurrentVideoSubtitleSourceState>;
+export type CurrentVideoTranscriptEvidenceResponse = BiliVizResponse<CurrentVideoTranscriptEvidenceState>;
 export type CurrentVideoSummaryResponse = BiliVizResponse<CurrentVideoSummaryResult>;
 export type VideoKnowledgeResponse = BiliVizResponse<VideoKnowledgeResult>;
 export type VideoKnowledgeJumpMessageResponse = BiliVizResponse<VideoKnowledgeJumpResponse>;

--- a/src/shared/types/video-knowledge.ts
+++ b/src/shared/types/video-knowledge.ts
@@ -1,3 +1,5 @@
+import type { CurrentVideoTranscriptEvidenceState } from './current-video-transcript';
+
 export type VideoKnowledgeSource =
   | 'metadata'
   | 'description'
@@ -64,6 +66,7 @@ export interface VideoKnowledgeSourceState {
   pages: boolean;
   chapters: boolean;
   transcript: boolean;
+  transcriptEvidence: boolean;
   contentText: boolean;
 }
 
@@ -72,6 +75,7 @@ export interface VideoKnowledgeResult {
   title: string;
   generatedAt: number;
   sourceState: VideoKnowledgeSourceState;
+  transcriptEvidence: CurrentVideoTranscriptEvidenceState | null;
   nodes: VideoKnowledgeNode[];
   warnings: string[];
   limitations: string[];

--- a/src/shared/video-knowledge.ts
+++ b/src/shared/video-knowledge.ts
@@ -199,9 +199,9 @@ function buildVideoKnowledgeWarnings(context: CurrentVideoContext): string[] {
 
 function buildVideoKnowledgeLimitations(context: CurrentVideoContext): string[] {
   const transcriptLimitation = context.transcriptEvidence?.active
-    ? '已缓存本地 transcript 证据，但当前 slice 仍不生成 transcript 节点、key nodes、模糊检索或完整视频总结。'
+    ? '已缓存本地字幕正文证据，但当前版本仍不生成字幕正文节点、关键节点、模糊检索或完整视频总结。'
     : context.sources.transcript === 'available'
-    ? '已探测到字幕来源，但当前版本只记录来源状态，尚未生成 transcript 节点或完整视频总结。'
+    ? '已探测到字幕来源，但当前版本只记录来源状态，尚未生成字幕正文节点或完整视频总结。'
     : context.sources.transcript === 'unknown'
       ? '字幕来源尚未完成探测；当前节点只基于元数据、简介、分 P 或章节。'
       : '没有可用字幕，因此元数据和简介节点不代表完整视频理解。';

--- a/src/shared/video-knowledge.ts
+++ b/src/shared/video-knowledge.ts
@@ -26,8 +26,10 @@ export function buildVideoKnowledgeResult(
         pages: false,
         chapters: false,
         transcript: false,
+        transcriptEvidence: false,
         contentText: false,
       },
+      transcriptEvidence: null,
       nodes: [],
       warnings: ['no_current_video_context'],
       limitations: ['请先打开一个 B 站视频页，再生成视频知识节点。'],
@@ -51,8 +53,10 @@ export function buildVideoKnowledgeResult(
       pages: context.sources.pages === 'available',
       chapters: context.sources.chapters === 'available',
       transcript: context.sources.transcript === 'available',
+      transcriptEvidence: context.transcriptEvidence?.active === true,
       contentText: false,
     },
+    transcriptEvidence: context.transcriptEvidence ?? null,
     nodes,
     warnings: buildVideoKnowledgeWarnings(context),
     limitations: buildVideoKnowledgeLimitations(context),
@@ -186,11 +190,17 @@ function buildVideoKnowledgeWarnings(context: CurrentVideoContext): string[] {
   } else {
     warnings.add('transcript_unavailable');
   }
+  if (context.transcriptEvidence?.active) {
+    warnings.add('transcript_evidence_cached');
+    warnings.add('transcript_evidence_not_used_for_nodes');
+  }
   return Array.from(warnings);
 }
 
 function buildVideoKnowledgeLimitations(context: CurrentVideoContext): string[] {
-  const transcriptLimitation = context.sources.transcript === 'available'
+  const transcriptLimitation = context.transcriptEvidence?.active
+    ? '已缓存本地 transcript 证据，但当前 slice 仍不生成 transcript 节点、key nodes、模糊检索或完整视频总结。'
+    : context.sources.transcript === 'available'
     ? '已探测到字幕来源，但当前版本只记录来源状态，尚未生成 transcript 节点或完整视频总结。'
     : context.sources.transcript === 'unknown'
       ? '字幕来源尚未完成探测；当前节点只基于元数据、简介、分 P 或章节。'

--- a/tests/current-video-summary.test.ts
+++ b/tests/current-video-summary.test.ts
@@ -82,6 +82,46 @@ test('keeps available subtitle source state separate from transcript summary', (
   assert.doesNotMatch(JSON.stringify(payload), /subtitleProbe|track|aisubtitle|subtitle_url/i);
 });
 
+test('keeps cached transcript evidence out of current video summary AI payload', () => {
+  const context = videoContext({
+    descriptionText: 'This description is still the only text supplied to the summary payload.',
+    descriptionAvailable: true,
+  });
+  context.sources.transcript = 'available';
+  context.transcriptEvidence = {
+    status: 'cached',
+    active: true,
+    checkedAt: 2000,
+    bvid: context.bvid,
+    cid: context.cid,
+    page: context.currentPart.page,
+    language: 'zh-CN',
+    source: 'bilibili_subtitle',
+    sourceType: 'bilibili_player_wbi_v2',
+    sourceHash: 'hash123',
+    segmentCount: 2,
+    staleSegmentCount: 0,
+    coverageStartSeconds: 0,
+    coverageEndSeconds: 8,
+    fetchedAt: 2000,
+    updatedAt: 2000,
+    reason: 'transcript_segments_cached',
+    message: 'cached transcript evidence only',
+    warnings: [],
+  };
+
+  const summary = buildLocalCurrentVideoSummary(context);
+  const payload = buildCurrentVideoSummaryAiPayload(context);
+  const rawPayload = JSON.stringify(payload);
+
+  assert.equal(summary.sourceTier, 'description_summary');
+  assert.equal(payload.availableSources.transcript, 'available');
+  assert.equal(payload.availableSources.contentText, 'unavailable');
+  assert.ok(summary.evidence.some(item => item.label === 'Transcript evidence cache'));
+  assert.ok(summary.limitations.some(item => item.includes('当前摘要 slice')));
+  assert.doesNotMatch(rawPayload, /sourceHash|segmentId|cached transcript evidence|SECRET TRANSCRIPT|watchHistory|Cookie|Key\.txt/i);
+});
+
 test('marks AI disabled fallback without changing source tier', () => {
   const summary = buildLocalCurrentVideoSummary(videoContext({}), {
     aiStatus: 'disabled',

--- a/tests/current-video-summary.test.ts
+++ b/tests/current-video-summary.test.ts
@@ -66,7 +66,7 @@ test('keeps available subtitle source state separate from transcript summary', (
     languages: ['zh-CN'],
     tracks: [],
     reason: 'subtitle_tracks_available',
-    message: '已探测到 1 条字幕 track；本版本只记录来源状态，不缓存字幕正文，也不会据此生成完整视频总结。',
+    message: '已探测到 1 条字幕轨道；本版本只记录来源状态，不缓存字幕正文，也不会据此生成完整视频总结。',
     warnings: ['transcript_source_available', 'transcript_text_not_cached'],
   };
 
@@ -106,7 +106,7 @@ test('keeps cached transcript evidence out of current video summary AI payload',
     fetchedAt: 2000,
     updatedAt: 2000,
     reason: 'transcript_segments_cached',
-    message: 'cached transcript evidence only',
+    message: '已缓存字幕正文证据，仅作为本地证据状态展示。',
     warnings: [],
   };
 
@@ -117,9 +117,9 @@ test('keeps cached transcript evidence out of current video summary AI payload',
   assert.equal(summary.sourceTier, 'description_summary');
   assert.equal(payload.availableSources.transcript, 'available');
   assert.equal(payload.availableSources.contentText, 'unavailable');
-  assert.ok(summary.evidence.some(item => item.label === 'Transcript evidence cache'));
-  assert.ok(summary.limitations.some(item => item.includes('当前摘要 slice')));
-  assert.doesNotMatch(rawPayload, /sourceHash|segmentId|cached transcript evidence|SECRET TRANSCRIPT|watchHistory|Cookie|Key\.txt/i);
+  assert.ok(summary.evidence.some(item => item.label === '字幕正文证据缓存'));
+  assert.ok(summary.limitations.some(item => item.includes('当前版本')));
+  assert.doesNotMatch(rawPayload, /sourceHash|segmentId|已缓存字幕正文证据|SECRET TRANSCRIPT|watchHistory|Cookie|Key\.txt/i);
 });
 
 test('marks AI disabled fallback without changing source tier', () => {

--- a/tests/current-video-transcript-cache.test.ts
+++ b/tests/current-video-transcript-cache.test.ts
@@ -1,0 +1,336 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { cacheCurrentVideoTranscriptEvidence } from '../src/background/current-video-transcript-cache.ts';
+import {
+  buildTranscriptEvidenceStateFromCache,
+  normalizeBilibiliTranscriptEvidence,
+  planTranscriptEvidenceUpsert,
+  withTranscriptEvidenceState,
+} from '../src/shared/current-video-transcript-cache.ts';
+import {
+  assertAssistantPayloadAudit,
+  auditAssistantPayload,
+  currentVideoSummaryPayloadContract,
+} from '../src/shared/assistant-payload-audit.ts';
+import { buildCurrentVideoSummaryAiPayload } from '../src/shared/current-video-summary.ts';
+import type { CurrentVideoContext } from '../src/shared/types/current-video-context.ts';
+import type {
+  CurrentVideoTranscriptEvidenceState,
+  CurrentVideoTranscriptEvidenceWrite,
+  CurrentVideoTranscriptSegment,
+  CurrentVideoTranscriptSourceRecord,
+} from '../src/shared/types/current-video-transcript.ts';
+
+test('normalizes Bilibili subtitle rows into stable transcript segments', () => {
+  const evidence = normalizeBilibiliTranscriptEvidence(
+    {
+      body: [
+        { from: 0, to: 1.25, content: '  hello transcript  ' },
+        { from: 1.25, to: 3, content: 'second line' },
+        { from: 4, to: 3, content: 'bad time' },
+        { from: 5, to: 6, content: '   ' },
+      ],
+    },
+    baseNormalizeOptions(),
+  );
+
+  assert.equal(evidence.sourceRecord.status, 'cached');
+  assert.equal(evidence.sourceRecord.segmentCount, 2);
+  assert.equal(evidence.sourceRecord.coverageStartSeconds, 0);
+  assert.equal(evidence.sourceRecord.coverageEndSeconds, 3);
+  assert.deepEqual(evidence.sourceRecord.warnings, ['transcript_segments_filtered']);
+  assert.equal(evidence.segments.length, 2);
+  assert.equal(evidence.segments[0].text, 'hello transcript');
+  assert.equal(evidence.segments[0].bvid, 'BV1Transcript00');
+  assert.equal(evidence.segments[0].cid, 101);
+  assert.equal(evidence.segments[0].page, 1);
+  assert.equal(evidence.segments[0].language, 'zh-CN');
+  assert.equal(evidence.segments[0].source, 'bilibili_subtitle');
+  assert.equal(evidence.segments[0].sourceHash, evidence.sourceRecord.sourceHash);
+  assert.match(evidence.segments[0].segmentId, /^transcript:BV1Transcript00:101:1:zh-cn:/);
+});
+
+test('upserts and reads transcript evidence without destructive unrelated changes', () => {
+  const store = memoryStore();
+  const evidence = normalizeBilibiliTranscriptEvidence(
+    { body: [{ from: 0, to: 2, content: 'cached line' }] },
+    baseNormalizeOptions(),
+  );
+  const state = store.upsert(evidence);
+
+  assert.equal(state.status, 'cached');
+  assert.equal(state.active, true);
+  assert.equal(state.segmentCount, 1);
+  assert.equal(store.sources.length, 1);
+  assert.equal(store.segments.length, 1);
+
+  const read = buildTranscriptEvidenceStateFromCache(
+    { bvid: 'BV1Transcript00', cid: 101, page: 1 },
+    store.sources,
+    store.segments,
+    2000,
+  );
+  assert.equal(read.status, 'cached');
+  assert.equal(read.active, true);
+  assert.equal(read.segmentCount, 1);
+});
+
+test('marks old same-identity segments stale when source hash changes', () => {
+  const store = memoryStore();
+  const first = normalizeBilibiliTranscriptEvidence(
+    { body: [{ from: 0, to: 2, content: 'first version' }] },
+    baseNormalizeOptions({ fetchedAt: 1000 }),
+  );
+  const second = normalizeBilibiliTranscriptEvidence(
+    { body: [{ from: 0, to: 2, content: 'second version' }] },
+    baseNormalizeOptions({ fetchedAt: 2000 }),
+  );
+
+  store.upsert(first);
+  const state = store.upsert(second);
+
+  assert.equal(state.status, 'cached');
+  assert.equal(state.segmentCount, 1);
+  assert.equal(state.staleSegmentCount, 1);
+  assert.equal(store.segments.filter(segment => segment.stale).length, 1);
+  assert.equal(store.segments.filter(segment => !segment.stale).length, 1);
+  assert.notEqual(first.sourceRecord.sourceHash, second.sourceRecord.sourceHash);
+});
+
+test('keeps same BVID but different CID/page from becoming active evidence', () => {
+  const store = memoryStore();
+  store.upsert(normalizeBilibiliTranscriptEvidence(
+    { body: [{ from: 0, to: 2, content: 'page one' }] },
+    baseNormalizeOptions({ cid: 101, page: 1 }),
+  ));
+
+  const wrongPart = buildTranscriptEvidenceStateFromCache(
+    { bvid: 'BV1Transcript00', cid: 202, page: 2 },
+    store.sources,
+    store.segments,
+    3000,
+  );
+  assert.equal(wrongPart.status, 'stale');
+  assert.equal(wrongPart.active, false);
+
+  store.upsert(normalizeBilibiliTranscriptEvidence(
+    { body: [{ from: 0, to: 2, content: 'page two' }] },
+    baseNormalizeOptions({ cid: 202, page: 2 }),
+  ));
+  const pageOne = buildTranscriptEvidenceStateFromCache(
+    { bvid: 'BV1Transcript00', cid: 101, page: 1 },
+    store.sources,
+    store.segments,
+    4000,
+  );
+  const pageTwo = buildTranscriptEvidenceStateFromCache(
+    { bvid: 'BV1Transcript00', cid: 202, page: 2 },
+    store.sources,
+    store.segments,
+    4000,
+  );
+  assert.equal(pageOne.status, 'cached');
+  assert.equal(pageTwo.status, 'cached');
+  assert.equal(pageOne.segmentCount, 1);
+  assert.equal(pageTwo.segmentCount, 1);
+});
+
+test('records empty and malformed transcript states without active segments', () => {
+  const empty = normalizeBilibiliTranscriptEvidence(
+    { body: [] },
+    baseNormalizeOptions(),
+  );
+  const malformed = normalizeBilibiliTranscriptEvidence(
+    { body: [{ from: 'bad', to: 3, content: 'no start' }] },
+    baseNormalizeOptions({ fetchedAt: 2000 }),
+  );
+
+  assert.equal(empty.sourceRecord.status, 'empty');
+  assert.equal(empty.segments.length, 0);
+  assert.equal(malformed.sourceRecord.status, 'malformed');
+  assert.equal(malformed.segments.length, 0);
+
+  const store = memoryStore();
+  const emptyState = store.upsert(empty);
+  assert.equal(emptyState.status, 'empty');
+  assert.equal(emptyState.active, false);
+});
+
+test('background cache fetch keeps raw subtitle URL internal and reports language/track diagnostics', async () => {
+  const store = memoryStore();
+  let fetchedUrl = '';
+  const state = await cacheCurrentVideoTranscriptEvidence(videoContext(), {
+    now: 5000,
+    fetchPlayerInfo: async () => ({
+      subtitle: {
+        subtitles: [
+          {
+            id: 7,
+            lan: 'zh-CN',
+            lan_doc: 'Chinese',
+            subtitle_url: '//aisubtitle.hdslb.com/bfs/ai_subtitle/private-track.json?token=secret',
+          },
+        ],
+      },
+    }),
+    fetchSubtitleJson: async (url) => {
+      fetchedUrl = url;
+      return { body: [{ from: 0, to: 2, content: 'background fetched text' }] };
+    },
+    upsertEvidence: async evidence => store.upsert(evidence),
+  });
+
+  assert.equal(state.status, 'cached');
+  assert.equal(state.language, 'zh-CN');
+  assert.equal(state.segmentCount, 1);
+  assert.match(fetchedUrl, /^https:\/\/aisubtitle\.hdslb\.com\//);
+  assert.doesNotMatch(JSON.stringify(state), /private-track|subtitle_url|token=secret|SESSDATA|Key\.txt/i);
+});
+
+test('background cache reports language mismatch and unavailable track states', async () => {
+  const mismatch = await cacheCurrentVideoTranscriptEvidence(videoContext(), {
+    now: 6000,
+    requestedLanguage: 'en-US',
+    fetchPlayerInfo: async () => ({
+      subtitle: {
+        subtitles: [
+          {
+            lan: 'zh-CN',
+            subtitle_url: '//aisubtitle.hdslb.com/bfs/ai_subtitle/zh.json',
+          },
+        ],
+      },
+    }),
+  });
+  assert.equal(mismatch.status, 'language_mismatch');
+  assert.equal(mismatch.active, false);
+
+  const unavailable = await cacheCurrentVideoTranscriptEvidence(videoContext(), {
+    now: 7000,
+    fetchPlayerInfo: async () => ({ subtitle: { subtitles: [{ lan: 'zh-CN' }] } }),
+  });
+  assert.equal(unavailable.status, 'track_unavailable');
+  assert.equal(unavailable.active, false);
+});
+
+test('privacy audit keeps cached transcript text out of current video AI payload', () => {
+  const store = memoryStore();
+  const state = store.upsert(normalizeBilibiliTranscriptEvidence(
+    {
+      body: [
+        { from: 0, to: 2, content: 'SECRET TRANSCRIPT BODY SHOULD STAY LOCAL' },
+      ],
+    },
+    baseNormalizeOptions(),
+  ));
+  const context = withTranscriptEvidenceState(videoContext(), state);
+  context.sources.transcript = 'available';
+
+  const payload = buildCurrentVideoSummaryAiPayload(context);
+  const rawPayload = JSON.stringify(payload);
+  const audit = auditAssistantPayload(payload, currentVideoSummaryPayloadContract);
+
+  assert.equal(context.transcriptEvidence?.active, true);
+  assert.equal(payload.availableSources.transcript, 'available');
+  assert.equal(payload.availableSources.contentText, 'unavailable');
+  assert.equal(audit.passed, true, JSON.stringify(audit.violations));
+  assertAssistantPayloadAudit(payload, currentVideoSummaryPayloadContract);
+  assert.doesNotMatch(
+    rawPayload,
+    /SECRET TRANSCRIPT BODY|segmentId|sourceHash|watchHistory|favorites|following|feedback|Cookie|Key\.txt|Chrome\\User Data/i,
+  );
+});
+
+function baseNormalizeOptions(overrides: Partial<Parameters<typeof normalizeBilibiliTranscriptEvidence>[1]> = {}) {
+  return {
+    bvid: 'BV1Transcript00',
+    cid: 101,
+    page: 1,
+    language: 'zh-CN',
+    sourceType: 'bilibili_player_wbi_v2' as const,
+    trackId: '7',
+    trackUrlHost: 'aisubtitle.hdslb.com',
+    fetchedAt: 1000,
+    ...overrides,
+  };
+}
+
+function memoryStore() {
+  const sources: CurrentVideoTranscriptSourceRecord[] = [];
+  const segments: CurrentVideoTranscriptSegment[] = [];
+  return {
+    sources,
+    segments,
+    upsert(evidence: CurrentVideoTranscriptEvidenceWrite): CurrentVideoTranscriptEvidenceState {
+      const plan = planTranscriptEvidenceUpsert(sources, segments, evidence);
+      putSources(sources, plan.sourcesToPut);
+      putSegments(segments, plan.segmentsToPut);
+      return plan.state;
+    },
+  };
+}
+
+function putSources(
+  target: CurrentVideoTranscriptSourceRecord[],
+  values: CurrentVideoTranscriptSourceRecord[],
+): void {
+  for (const value of values) {
+    const index = target.findIndex(item => item.identityKey === value.identityKey);
+    if (index >= 0) {
+      target[index] = value;
+    } else {
+      target.push(value);
+    }
+  }
+}
+
+function putSegments(
+  target: CurrentVideoTranscriptSegment[],
+  values: CurrentVideoTranscriptSegment[],
+): void {
+  for (const value of values) {
+    const index = target.findIndex(item => item.segmentId === value.segmentId);
+    if (index >= 0) {
+      target[index] = value;
+    } else {
+      target.push(value);
+    }
+  }
+}
+
+function videoContext(): CurrentVideoContext {
+  return {
+    kind: 'video',
+    url: 'https://www.bilibili.com/video/BV1Transcript00?p=1',
+    collectedAt: 1000,
+    bvid: 'BV1Transcript00',
+    cid: 101,
+    title: 'Transcript cache video',
+    authorName: 'Cache UP',
+    authorMid: 42,
+    durationSeconds: 600,
+    currentPart: {
+      page: 1,
+      title: 'Main',
+      total: 1,
+    },
+    parts: [{ page: 1, cid: 101, title: 'Main', durationSeconds: 600 }],
+    chapters: [],
+    description: {
+      availability: 'available',
+      text: 'Visible description remains the summary fallback.',
+      length: 49,
+    },
+    sources: {
+      metadata: 'available',
+      description: 'available',
+      pages: 'available',
+      chapters: 'unknown',
+      transcript: 'unknown',
+      contentText: 'unavailable',
+    },
+    subtitleProbe: null,
+    transcriptEvidence: null,
+    warnings: ['transcript_probe_pending'],
+  };
+}

--- a/tests/video-knowledge.test.ts
+++ b/tests/video-knowledge.test.ts
@@ -61,7 +61,7 @@ test('exposes available subtitle source state without generating transcript node
     languages: ['zh-CN'],
     tracks: [],
     reason: 'subtitle_tracks_available',
-    message: '已探测到 1 条字幕 track；本版本只记录来源状态，不缓存字幕正文，也不会据此生成完整视频总结。',
+    message: '已探测到 1 条字幕轨道；本版本只记录来源状态，不缓存字幕正文，也不会据此生成完整视频总结。',
     warnings: ['transcript_source_available', 'transcript_text_not_cached'],
   };
 
@@ -73,7 +73,7 @@ test('exposes available subtitle source state without generating transcript node
   assert.equal(result.transcriptEvidence, null);
   assert.equal(result.nodes.some(node => node.source === 'transcript'), false);
   assert.ok(result.warnings.includes('transcript_nodes_not_generated'));
-  assert.ok(result.limitations.some(item => item.includes('尚未生成 transcript 节点')));
+  assert.ok(result.limitations.some(item => item.includes('尚未生成字幕正文节点')));
 });
 
 test('exposes cached transcript evidence state without generating transcript nodes', () => {
@@ -101,7 +101,7 @@ test('exposes cached transcript evidence state without generating transcript nod
     fetchedAt: 2000,
     updatedAt: 2000,
     reason: 'transcript_segments_cached',
-    message: 'cached transcript evidence only',
+    message: '已缓存字幕正文证据，仅作为本地证据状态展示。',
     warnings: [],
   };
 

--- a/tests/video-knowledge.test.ts
+++ b/tests/video-knowledge.test.ts
@@ -68,10 +68,51 @@ test('exposes available subtitle source state without generating transcript node
   const result = buildVideoKnowledgeResult(context, 1000);
 
   assert.equal(result.sourceState.transcript, true);
+  assert.equal(result.sourceState.transcriptEvidence, false);
   assert.equal(result.sourceState.contentText, false);
+  assert.equal(result.transcriptEvidence, null);
   assert.equal(result.nodes.some(node => node.source === 'transcript'), false);
   assert.ok(result.warnings.includes('transcript_nodes_not_generated'));
   assert.ok(result.limitations.some(item => item.includes('尚未生成 transcript 节点')));
+});
+
+test('exposes cached transcript evidence state without generating transcript nodes', () => {
+  const context = videoContext({
+    descriptionText: 'Description fallback remains visible.',
+    parts: [],
+    chapters: [],
+  });
+  context.sources.transcript = 'available';
+  context.transcriptEvidence = {
+    status: 'cached',
+    active: true,
+    checkedAt: 2000,
+    bvid: context.bvid,
+    cid: context.cid,
+    page: context.currentPart.page,
+    language: 'zh-CN',
+    source: 'bilibili_subtitle',
+    sourceType: 'bilibili_player_wbi_v2',
+    sourceHash: 'hash123',
+    segmentCount: 2,
+    staleSegmentCount: 0,
+    coverageStartSeconds: 0,
+    coverageEndSeconds: 9,
+    fetchedAt: 2000,
+    updatedAt: 2000,
+    reason: 'transcript_segments_cached',
+    message: 'cached transcript evidence only',
+    warnings: [],
+  };
+
+  const result = buildVideoKnowledgeResult(context, 2000);
+
+  assert.equal(result.sourceState.transcript, true);
+  assert.equal(result.sourceState.transcriptEvidence, true);
+  assert.equal(result.sourceState.contentText, false);
+  assert.equal(result.transcriptEvidence?.segmentCount, 2);
+  assert.equal(result.nodes.some(node => node.source === 'transcript'), false);
+  assert.ok(result.warnings.includes('transcript_evidence_not_used_for_nodes'));
 });
 
 test('marks pending subtitle probe as unknown source state', () => {


### PR DESCRIPTION
## Scope
- Adds current-video transcript evidence types, parser, source hashing, stale-state logic, and local IndexedDB tables for transcript source records and normalized segments.
- Adds a background `GET_CURRENT_VIDEO_TRANSCRIPT_EVIDENCE` action that re-requests Bilibili player subtitle metadata internally, fetches the selected subtitle JSON, normalizes timed rows, and upserts local evidence.
- Exposes a separate `transcriptEvidence` state on current-video context and video knowledge without changing transcript source availability into a summary/content-text signal.
- Adds a narrow `https://*.hdslb.com/*` host permission for Bilibili subtitle CDN JSON fetches.

## Root Cause / Product Judgment
#99 could determine whether subtitle sources exist, but it intentionally did not retain raw subtitle URLs or transcript body. #100 needs a local evidence cache so later #101/#102/#103 work can cite stable transcript segments without refetching or inventing timestamps.

This PR keeps the URL boundary: raw `subtitle_url` is used only inside the background fetch path, validated to Bilibili/hdslb hosts, and never returned to UI, Video Knowledge, or AI payloads. Cached evidence is stored as normalized segments plus source hash/diagnostics; summaries and knowledge nodes still fall back to metadata/description until later slices explicitly consume transcript evidence.

## Validation
- `npm ci`
- `npm run test:current-video-transcript`
- `node --test tests/current-video-subtitle-probe.test.ts`
- `npm run test:current-video-summary`
- `npm run test:video-knowledge`
- `node --test tests/current-video-context.test.ts`
- `node --test tests/current-video-context-resolver.test.ts`
- `npm run typecheck`
- `npm run build` (passes; Vite reports existing chunk-size and mixed static/dynamic import warnings)
- `git diff --check` and `git diff --check --cached` (cached check clean; unstaged check only showed Windows LF/CRLF normalization notices before commit)
- `rg -n 未消费|猜你喜欢 dashboard popup public src README.md tests` (no matches)

## Browser / Mock QA
- Mock QA is covered by `tests/current-video-transcript-cache.test.ts` for cached transcript, empty transcript, malformed rows, stale source hash, same BVID different CID/page, language mismatch, unavailable track URL, and AI payload privacy.
- No real Bilibili browser-profile/Cookie/key-file smoke was run; this PR does not read local Cookie/profile/key/login-state files.

## Blocker / Must-Fix / Follow-Up
- Blockers: none.
- Must-fix: none known.
- Follow-up: #101 should decide how to feed bounded transcript evidence into the summary pipeline; #102 can build key nodes from cached segments; #83/#103 can use sourceHash/segmentId for retrieval and stale checks without re-fetching.

## Privacy Boundary
- Does not read local key files, Cookie files, browser profiles, Bilibili login-state files, or `C:\Users\LittleNub\Desktop\Key.txt`.
- Does not upload full history, favorites, following, feedback, local DB content, raw subtitle URLs, or transcript segments to AI.
- Uses current extension runtime fetch with normal browser credentials only when the user/browser session already has access; no credential copying.
- Does not write back to Bilibili.

Closes #100