### PR TITLE
[codex] Generate transcript-grounded video knowledge nodes

### DIFF
--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -710,6 +710,7 @@ function VideoKnowledgePanel({
   onConfirm: (node: VideoKnowledgeNode) => void;
 }) {
   const nodes = knowledge?.nodes ?? [];
+  const transcriptNodeCount = nodes.filter(node => node.source === 'transcript').length;
   return (
     <div style={{
       marginTop: '8px',
@@ -720,7 +721,7 @@ function VideoKnowledgePanel({
     }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', gap: '8px', alignItems: 'center' }}>
         <span style={{ color: '#FFD6E2', fontSize: '10px', fontWeight: 700 }}>
-          视频知识节点 v0
+          视频知识节点
         </span>
         <button
           onClick={onRefresh}
@@ -738,7 +739,7 @@ function VideoKnowledgePanel({
         </button>
       </div>
       <div style={{ color: '#FFCF8A', fontSize: '10px', lineHeight: 1.45, marginTop: '6px' }}>
-        当前没有字幕。节点只使用元数据、简介、分 P 或章节；不会生成推测时间戳。
+        {videoKnowledgeNotice(knowledge, transcriptNodeCount)}
       </div>
       {nodes.length === 0 ? (
         <div style={{ color: '#A0A0B0', fontSize: '10px', lineHeight: 1.45, marginTop: '6px' }}>
@@ -758,11 +759,22 @@ function VideoKnowledgePanel({
             </div>
             <div style={{ color: '#A0A0B0', fontSize: '9px', lineHeight: 1.45, marginTop: '2px' }}>
               来源 {node.sourceLabel} / 证据强度 {Math.round(node.confidence * 100)}%
-              {node.timestamp === null ? ' / 无时间点' : ` / ${formatPopupDuration(node.timestamp)}`}
+              {node.timestamp === null ? ' / 无时间点' : ` / ${formatNodeTimeRange(node)}`}
+              {node.evidence?.sourceStatus ? ` / 来源状态 ${evidenceSourceStatusLabel(node.evidence.sourceStatus)}` : ''}
             </div>
             <div style={{ color: '#C8C8D8', fontSize: '9px', lineHeight: 1.4, marginTop: '2px' }}>
               {node.reason}
             </div>
+            {node.evidence?.textSpan && (
+              <div style={{ color: '#C8E6FF', fontSize: '9px', lineHeight: 1.4, marginTop: '2px' }}>
+                证据片段：{node.evidence.textSpan}
+              </div>
+            )}
+            {node.source === 'transcript' && node.evidence?.segmentId && (
+              <div style={{ color: '#9090A0', fontSize: '9px', lineHeight: 1.4, marginTop: '2px', wordBreak: 'break-all' }}>
+                字幕证据编号：{compactEvidenceId(node.evidence.segmentId)}；暂不提供跳转。
+              </div>
+            )}
             {node.jumpAction && (
               <button
                 onClick={() => onPreview(node.id)}
@@ -868,6 +880,63 @@ function subtitleProbeDetail(probe: CurrentVideoSubtitleSourceState): string {
 function transcriptEvidenceDetail(evidence: CurrentVideoTranscriptEvidenceState): string {
   if (!evidence.active) return evidence.message;
   return `${evidence.message} 已缓存片段=${evidence.segmentCount}`;
+}
+
+function videoKnowledgeNotice(knowledge: VideoKnowledgeResult | null, transcriptNodeCount: number): string {
+  if (!knowledge) return '正在读取当前视频的知识节点。';
+  if (transcriptNodeCount > 0) {
+    return `已用当前视频本地字幕证据生成 ${transcriptNodeCount} 个节点；时间范围只来自字幕片段，暂不提供跳转。`;
+  }
+  const evidence = knowledge.transcriptEvidence;
+  if (!evidence) {
+    return '当前没有可引用字幕正文。节点只使用元数据、简介、分 P 或章节；不会生成推测时间戳。';
+  }
+  if (evidence.status === 'stale') {
+    return '本地字幕证据与当前视频或分 P 不匹配，已回退到元数据、简介、分 P 或章节节点。';
+  }
+  if (evidence.status === 'language_mismatch') {
+    return '本地字幕语言与当前请求不匹配，暂不生成字幕节点。';
+  }
+  if (evidence.status === 'empty') {
+    return '已检测到字幕来源，但没有可用正文片段，暂不生成字幕节点。';
+  }
+  if (evidence.status === 'malformed') {
+    return '字幕正文结构异常，暂不作为节点证据。';
+  }
+  if (evidence.active) {
+    return '已检测到本地字幕证据，但没有匹配当前版本的可用片段，已回退到辅助节点。';
+  }
+  return evidence.message || '当前没有可引用字幕正文；不会生成推测时间戳。';
+}
+
+function evidenceSourceStatusLabel(
+  status: NonNullable<NonNullable<VideoKnowledgeNode['evidence']>['sourceStatus']>,
+): string {
+  switch (status) {
+    case 'active':
+      return '当前匹配';
+    case 'stale':
+      return '已过期';
+    case 'mismatch':
+      return '不匹配';
+    case 'unavailable':
+      return '不可用';
+    default:
+      return '未知';
+  }
+}
+
+function formatNodeTimeRange(node: VideoKnowledgeNode): string {
+  if (node.timestamp === null) return '无时间点';
+  if (typeof node.endTimestamp === 'number' && node.endTimestamp > node.timestamp) {
+    return `${formatPopupDuration(node.timestamp)}-${formatPopupDuration(node.endTimestamp)}`;
+  }
+  return formatPopupDuration(node.timestamp);
+}
+
+function compactEvidenceId(segmentId: string): string {
+  if (segmentId.length <= 40) return segmentId;
+  return `${segmentId.slice(0, 24)}...${segmentId.slice(-12)}`;
 }
 
 function formatSeconds(seconds: number): string {

--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -770,9 +770,9 @@ function VideoKnowledgePanel({
                 证据片段：{node.evidence.textSpan}
               </div>
             )}
-            {node.source === 'transcript' && node.evidence?.segmentId && (
-              <div style={{ color: '#9090A0', fontSize: '9px', lineHeight: 1.4, marginTop: '2px', wordBreak: 'break-all' }}>
-                字幕证据编号：{compactEvidenceId(node.evidence.segmentId)}；暂不提供跳转。
+            {node.source === 'transcript' && node.timestamp !== null && (
+              <div style={{ color: '#9090A0', fontSize: '9px', lineHeight: 1.4, marginTop: '2px' }}>
+                字幕证据：{formatNodeTimeRange(node)}；来自当前视频字幕片段，暂不提供跳转。
               </div>
             )}
             {node.jumpAction && (
@@ -932,11 +932,6 @@ function formatNodeTimeRange(node: VideoKnowledgeNode): string {
     return `${formatPopupDuration(node.timestamp)}-${formatPopupDuration(node.endTimestamp)}`;
   }
   return formatPopupDuration(node.timestamp);
-}
-
-function compactEvidenceId(segmentId: string): string {
-  if (segmentId.length <= 40) return segmentId;
-  return `${segmentId.slice(0, 24)}...${segmentId.slice(-12)}`;
 }
 
 function formatSeconds(seconds: number): string {

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -304,11 +304,14 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
       return { success: true, data: await getTranscriptEvidenceForActiveTab(request.params) as T };
     case 'GET_CURRENT_VIDEO_SUMMARY': {
       const context = await getCurrentVideoContextForActiveTab();
-      const transcriptSegments = await getSummaryTranscriptSegments(context);
+      const transcriptSegments = await getActiveCurrentVideoTranscriptSegments(context);
       return { success: true, data: await generateCurrentVideoSummary(context, { transcriptSegments }) as T };
     }
-    case 'GET_VIDEO_KNOWLEDGE':
-      return { success: true, data: buildVideoKnowledgeResult(await getCurrentVideoContextForActiveTab()) as T };
+    case 'GET_VIDEO_KNOWLEDGE': {
+      const context = await getCurrentVideoContextForActiveTab();
+      const transcriptSegments = await getActiveCurrentVideoTranscriptSegments(context);
+      return { success: true, data: buildVideoKnowledgeResult(context, { transcriptSegments }) as T };
+    }
     case 'REQUEST_VIDEO_KNOWLEDGE_JUMP':
       return { success: true, data: await requestVideoKnowledgeJump(request.params) as T };
     case 'GET_SMART_FAVORITES':
@@ -551,7 +554,7 @@ async function enrichCurrentVideoContextWithTranscriptEvidence(
   return withTranscriptEvidenceState(context, state);
 }
 
-async function getSummaryTranscriptSegments(
+async function getActiveCurrentVideoTranscriptSegments(
   context: CurrentVideoContextResult,
 ) {
   if (

--- a/src/shared/types/video-knowledge.ts
+++ b/src/shared/types/video-knowledge.ts
@@ -18,10 +18,20 @@ export type VideoKnowledgeSafetyFlag =
   | 'description_only'
   | 'page_bound'
   | 'chapter_bound'
+  | 'transcript_grounded'
+  | 'bounded_current_video'
   | 'manual_confirm_required'
   | 'auto_jump_disabled'
   | 'no_transcript'
-  | 'low_confidence';
+  | 'low_confidence'
+  | 'stale_source'
+  | 'language_mismatch';
+
+export type VideoKnowledgeEvidenceSourceStatus =
+  | 'active'
+  | 'stale'
+  | 'mismatch'
+  | 'unavailable';
 
 export interface VideoKnowledgeEvidence {
   textSpan: string | null;
@@ -29,6 +39,11 @@ export interface VideoKnowledgeEvidence {
   endChar: number | null;
   language: string | null;
   sourceId: string;
+  segmentId?: string | null;
+  startSeconds?: number | null;
+  endSeconds?: number | null;
+  sourceHash?: string | null;
+  sourceStatus?: VideoKnowledgeEvidenceSourceStatus;
 }
 
 export interface VideoKnowledgeJumpAction {

--- a/src/shared/video-knowledge.ts
+++ b/src/shared/video-knowledge.ts
@@ -1,4 +1,5 @@
 import type { CurrentVideoContext, CurrentVideoContextResult, CurrentVideoPart } from './types/current-video-context';
+import type { CurrentVideoTranscriptSegment } from './types/current-video-transcript';
 import type {
   VideoKnowledgeEvidence,
   VideoKnowledgeJumpAction,
@@ -9,12 +10,22 @@ import type {
 } from './types/video-knowledge';
 
 const DESCRIPTION_EVIDENCE_LIMIT = 280;
+const TRANSCRIPT_EVIDENCE_LIMIT = 220;
+const TRANSCRIPT_NODE_LIMIT = 6;
 const NODE_LIMIT = 16;
+
+export interface BuildVideoKnowledgeOptions {
+  now?: number;
+  transcriptSegments?: CurrentVideoTranscriptSegment[];
+}
 
 export function buildVideoKnowledgeResult(
   context: CurrentVideoContextResult,
-  now = Date.now(),
+  options: BuildVideoKnowledgeOptions | number = {},
 ): VideoKnowledgeResult {
+  const now = typeof options === 'number' ? options : options.now ?? Date.now();
+  const transcriptSegments = typeof options === 'number' ? undefined : options.transcriptSegments;
+
   if (context.kind !== 'video') {
     return {
       status: 'no_context',
@@ -36,7 +47,9 @@ export function buildVideoKnowledgeResult(
     };
   }
 
+  const transcriptNodes = buildTranscriptNodes(context, transcriptSegments, now);
   const nodes: VideoKnowledgeNode[] = [
+    ...transcriptNodes,
     buildMetadataNode(context, now),
     ...buildDescriptionNodes(context, now),
     ...buildPageNodes(context, now),
@@ -58,8 +71,8 @@ export function buildVideoKnowledgeResult(
     },
     transcriptEvidence: context.transcriptEvidence ?? null,
     nodes,
-    warnings: buildVideoKnowledgeWarnings(context),
-    limitations: buildVideoKnowledgeLimitations(context),
+    warnings: buildVideoKnowledgeWarnings(context, transcriptNodes.length),
+    limitations: buildVideoKnowledgeLimitations(context, transcriptNodes.length),
   };
 }
 
@@ -180,8 +193,137 @@ function buildChapterNodes(context: CurrentVideoContext, now: number): VideoKnow
     });
 }
 
-function buildVideoKnowledgeWarnings(context: CurrentVideoContext): string[] {
+function buildTranscriptNodes(
+  context: CurrentVideoContext,
+  segments: CurrentVideoTranscriptSegment[] | undefined,
+  now: number,
+): VideoKnowledgeNode[] {
+  const evidenceState = context.transcriptEvidence;
+  if (
+    !context.cid
+    || evidenceState?.active !== true
+    || !segments?.length
+    || evidenceState.bvid !== context.bvid
+    || evidenceState.cid !== context.cid
+    || evidenceState.page !== context.currentPart.page
+    || !evidenceState.sourceHash
+  ) {
+    return [];
+  }
+
+  const expectedLanguage = languageKey(evidenceState.language);
+  const rows = segments
+    .filter(segment =>
+      segment.bvid === context.bvid
+      && segment.cid === context.cid
+      && segment.page === context.currentPart.page
+      && !segment.stale
+      && segment.sourceHash === evidenceState.sourceHash
+      && (!evidenceState.language || languageKey(segment.language) === expectedLanguage)
+      && Number.isFinite(segment.startSeconds)
+      && Number.isFinite(segment.endSeconds)
+      && segment.endSeconds > segment.startSeconds
+      && Boolean(normalizeText(segment.text)),
+    )
+    .sort((a, b) => a.startSeconds - b.startSeconds || a.endSeconds - b.endSeconds);
+
+  if (rows.length === 0) return [];
+
+  return selectTranscriptNodeSegments(rows).map((segment, index) => {
+    const text = limitText(segment.text, TRANSCRIPT_EVIDENCE_LIMIT);
+    return node({
+      id: `node:${segment.segmentId}`,
+      context,
+      page: context.currentPart.page,
+      cid: segment.cid,
+      timestamp: segment.startSeconds,
+      endTimestamp: segment.endSeconds,
+      title: transcriptNodeTitle(segment, text),
+      reason: transcriptNodeReason(index, rows.length),
+      source: 'transcript',
+      confidence: transcriptConfidence(evidenceState, segment, rows.length),
+      evidence: {
+        textSpan: text,
+        startChar: 0,
+        endChar: text.length,
+        language: segment.language,
+        sourceId: segment.segmentId,
+        segmentId: segment.segmentId,
+        startSeconds: segment.startSeconds,
+        endSeconds: segment.endSeconds,
+        sourceHash: segment.sourceHash,
+        sourceStatus: 'active',
+      },
+      jumpAction: null,
+      safetyFlags: ['transcript_grounded', 'bounded_current_video', 'auto_jump_disabled'],
+      now,
+    });
+  });
+}
+
+function selectTranscriptNodeSegments(
+  rows: CurrentVideoTranscriptSegment[],
+): CurrentVideoTranscriptSegment[] {
+  if (rows.length <= TRANSCRIPT_NODE_LIMIT) return rows;
+  const selectedIndexes = new Set<number>();
+  for (let index = 0; index < TRANSCRIPT_NODE_LIMIT; index += 1) {
+    selectedIndexes.add(Math.round(index * (rows.length - 1) / (TRANSCRIPT_NODE_LIMIT - 1)));
+  }
+  return Array.from(selectedIndexes)
+    .sort((a, b) => a - b)
+    .map(index => rows[index])
+    .filter((segment): segment is CurrentVideoTranscriptSegment => Boolean(segment));
+}
+
+function transcriptNodeTitle(
+  segment: CurrentVideoTranscriptSegment,
+  text: string,
+): string {
+  const lead = transcriptLead(text);
+  return lead
+    ? `字幕节点 ${formatDuration(segment.startSeconds)}-${formatDuration(segment.endSeconds)}：${lead}`
+    : `字幕节点 ${formatDuration(segment.startSeconds)}-${formatDuration(segment.endSeconds)}`;
+}
+
+function transcriptNodeReason(index: number, total: number): string {
+  const ordinal = total > 1 ? `第 ${index + 1} 个` : '当前';
+  return `${ordinal}字幕证据片段可作为关键节点候选；时间范围、证据编号和文字片段都来自当前视频本地缓存的有效字幕，不从简介或元数据推断时间点。`;
+}
+
+function transcriptConfidence(
+  evidenceState: NonNullable<CurrentVideoContext['transcriptEvidence']>,
+  segment: CurrentVideoTranscriptSegment,
+  matchingSegmentCount: number,
+): number {
+  const textLength = normalizeText(segment.text).length;
+  const duration = segment.endSeconds - segment.startSeconds;
+  const coverage = typeof evidenceState.coverageStartSeconds === 'number'
+    && typeof evidenceState.coverageEndSeconds === 'number'
+    ? evidenceState.coverageEndSeconds - evidenceState.coverageStartSeconds
+    : 0;
+
+  let score = 0.62;
+  if (textLength >= 24) score += 0.08;
+  if (textLength >= 60) score += 0.05;
+  if (duration >= 1 && duration <= 20) score += 0.05;
+  if (matchingSegmentCount >= 6) score += 0.06;
+  else if (matchingSegmentCount <= 2) score -= 0.08;
+  if (coverage >= 120) score += 0.06;
+  else if (coverage >= 30) score += 0.03;
+  if (evidenceState.staleSegmentCount === 0) score += 0.04;
+  else score -= 0.08;
+  if (evidenceState.warnings.length > 0) score -= 0.04;
+
+  return Math.round(Math.max(0.48, Math.min(0.92, score)) * 100) / 100;
+}
+
+function buildVideoKnowledgeWarnings(context: CurrentVideoContext, transcriptNodeCount: number): string[] {
   const warnings = new Set(context.warnings);
+  if (transcriptNodeCount > 0) {
+    warnings.add('transcript_nodes_generated');
+    return Array.from(warnings);
+  }
+
   if (context.sources.transcript === 'available') {
     warnings.add('transcript_source_available');
     warnings.add('transcript_nodes_not_generated');
@@ -192,16 +334,24 @@ function buildVideoKnowledgeWarnings(context: CurrentVideoContext): string[] {
   }
   if (context.transcriptEvidence?.active) {
     warnings.add('transcript_evidence_cached');
-    warnings.add('transcript_evidence_not_used_for_nodes');
+    warnings.add('transcript_evidence_segments_not_available_for_nodes');
   }
   return Array.from(warnings);
 }
 
-function buildVideoKnowledgeLimitations(context: CurrentVideoContext): string[] {
+function buildVideoKnowledgeLimitations(context: CurrentVideoContext, transcriptNodeCount: number): string[] {
+  if (transcriptNodeCount > 0) {
+    return [
+      '已基于当前视频本地缓存的有效字幕生成关键节点候选；每个时间范围只来自真实字幕片段。',
+      '字幕节点目前只展示证据和时间范围，不新增自动跳转或新的时间点跳转能力。',
+      '证据强度只反映字幕片段的完整度、匹配状态和本地证据质量，不代表视频质量。',
+    ];
+  }
+
   const transcriptLimitation = context.transcriptEvidence?.active
-    ? '已缓存本地字幕正文证据，但当前版本仍不生成字幕正文节点、关键节点、模糊检索或完整视频总结。'
+    ? '已缓存本地字幕正文证据，但当前没有可用于生成节点的匹配字幕片段；已回退到元数据、简介、分 P 或章节节点。'
     : context.sources.transcript === 'available'
-    ? '已探测到字幕来源，但当前版本只记录来源状态，尚未生成字幕正文节点或完整视频总结。'
+    ? '已探测到字幕来源，但当前没有可引用的本地字幕正文片段；节点只使用元数据、简介、分 P 或章节。'
     : context.sources.transcript === 'unknown'
       ? '字幕来源尚未完成探测；当前节点只基于元数据、简介、分 P 或章节。'
       : '没有可用字幕，因此元数据和简介节点不代表完整视频理解。';
@@ -219,6 +369,7 @@ function node(input: {
   page: number;
   cid?: number | null;
   timestamp?: number | null;
+  endTimestamp?: number | null;
   title: string;
   reason: string;
   source: VideoKnowledgeSource;
@@ -234,7 +385,7 @@ function node(input: {
     cid: input.cid ?? input.context.cid,
     page: input.page,
     timestamp: input.timestamp ?? null,
-    endTimestamp: null,
+    endTimestamp: input.endTimestamp ?? null,
     title: limitText(input.title, 140),
     reason: limitText(input.reason, 260),
     source: input.source,
@@ -297,6 +448,17 @@ function limitText(value: string, maxLength: number): string {
   if (normalized.length <= maxLength) return normalized;
   if (maxLength <= 3) return normalized.slice(0, maxLength);
   return `${normalized.slice(0, maxLength - 3)}...`;
+}
+
+function transcriptLead(text: string): string {
+  const normalized = normalizeText(text);
+  if (!normalized) return '';
+  const sentence = normalized.split(/(?<=[.!?。！？])\s*/u)[0] ?? normalized;
+  return limitText(sentence, 42);
+}
+
+function languageKey(value: string | null | undefined): string {
+  return (value ?? 'unknown').trim().toLowerCase() || 'unknown';
 }
 
 export function formatVideoKnowledgeTime(seconds: number): string {

--- a/tests/video-knowledge.test.ts
+++ b/tests/video-knowledge.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { buildVideoKnowledgeResult } from '../src/shared/video-knowledge.ts';
 import type { CurrentVideoContext, CurrentVideoContextResult } from '../src/shared/types/current-video-context.ts';
+import type { CurrentVideoTranscriptEvidenceStatus, CurrentVideoTranscriptSegment } from '../src/shared/types/current-video-transcript.ts';
 
 test('builds metadata-only node without transcript or fabricated timestamp', () => {
   const result = buildVideoKnowledgeResult(videoContext({
@@ -73,10 +74,10 @@ test('exposes available subtitle source state without generating transcript node
   assert.equal(result.transcriptEvidence, null);
   assert.equal(result.nodes.some(node => node.source === 'transcript'), false);
   assert.ok(result.warnings.includes('transcript_nodes_not_generated'));
-  assert.ok(result.limitations.some(item => item.includes('尚未生成字幕正文节点')));
+  assert.ok(result.limitations.some(item => item.includes('没有可引用的本地字幕正文片段')));
 });
 
-test('exposes cached transcript evidence state without generating transcript nodes', () => {
+test('does not use active transcript cache without supplied evidence segments', () => {
   const context = videoContext({
     descriptionText: 'Description fallback remains visible.',
     parts: [],
@@ -112,7 +113,124 @@ test('exposes cached transcript evidence state without generating transcript nod
   assert.equal(result.sourceState.contentText, false);
   assert.equal(result.transcriptEvidence?.segmentCount, 2);
   assert.equal(result.nodes.some(node => node.source === 'transcript'), false);
-  assert.ok(result.warnings.includes('transcript_evidence_not_used_for_nodes'));
+  assert.ok(result.warnings.includes('transcript_evidence_segments_not_available_for_nodes'));
+});
+
+test('builds transcript-grounded nodes from active cached evidence segments', () => {
+  const context = withTranscriptEvidence(videoContext({
+    descriptionText: 'Description fallback remains visible.',
+    parts: [],
+    chapters: [],
+  }));
+  const result = buildVideoKnowledgeResult(context, {
+    transcriptSegments: transcriptSegments(),
+    now: 3000,
+  });
+
+  const transcriptNodes = result.nodes.filter(node => node.source === 'transcript');
+  const first = transcriptNodes[0];
+
+  assert.equal(result.sourceState.transcript, true);
+  assert.equal(result.sourceState.transcriptEvidence, true);
+  assert.equal(result.sourceState.contentText, false);
+  assert.equal(transcriptNodes.length, 4);
+  assert.ok(first);
+  assert.equal(first.timestamp, 0);
+  assert.equal(first.endTimestamp, 4);
+  assert.equal(first.jumpAction, null);
+  assert.equal(first.sourceLabel, '字幕');
+  assert.equal(first.evidence?.segmentId, 'transcript:BV1Knowledge00:101:1:zh-cn:hash123:0');
+  assert.equal(first.evidence?.sourceId, first.evidence?.segmentId);
+  assert.equal(first.evidence?.startSeconds, 0);
+  assert.equal(first.evidence?.endSeconds, 4);
+  assert.equal(first.evidence?.sourceHash, 'hash123');
+  assert.equal(first.evidence?.sourceStatus, 'active');
+  assert.ok(first.evidence?.textSpan?.includes('first transcript point'));
+  assert.ok(first.reason.includes('不从简介或元数据推断时间点'));
+  assert.ok(first.safetyFlags.includes('transcript_grounded'));
+  assert.ok(first.safetyFlags.includes('bounded_current_video'));
+  assert.ok(first.safetyFlags.includes('auto_jump_disabled'));
+  assert.ok(first.confidence >= 0.7);
+  assert.ok(result.warnings.includes('transcript_nodes_generated'));
+  assert.ok(result.limitations.some(item => item.includes('不新增自动跳转')));
+});
+
+test('keeps transcript nodes bounded to current video identity and source hash', () => {
+  const context = withTranscriptEvidence(videoContext({
+    descriptionText: 'Description fallback remains visible.',
+    parts: [],
+    chapters: [],
+  }));
+  const mixedSegments = [
+    ...transcriptSegments(),
+    {
+      ...transcriptSegments()[0],
+      segmentId: 'transcript:BV1Other:101:1:zh-cn:hash123:leak',
+      bvid: 'BV1Other',
+      text: 'SECRET TRANSCRIPT FROM ANOTHER VIDEO',
+    },
+    {
+      ...transcriptSegments()[1],
+      segmentId: 'transcript:BV1Knowledge00:101:1:zh-cn:oldhash:stale',
+      sourceHash: 'oldhash',
+      text: 'OLD HASH TRANSCRIPT SHOULD NOT APPEAR',
+    },
+  ];
+  const result = buildVideoKnowledgeResult(context, {
+    transcriptSegments: mixedSegments,
+    now: 3000,
+  });
+  const rawResult = JSON.stringify(result);
+
+  assert.equal(result.nodes.filter(node => node.source === 'transcript').length, 4);
+  assert.doesNotMatch(rawResult, /SECRET TRANSCRIPT|OLD HASH TRANSCRIPT|watchHistory|favorites|following|feedback|Cookie|Key\.txt|Chrome\\User Data/i);
+});
+
+test('does not generate transcript nodes for stale, mismatch, empty, or malformed evidence states', () => {
+  const statuses: CurrentVideoTranscriptEvidenceStatus[] = ['stale', 'language_mismatch', 'empty', 'malformed'];
+  for (const status of statuses) {
+    const context = withTranscriptEvidence(videoContext({
+      descriptionText: 'Description fallback remains visible.',
+      parts: [],
+      chapters: [],
+    }), {
+      status,
+      active: false,
+      message: `状态 ${status} 不能作为当前字幕正文证据。`,
+      warnings: [`transcript_${status}`],
+    });
+    const result = buildVideoKnowledgeResult(context, {
+      transcriptSegments: transcriptSegments(),
+      now: 3000,
+    });
+
+    assert.equal(result.nodes.some(node => node.source === 'transcript'), false);
+    assert.ok(result.nodes.some(node => node.source === 'description'));
+    assert.ok(result.limitations.some(item => item.includes('元数据') || item.includes('简介')));
+  }
+});
+
+test('drops empty, stale, language-mismatched, and malformed transcript segments', () => {
+  const context = withTranscriptEvidence(videoContext({
+    descriptionText: 'Description fallback remains visible.',
+    parts: [],
+    chapters: [],
+  }));
+  const [valid] = transcriptSegments();
+  const result = buildVideoKnowledgeResult(context, {
+    transcriptSegments: [
+      valid,
+      { ...valid, segmentId: 'transcript:bad:empty', text: '   ', startSeconds: 5, endSeconds: 6 },
+      { ...valid, segmentId: 'transcript:bad:stale', stale: true, text: 'stale segment', startSeconds: 7, endSeconds: 8 },
+      { ...valid, segmentId: 'transcript:bad:lang', language: 'en-US', text: 'wrong language', startSeconds: 9, endSeconds: 10 },
+      { ...valid, segmentId: 'transcript:bad:time', text: 'bad time', startSeconds: 11, endSeconds: 11 },
+    ],
+    now: 3000,
+  });
+
+  const transcriptNodes = result.nodes.filter(node => node.source === 'transcript');
+  assert.equal(transcriptNodes.length, 1);
+  assert.equal(transcriptNodes[0].evidence?.segmentId, valid.segmentId);
 });
 
 test('marks pending subtitle probe as unknown source state', () => {
@@ -226,4 +344,62 @@ function videoContext(options: {
     },
     warnings: ['transcript_unavailable'],
   };
+}
+
+function withTranscriptEvidence(
+  context: CurrentVideoContext,
+  overrides: Partial<NonNullable<CurrentVideoContext['transcriptEvidence']>> = {},
+): CurrentVideoContext {
+  context.sources.transcript = 'available';
+  context.transcriptEvidence = {
+    status: 'cached',
+    active: true,
+    checkedAt: 2000,
+    bvid: context.bvid,
+    cid: context.cid,
+    page: context.currentPart.page,
+    language: 'zh-CN',
+    source: 'bilibili_subtitle',
+    sourceType: 'bilibili_player_wbi_v2',
+    sourceHash: 'hash123',
+    segmentCount: 4,
+    staleSegmentCount: 0,
+    coverageStartSeconds: 0,
+    coverageEndSeconds: 19,
+    fetchedAt: 2000,
+    updatedAt: 2000,
+    reason: 'transcript_segments_cached',
+    message: '已缓存字幕正文证据，仅作为本地证据状态展示。',
+    warnings: [],
+    ...overrides,
+  };
+  return context;
+}
+
+function transcriptSegments(): CurrentVideoTranscriptSegment[] {
+  return [
+    'first transcript point introduces the problem',
+    'second transcript point explains the method',
+    'third transcript point compares the result',
+    'fourth transcript point closes the conclusion',
+  ].map((text, index) => {
+    const startSeconds = index * 5;
+    const endSeconds = startSeconds + 4;
+    return {
+      segmentId: `transcript:BV1Knowledge00:101:1:zh-cn:hash123:${index}`,
+      bvid: 'BV1Knowledge00',
+      cid: 101,
+      page: 1,
+      startSeconds,
+      endSeconds,
+      text,
+      language: 'zh-CN',
+      source: 'bilibili_subtitle',
+      sourceType: 'bilibili_player_wbi_v2',
+      sourceHash: 'hash123',
+      stale: false,
+      fetchedAt: 2000,
+      updatedAt: 2000,
+    };
+  });
 }


### PR DESCRIPTION
## Scope

- Issue: #102
- Generate Video Knowledge transcript nodes from active cached current-video transcript segments.
- Reuse the bounded transcript segment read path introduced by the transcript cache/summary work.
- Show transcript node time range, evidence snippet, evidence strength, and current source status in the popup.
- Keep internal segmentId/sourceHash bindings for evidence validation, but do not render raw internal evidence IDs to ordinary users.
- Keep metadata, description, page, and chapter helper nodes as fallback when transcript evidence is missing, stale, mismatched, empty, or malformed.

## Root Cause / Product Judgment

Video Knowledge already exposed transcript availability and cache state, but it never received bounded segment rows. That meant it could only produce helper nodes and could not cite the real subtitle segment, time span, or evidence text.

This PR keeps node generation local and deterministic. Transcript nodes are produced only when the active evidence state and supplied segments match the current bvid, cid, page, language, and sourceHash. The node confidence reflects segment/source evidence quality, not video quality. Transcript nodes intentionally do not get a jumpAction, so this does not expand timestamp seek behavior from #104.

## Validation

- `npm ci`
- `npm run test:video-knowledge`
- `npm run test:current-video-transcript`
- `npm run test:current-video-summary`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- `rg -n 未消费|猜你喜欢 dashboard popup public src README.md tests` returned no matches.
- Targeted leak scan for `字幕证据编号`, `compactEvidenceId`, `transcript:BV`, `sourceHash`, and test hash strings in popup sources/build output returned no matches.
- Browser mock QA against built popup with mocked read-only current-video responses verified nonblank render, no console error/warn, transcript node time range, evidence snippet, source status, user-facing evidence location copy, and no transcript jump button.

## Blocker / Must Fix / Follow-up

- Blocker: none.
- Must fix: none remaining.
- Follow-up: #103 fuzzy search, #104 timestamp jump behavior, and #105 AI rerank remain out of scope.

## Privacy Boundary

This PR reads only current-video bounded transcript evidence already stored by the extension. It does not upload full transcripts, history, favorites, following, feedback, Cookie, browser profile, login state, local keys, or `C:\Users\LittleNub\Desktop\Key.txt`. It does not write back to Bilibili.