### PR TITLE
[codex] Add local current-video fuzzy segment retrieval

### DIFF
--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -10,6 +10,10 @@ import type {
   CurrentVideoSubtitleSourceState,
 } from '../src/shared/types/current-video-context';
 import type { CurrentVideoTranscriptEvidenceState } from '../src/shared/types/current-video-transcript';
+import type {
+  CurrentVideoSegmentRetrievalCandidate,
+  CurrentVideoSegmentRetrievalResult,
+} from '../src/shared/types/current-video-segment-retrieval';
 import type { CurrentVideoSummaryResult } from '../src/shared/types/current-video-summary';
 import type { VideoKnowledgeJumpResponse, VideoKnowledgeNode, VideoKnowledgeResult } from '../src/shared/types/video-knowledge';
 import { cancelledCurrentVideoSummary, loadingCurrentVideoSummary } from '../src/shared/current-video-summary';
@@ -531,6 +535,33 @@ function CurrentVideoAssistantStatus({
 }) {
   const isVideo = context?.kind === 'video';
   const previewNode = knowledge?.nodes.find(node => node.id === previewNodeId) ?? null;
+  const [segmentQuery, setSegmentQuery] = useState('');
+  const [segmentResult, setSegmentResult] = useState<CurrentVideoSegmentRetrievalResult | null>(null);
+  const [segmentLoading, setSegmentLoading] = useState(false);
+  const [segmentError, setSegmentError] = useState<string | null>(null);
+
+  async function searchCurrentVideoSegments() {
+    const query = segmentQuery.trim();
+    if (!query) {
+      setSegmentError('请输入想查找的片段内容。');
+      setSegmentResult(null);
+      return;
+    }
+
+    setSegmentLoading(true);
+    setSegmentError(null);
+    try {
+      const result = await requestSW<CurrentVideoSegmentRetrievalResult>('SEARCH_CURRENT_VIDEO_SEGMENTS', {
+        query,
+      });
+      setSegmentResult(result);
+    } catch (e) {
+      setSegmentError((e as Error).message);
+      setSegmentResult(null);
+    } finally {
+      setSegmentLoading(false);
+    }
+  }
 
   return (
     <section style={{
@@ -641,6 +672,14 @@ function CurrentVideoAssistantStatus({
             onPreview={onPreviewNode}
             onConfirm={onConfirmJump}
           />
+          <CurrentVideoSegmentRetrievalPanel
+            query={segmentQuery}
+            result={segmentResult}
+            loading={segmentLoading}
+            error={segmentError}
+            onQueryChange={setSegmentQuery}
+            onSearch={searchCurrentVideoSegments}
+          />
           <div style={{ display: 'flex', gap: '6px', marginTop: '8px' }}>
             <button
               onClick={onRefresh}
@@ -691,6 +730,144 @@ function CurrentVideoAssistantStatus({
         </div>
       )}
     </section>
+  );
+}
+
+function CurrentVideoSegmentRetrievalPanel({
+  query,
+  result,
+  loading,
+  error,
+  onQueryChange,
+  onSearch,
+}: {
+  query: string;
+  result: CurrentVideoSegmentRetrievalResult | null;
+  loading: boolean;
+  error: string | null;
+  onQueryChange: (query: string) => void;
+  onSearch: () => void;
+}) {
+  return (
+    <div style={{
+      marginTop: '8px',
+      padding: '8px',
+      border: '1px solid rgba(127, 219, 255, 0.18)',
+      borderRadius: '6px',
+      background: 'rgba(0, 161, 214, 0.08)',
+    }}>
+      <div style={{ color: '#C8E6FF', fontSize: '10px', fontWeight: 700 }}>
+        本地片段检索
+      </div>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          onSearch();
+        }}
+        style={{ display: 'flex', gap: '6px', marginTop: '6px' }}
+      >
+        <input
+          value={query}
+          onInput={(event) => onQueryChange((event.currentTarget as HTMLInputElement).value)}
+          placeholder="例如：模型架构那段"
+          style={{
+            minWidth: 0,
+            flex: 1,
+            background: 'rgba(255,255,255,0.08)',
+            color: '#E8E8F2',
+            border: '1px solid rgba(255,255,255,0.14)',
+            borderRadius: '6px',
+            fontSize: '11px',
+            padding: '6px 8px',
+            outline: 'none',
+          }}
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          style={{
+            width: '54px',
+            background: loading ? 'rgba(0, 161, 214, 0.12)' : 'rgba(0, 161, 214, 0.28)',
+            color: '#C8E6FF',
+            border: '1px solid rgba(127, 219, 255, 0.32)',
+            borderRadius: '6px',
+            cursor: loading ? 'default' : 'pointer',
+            fontSize: '10px',
+            padding: '6px 8px',
+          }}
+        >
+          {loading ? '检索中' : '检索'}
+        </button>
+      </form>
+      <div style={{ color: '#A0A0B0', fontSize: '9px', lineHeight: 1.45, marginTop: '5px' }}>
+        只查当前视频本地已有证据；结果只展示候选时间和证据，不提供跳转。
+      </div>
+      {error && (
+        <div style={{ color: '#FFB347', fontSize: '10px', lineHeight: 1.45, marginTop: '6px' }}>
+          {error}
+        </div>
+      )}
+      {result && (
+        <div style={{ marginTop: '7px' }}>
+          <div style={{ color: retrievalStatusColor(result), fontSize: '10px', lineHeight: 1.45 }}>
+            {retrievalStatusMessage(result)}
+          </div>
+          {result.candidates.length === 0 ? (
+            <div style={{ color: '#A0A0B0', fontSize: '10px', lineHeight: 1.45, marginTop: '5px' }}>
+              {result.limitations[0]}
+            </div>
+          ) : (
+            result.candidates.map((candidate, index) => (
+              <SegmentCandidateCard key={candidate.id} candidate={candidate} index={index} />
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SegmentCandidateCard({
+  candidate,
+  index,
+}: {
+  candidate: CurrentVideoSegmentRetrievalCandidate;
+  index: number;
+}) {
+  return (
+    <div style={{
+      marginTop: '6px',
+      paddingTop: '6px',
+      borderTop: '1px solid rgba(255,255,255,0.08)',
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '8px', alignItems: 'flex-start' }}>
+        <div style={{ minWidth: 0, color: '#E8E8F2', fontSize: '10px', lineHeight: 1.35, fontWeight: 650 }}>
+          候选 {index + 1} · {candidate.timeRangeLabel}
+        </div>
+        <div style={{
+          flex: '0 0 auto',
+          color: candidate.confidenceLabel === '低' ? '#FFCF8A' : '#A0E7A0',
+          fontSize: '9px',
+          lineHeight: 1.35,
+        }}>
+          {candidate.confidenceLabel} {Math.round(candidate.confidence * 100)}%
+        </div>
+      </div>
+      <div style={{ color: '#A0A0B0', fontSize: '9px', lineHeight: 1.4, marginTop: '2px' }}>
+        来源 {candidate.sourceLabel}
+      </div>
+      <div style={{ color: '#C8E6FF', fontSize: '9px', lineHeight: 1.4, marginTop: '3px' }}>
+        证据片段：{candidate.evidenceText || '暂无可展示文本'}
+      </div>
+      <div style={{ color: '#C8C8D8', fontSize: '9px', lineHeight: 1.4, marginTop: '3px' }}>
+        匹配原因：{candidate.matchReasons.join('；')}
+      </div>
+      {candidate.note && (
+        <div style={{ color: '#FFCF8A', fontSize: '9px', lineHeight: 1.4, marginTop: '3px' }}>
+          {candidate.note}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -924,6 +1101,33 @@ function evidenceSourceStatusLabel(
     default:
       return '未知';
   }
+}
+
+function retrievalStatusMessage(result: CurrentVideoSegmentRetrievalResult): string {
+  switch (result.status) {
+    case 'ready':
+      return result.summary;
+    case 'low_confidence':
+      return result.summary;
+    case 'metadata_only':
+      return result.summary;
+    case 'empty_query':
+      return '请输入想查找的片段内容。';
+    case 'no_context':
+      return '当前没有可用的视频上下文。';
+    case 'stale_context':
+      return '当前视频上下文已过期，请刷新后再试。';
+    case 'no_evidence':
+      return '没有找到可用的本地证据。';
+    default:
+      return result.summary;
+  }
+}
+
+function retrievalStatusColor(result: CurrentVideoSegmentRetrievalResult): string {
+  if (result.status === 'ready') return '#A0E7A0';
+  if (result.status === 'metadata_only' || result.status === 'low_confidence') return '#FFCF8A';
+  return '#A0A0B0';
 }
 
 function formatNodeTimeRange(node: VideoKnowledgeNode): string {

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -34,6 +34,7 @@ import {
   buildCurrentVideoTranscriptEvidenceState,
   withTranscriptEvidenceState,
 } from '../../shared/current-video-transcript-cache';
+import { searchCurrentVideoSegments } from '../../shared/current-video-segment-retrieval';
 import { buildVideoKnowledgeResult, findVideoKnowledgeNode } from '../../shared/video-knowledge';
 import {
   getQuickStats,
@@ -311,6 +312,20 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
       const context = await getCurrentVideoContextForActiveTab();
       const transcriptSegments = await getActiveCurrentVideoTranscriptSegments(context);
       return { success: true, data: buildVideoKnowledgeResult(context, { transcriptSegments }) as T };
+    }
+    case 'SEARCH_CURRENT_VIDEO_SEGMENTS': {
+      const query = String(request.params?.query ?? '');
+      const context = await getCurrentVideoContextForActiveTab();
+      const transcriptSegments = await getActiveCurrentVideoTranscriptSegments(context);
+      const videoKnowledge = buildVideoKnowledgeResult(context, { transcriptSegments });
+      return {
+        success: true,
+        data: searchCurrentVideoSegments(context, {
+          query,
+          transcriptSegments,
+          videoKnowledge,
+        }) as T,
+      };
     }
     case 'REQUEST_VIDEO_KNOWLEDGE_JUMP':
       return { success: true, data: await requestVideoKnowledgeJump(request.params) as T };

--- a/src/shared/current-video-segment-retrieval.ts
+++ b/src/shared/current-video-segment-retrieval.ts
@@ -1,0 +1,748 @@
+import type { CurrentVideoContext, CurrentVideoContextResult } from './types/current-video-context';
+import type { CurrentVideoTranscriptSegment } from './types/current-video-transcript';
+import type {
+  CurrentVideoSegmentRetrievalCandidate,
+  CurrentVideoSegmentRetrievalCandidateSource,
+  CurrentVideoSegmentRetrievalConfidenceLabel,
+  CurrentVideoSegmentRetrievalResult,
+  CurrentVideoSegmentRetrievalStatus,
+} from './types/current-video-segment-retrieval';
+import type { VideoKnowledgeNode, VideoKnowledgeResult } from './types/video-knowledge';
+
+const DEFAULT_CONTEXT_MAX_AGE_MS = 10 * 60 * 1000;
+const DEFAULT_LIMIT = 5;
+const MIN_TIMED_SCORE = 0.02;
+const MIN_METADATA_SCORE = 0.22;
+const LOW_CONFIDENCE_THRESHOLD = 0.45;
+const MEDIUM_CONFIDENCE_THRESHOLD = 0.62;
+const HIGH_CONFIDENCE_THRESHOLD = 0.78;
+const EVIDENCE_TEXT_LIMIT = 220;
+
+const QUERY_HELPER_WORDS = [
+  '那段',
+  '这一段',
+  '这段',
+  '地方',
+  '哪里',
+  '哪个',
+  '讲到',
+  '讲了',
+  '讲',
+  '介绍',
+  '说到',
+  '说',
+  '关于',
+  '部分',
+  '片段',
+  '时间',
+  '视频',
+  '一下',
+  '这个',
+  '那个',
+  '的',
+  '了',
+  '是',
+  '在',
+  '和',
+  '与',
+  '及',
+  '到',
+];
+
+export interface SearchCurrentVideoSegmentsOptions {
+  query: string;
+  now?: number;
+  limit?: number;
+  contextMaxAgeMs?: number;
+  transcriptSegments?: CurrentVideoTranscriptSegment[];
+  videoKnowledge?: VideoKnowledgeResult | null;
+}
+
+interface QueryProfile {
+  original: string;
+  normalized: string;
+  compact: string;
+  meaningfulCompact: string;
+  terms: string[];
+  cjkTerms: string[];
+  latinTerms: string[];
+}
+
+interface ScoreResult {
+  score: number;
+  reasons: string[];
+  matchedTerms: string[];
+  exact: boolean;
+}
+
+export function searchCurrentVideoSegments(
+  context: CurrentVideoContextResult,
+  options: SearchCurrentVideoSegmentsOptions,
+): CurrentVideoSegmentRetrievalResult {
+  const now = options.now ?? Date.now();
+  const limit = Math.max(1, Math.floor(options.limit ?? DEFAULT_LIMIT));
+  const profile = buildQueryProfile(options.query);
+
+  if (!profile.normalized) {
+    return result({
+      status: 'empty_query',
+      context,
+      profile,
+      now,
+      candidates: [],
+      summary: '请输入想查找的内容，例如“模型架构那段”或“DeepSeek V3.2”。',
+      limitations: ['本功能只检索当前视频已经保存在本地的证据，不会请求 AI 或上传字幕。'],
+      contextFresh: false,
+    });
+  }
+
+  if (context.kind !== 'video') {
+    return result({
+      status: 'no_context',
+      context,
+      profile,
+      now,
+      candidates: [],
+      summary: '当前没有可用的视频上下文。请先打开一个 B 站视频页，再检索时间片段。',
+      limitations: ['没有当前视频上下文时，不会从历史、收藏或账号资料中查找替代证据。'],
+      contextFresh: false,
+    });
+  }
+
+  const contextFresh = now - context.collectedAt <= (options.contextMaxAgeMs ?? DEFAULT_CONTEXT_MAX_AGE_MS);
+  if (!contextFresh) {
+    return result({
+      status: 'stale_context',
+      context,
+      profile,
+      now,
+      candidates: [],
+      summary: '当前视频上下文已过期。请刷新视频页或重新打开弹窗后再试。',
+      limitations: ['过期上下文不会用于定位时间片段，避免把旧页面证据误认为当前视频。'],
+      contextFresh,
+    });
+  }
+
+  const transcriptSegments = filterCurrentTranscriptSegments(context, options.transcriptSegments ?? []);
+  const knowledgeNodes = filterCurrentKnowledgeNodes(context, options.videoKnowledge?.nodes ?? []);
+  const evidenceState = {
+    transcriptSegmentCount: transcriptSegments.length,
+    timedKnowledgeNodeCount: knowledgeNodes.filter(node => knowledgeCandidateSource(node) !== null).length,
+    metadataHintAvailable: hasMetadataHint(context),
+  };
+  const candidates = mergeAndRankCandidates([
+    ...buildTranscriptCandidates(context, transcriptSegments, profile),
+    ...buildKnowledgeNodeCandidates(knowledgeNodes, profile),
+  ], limit);
+
+  if (candidates.length > 0) {
+    const status: CurrentVideoSegmentRetrievalStatus = candidates[0].confidence < LOW_CONFIDENCE_THRESHOLD
+      ? 'low_confidence'
+      : 'ready';
+    return result({
+      status,
+      context,
+      profile,
+      now,
+      candidates,
+      summary: status === 'ready'
+        ? `找到 ${candidates.length} 个基于当前视频本地证据的候选片段。`
+        : '只找到低置信候选，请把问题写得更接近字幕原文或章节标题。',
+      limitations: [
+        '候选时间只来自当前视频已有字幕片段或本地关键节点，不会推测新时间点。',
+        '当前结果只展示证据和时间范围，不提供播放器跳转。',
+      ],
+      evidenceState,
+      contextFresh,
+    });
+  }
+
+  const metadataCandidates = buildMetadataHintCandidates(context, profile, limit);
+  if (metadataCandidates.length > 0) {
+    return result({
+      status: 'metadata_only',
+      context,
+      profile,
+      now,
+      candidates: metadataCandidates,
+      summary: '当前没有可定位的字幕片段或本地关键节点；仅找到视频信息或简介中的弱匹配，无法定位到具体时间点。',
+      limitations: [
+        '仅元数据或简介匹配不能代表字幕正文证据。',
+        '没有当前视频字幕片段或本地关键节点时，不会生成推测时间。',
+      ],
+      evidenceState,
+      contextFresh,
+    });
+  }
+
+  return result({
+    status: 'no_evidence',
+    context,
+    profile,
+    now,
+    candidates: [],
+    summary: '没有找到可用的本地证据。请先缓存当前视频字幕正文，或换一个更具体的关键词。',
+    limitations: [
+      '当前检索不会读取历史、收藏、关注、反馈、Cookie、浏览器资料或本地密钥。',
+      '没有字幕片段或本地关键节点时，不会编造时间点。',
+    ],
+    evidenceState,
+    contextFresh,
+  });
+}
+
+function buildTranscriptCandidates(
+  context: CurrentVideoContext,
+  segments: CurrentVideoTranscriptSegment[],
+  profile: QueryProfile,
+): CurrentVideoSegmentRetrievalCandidate[] {
+  return segments
+    .map((segment) => {
+      const scored = scoreText(profile, segment.text);
+      if (scored.score < MIN_TIMED_SCORE) return null;
+
+      const weakHintScore = scoreContextWeakHints(context, profile);
+      const confidence = capWeakConfidence(scored.score, confidenceFromScore(
+        scored.score + Math.min(0.08, weakHintScore * 0.08),
+        'transcript_segment',
+        segmentTextQuality(segment),
+      ));
+      const reasons = [...scored.reasons];
+      if (weakHintScore >= 0.5) {
+        reasons.push('标题、简介或章节中也有相近提示');
+      }
+
+      return candidate({
+        id: `candidate:segment:${segment.segmentId}`,
+        binding: {
+          kind: 'transcript_segment',
+          segmentId: segment.segmentId,
+        },
+        source: 'transcript_segment',
+        startSeconds: segment.startSeconds,
+        endSeconds: segment.endSeconds,
+        evidenceText: segment.text,
+        matchReasons: reasons,
+        confidence,
+      });
+    })
+    .filter((item): item is CurrentVideoSegmentRetrievalCandidate => Boolean(item));
+}
+
+function buildKnowledgeNodeCandidates(
+  nodes: VideoKnowledgeNode[],
+  profile: QueryProfile,
+): CurrentVideoSegmentRetrievalCandidate[] {
+  return nodes
+    .map((node) => {
+      const text = [
+        node.title,
+        node.reason,
+        node.evidence?.textSpan ?? '',
+      ].join(' ');
+      const scored = scoreText(profile, text);
+      if (scored.score < MIN_TIMED_SCORE) return null;
+
+      const source = knowledgeCandidateSource(node);
+      if (!source) return null;
+
+      const sourceQuality = node.source === 'transcript'
+        ? 0.08
+        : node.source === 'chapter'
+          ? 0
+          : -0.06;
+      const confidence = capWeakConfidence(scored.score, confidenceFromScore(
+        scored.score + node.confidence * 0.12 + sourceQuality,
+        source,
+        node.evidence?.textSpan ? 0.05 : 0,
+      ));
+
+      return candidate({
+        id: node.evidence?.segmentId
+          ? `candidate:segment:${node.evidence.segmentId}`
+          : `candidate:node:${node.id}`,
+        binding: node.evidence?.segmentId
+          ? {
+              kind: 'transcript_segment',
+              segmentId: node.evidence.segmentId,
+              nodeId: node.id,
+            }
+          : {
+              kind: 'video_knowledge_node',
+              nodeId: node.id,
+            },
+        source,
+        startSeconds: node.timestamp,
+        endSeconds: node.endTimestamp,
+        evidenceText: node.evidence?.textSpan ?? node.title,
+        matchReasons: [
+          ...scored.reasons,
+          node.source === 'transcript' ? '同时命中本地字幕节点' : '命中当前视频本地节点提示',
+        ],
+        confidence,
+      });
+    })
+    .filter((item): item is CurrentVideoSegmentRetrievalCandidate => Boolean(item));
+}
+
+function buildMetadataHintCandidates(
+  context: CurrentVideoContext,
+  profile: QueryProfile,
+  limit: number,
+): CurrentVideoSegmentRetrievalCandidate[] {
+  const hints = [
+    {
+      source: 'metadata_hint' as const,
+      id: `candidate:metadata:${context.bvid}`,
+      labelText: [context.title, context.currentPart.title].filter(Boolean).join(' / '),
+      evidenceText: [context.title, context.currentPart.title, context.authorName].filter(Boolean).join(' / '),
+    },
+    {
+      source: 'description_hint' as const,
+      id: `candidate:description:${context.bvid}`,
+      labelText: context.description.text ?? '',
+      evidenceText: context.description.text ?? '',
+    },
+  ];
+
+  return hints
+    .map((hint) => {
+      const scored = scoreText(profile, hint.labelText);
+      if (scored.score < MIN_METADATA_SCORE) return null;
+      const confidence = Math.min(0.38, confidenceFromScore(scored.score, hint.source, -0.08));
+      return candidate({
+        id: hint.id,
+        binding: { kind: 'metadata_hint' },
+        source: hint.source,
+        startSeconds: null,
+        endSeconds: null,
+        evidenceText: hint.evidenceText,
+        matchReasons: [...scored.reasons, '这只是视频信息中的弱提示'],
+        confidence,
+        note: '仅能说明当前视频信息相关，无法定位到具体时间点。',
+      });
+    })
+    .filter((item): item is CurrentVideoSegmentRetrievalCandidate => Boolean(item))
+    .sort((a, b) => b.confidence - a.confidence)
+    .slice(0, limit);
+}
+
+function mergeAndRankCandidates(
+  candidates: CurrentVideoSegmentRetrievalCandidate[],
+  limit: number,
+): CurrentVideoSegmentRetrievalCandidate[] {
+  const byId = new Map<string, CurrentVideoSegmentRetrievalCandidate>();
+  for (const item of candidates) {
+    const existing = byId.get(item.id);
+    if (!existing) {
+      byId.set(item.id, item);
+      continue;
+    }
+
+    byId.set(item.id, {
+      ...existing,
+      source: preferSource(existing.source, item.source),
+      sourceLabel: sourceLabel(preferSource(existing.source, item.source)),
+      binding: {
+        kind: existing.binding.kind,
+        segmentId: existing.binding.segmentId ?? item.binding.segmentId ?? null,
+        nodeId: existing.binding.nodeId ?? item.binding.nodeId ?? null,
+      },
+      confidence: roundScore(Math.max(existing.confidence, item.confidence)),
+      confidenceLabel: confidenceLabel(Math.max(existing.confidence, item.confidence)),
+      matchReasons: uniqueReasons([...existing.matchReasons, ...item.matchReasons]).slice(0, 4),
+      evidenceText: existing.evidenceText.length >= item.evidenceText.length
+        ? existing.evidenceText
+        : item.evidenceText,
+    });
+  }
+
+  return Array.from(byId.values())
+    .sort((a, b) =>
+      b.confidence - a.confidence
+      || (a.startSeconds ?? Number.MAX_SAFE_INTEGER) - (b.startSeconds ?? Number.MAX_SAFE_INTEGER),
+    )
+    .slice(0, limit);
+}
+
+function scoreText(profile: QueryProfile, text: string | null | undefined): ScoreResult {
+  const normalized = normalizeText(text);
+  if (!normalized || profile.terms.length === 0) {
+    return { score: 0, reasons: [], matchedTerms: [], exact: false };
+  }
+
+  const compact = compactText(normalized);
+  const matchedTerms = uniqueTerms(profile.terms.filter(term => compact.includes(term)));
+  const totalWeight = profile.terms.reduce((sum, term) => sum + termWeight(term), 0);
+  const matchedWeight = matchedTerms.reduce((sum, term) => sum + termWeight(term), 0);
+  const coverage = totalWeight > 0 ? matchedWeight / totalWeight : 0;
+  const exact = Boolean(profile.meaningfulCompact && compact.includes(profile.meaningfulCompact));
+  const latinExact = profile.latinTerms.length > 0 && profile.latinTerms.every(term => compact.includes(term));
+  const cjkCoverage = profile.cjkTerms.length > 0
+    ? matchedTerms.filter(term => profile.cjkTerms.includes(term)).length / profile.cjkTerms.length
+    : 0;
+
+  let score = coverage * 0.58;
+  if (exact) score += 0.28;
+  if (latinExact) score += 0.18;
+  if (cjkCoverage >= 0.5) score += 0.14;
+  if (matchedTerms.length >= 2) score += 0.06;
+  if (matchedTerms.length === 1 && matchedTerms[0].length <= 2) score -= 0.03;
+
+  const reasons: string[] = [];
+  if (exact) {
+    reasons.push(`证据文本包含完整关键词“${limitText(profile.original, 26)}”`);
+  }
+  if (latinExact && !exact) {
+    reasons.push(`证据文本命中 ${profile.latinTerms.slice(0, 3).join('、')}`);
+  }
+  if (matchedTerms.length > 0) {
+    reasons.push(`和问题词有重叠：${matchedTerms.slice(0, 5).join('、')}`);
+  }
+  if (cjkCoverage >= 0.5 && profile.cjkTerms.length > 0) {
+    reasons.push('中文短语有连续重叠');
+  }
+
+  return {
+    score: roundScore(Math.max(0, Math.min(1, score))),
+    reasons: uniqueReasons(reasons),
+    matchedTerms,
+    exact,
+  };
+}
+
+function filterCurrentTranscriptSegments(
+  context: CurrentVideoContext,
+  segments: CurrentVideoTranscriptSegment[],
+): CurrentVideoTranscriptSegment[] {
+  const evidence = context.transcriptEvidence;
+  if (
+    !context.cid
+    || evidence?.active !== true
+    || evidence.bvid !== context.bvid
+    || evidence.cid !== context.cid
+    || evidence.page !== context.currentPart.page
+    || !evidence.sourceHash
+  ) {
+    return [];
+  }
+
+  const expectedLanguage = languageKey(evidence.language);
+  return segments
+    .filter(segment =>
+      segment.bvid === context.bvid
+      && segment.cid === context.cid
+      && segment.page === context.currentPart.page
+      && !segment.stale
+      && segment.sourceHash === evidence.sourceHash
+      && (!evidence.language || languageKey(segment.language) === expectedLanguage)
+      && Number.isFinite(segment.startSeconds)
+      && Number.isFinite(segment.endSeconds)
+      && segment.endSeconds > segment.startSeconds
+      && Boolean(normalizeText(segment.text)),
+    )
+    .sort((a, b) => a.startSeconds - b.startSeconds || a.endSeconds - b.endSeconds);
+}
+
+function filterCurrentKnowledgeNodes(
+  context: CurrentVideoContext,
+  nodes: VideoKnowledgeNode[],
+): VideoKnowledgeNode[] {
+  return nodes.filter(node =>
+    node.bvid === context.bvid
+    && node.page === context.currentPart.page
+    && (node.cid === null || context.cid === null || node.cid === context.cid)
+    && (
+      node.source === 'transcript'
+      || node.source === 'chapter'
+      || node.source === 'page'
+      || node.source === 'metadata'
+      || node.source === 'description'
+    ),
+  );
+}
+
+function knowledgeCandidateSource(node: VideoKnowledgeNode): CurrentVideoSegmentRetrievalCandidateSource | null {
+  if (node.source === 'transcript' && (node.evidence?.segmentId || node.timestamp !== null)) {
+    return 'transcript_node';
+  }
+  if (node.source === 'chapter' && node.timestamp !== null) return 'chapter_node';
+  if (node.source === 'page' && node.timestamp !== null) return 'page_node';
+  return null;
+}
+
+function scoreContextWeakHints(context: CurrentVideoContext, profile: QueryProfile): number {
+  const text = [
+    context.title,
+    context.currentPart.title,
+    context.description.text,
+    ...context.chapters.map(chapter => chapter.title),
+    ...context.parts.map(part => part.title),
+  ].filter(Boolean).join(' ');
+  return scoreText(profile, text).score;
+}
+
+function hasMetadataHint(context: CurrentVideoContext): boolean {
+  return Boolean(
+    normalizeText(context.title)
+    || normalizeText(context.currentPart.title)
+    || normalizeText(context.description.text),
+  );
+}
+
+function candidate(input: {
+  id: string;
+  binding: CurrentVideoSegmentRetrievalCandidate['binding'];
+  source: CurrentVideoSegmentRetrievalCandidateSource;
+  startSeconds: number | null;
+  endSeconds: number | null;
+  evidenceText: string;
+  matchReasons: string[];
+  confidence: number;
+  note?: string | null;
+}): CurrentVideoSegmentRetrievalCandidate {
+  const confidence = roundScore(Math.max(0, Math.min(1, input.confidence)));
+  return {
+    id: input.id,
+    binding: input.binding,
+    source: input.source,
+    sourceLabel: sourceLabel(input.source),
+    startSeconds: input.startSeconds,
+    endSeconds: input.endSeconds,
+    timeRangeLabel: formatTimeRange(input.startSeconds, input.endSeconds),
+    evidenceText: limitText(input.evidenceText, EVIDENCE_TEXT_LIMIT),
+    matchReasons: uniqueReasons(input.matchReasons).slice(0, 4),
+    confidence,
+    confidenceLabel: confidenceLabel(confidence),
+    note: input.note ?? (confidence < LOW_CONFIDENCE_THRESHOLD ? '匹配较弱，建议换成更具体的关键词。' : null),
+  };
+}
+
+function result(input: {
+  status: CurrentVideoSegmentRetrievalStatus;
+  context: CurrentVideoContextResult;
+  profile: QueryProfile;
+  now: number;
+  candidates: CurrentVideoSegmentRetrievalCandidate[];
+  summary: string;
+  limitations: string[];
+  evidenceState?: {
+    transcriptSegmentCount: number;
+    timedKnowledgeNodeCount: number;
+    metadataHintAvailable: boolean;
+  };
+  contextFresh: boolean;
+}): CurrentVideoSegmentRetrievalResult {
+  const videoContext = input.context.kind === 'video' ? input.context : null;
+  const fallbackEvidenceState = {
+    transcriptSegmentCount: input.candidates.filter(candidate => candidate.binding.segmentId).length,
+    timedKnowledgeNodeCount: input.candidates.filter(candidate =>
+      candidate.binding.kind === 'video_knowledge_node'
+      || candidate.binding.nodeId,
+    ).length,
+    metadataHintAvailable: input.candidates.some(candidate => candidate.binding.kind === 'metadata_hint'),
+  };
+  const evidenceState = input.evidenceState ?? fallbackEvidenceState;
+
+  return {
+    status: input.status,
+    query: input.profile.original,
+    normalizedQuery: input.profile.normalized,
+    title: videoContext?.title ?? videoContext?.bvid ?? '当前视频',
+    generatedAt: input.now,
+    candidates: input.candidates,
+    summary: input.summary,
+    limitations: input.limitations,
+    evidenceState: {
+      transcriptSegmentCount: evidenceState.transcriptSegmentCount,
+      timedKnowledgeNodeCount: evidenceState.timedKnowledgeNodeCount,
+      metadataHintAvailable: evidenceState.metadataHintAvailable,
+      contextFresh: input.contextFresh,
+    },
+  };
+}
+
+function buildQueryProfile(query: string): QueryProfile {
+  const original = normalizeText(query);
+  const normalized = normalizeSearchText(original);
+  const compact = compactText(normalized);
+  const meaningfulCompact = stripQueryHelpers(compact);
+  const latinTerms = uniqueTerms(
+    (normalized.match(/[a-z0-9]+(?:\.[a-z0-9]+)*/g) ?? [])
+      .map(compactText)
+      .filter(term => term.length >= 2),
+  );
+  const cjkTerms = buildCjkTerms(normalized);
+  const terms = uniqueTerms([
+    meaningfulCompact.length >= 2 ? meaningfulCompact : '',
+    ...latinTerms,
+    ...cjkTerms,
+  ].filter(Boolean));
+
+  return {
+    original,
+    normalized,
+    compact,
+    meaningfulCompact,
+    terms,
+    cjkTerms,
+    latinTerms,
+  };
+}
+
+function buildCjkTerms(value: string): string[] {
+  const sequences = value.match(/\p{Script=Han}+/gu) ?? [];
+  const terms: string[] = [];
+  for (const sequence of sequences) {
+    const stripped = stripQueryHelpers(sequence);
+    if (stripped.length < 2) continue;
+    if (stripped.length <= 8) terms.push(stripped);
+    for (let size = 2; size <= Math.min(4, stripped.length); size += 1) {
+      for (let index = 0; index <= stripped.length - size; index += 1) {
+        const term = stripped.slice(index, index + size);
+        if (!QUERY_HELPER_WORDS.includes(term)) terms.push(term);
+      }
+    }
+  }
+  return uniqueTerms(terms);
+}
+
+function stripQueryHelpers(value: string): string {
+  let next = value;
+  for (const word of QUERY_HELPER_WORDS) {
+    next = next.replaceAll(word, '');
+  }
+  return next;
+}
+
+function confidenceFromScore(
+  score: number,
+  source: CurrentVideoSegmentRetrievalCandidateSource,
+  qualityBonus: number,
+): number {
+  const sourceBonus = source === 'transcript_segment'
+    ? 0.16
+    : source === 'transcript_node'
+      ? 0.12
+      : source === 'chapter_node'
+        ? 0.02
+        : source === 'page_node'
+          ? -0.03
+          : -0.14;
+  return roundScore(0.22 + score * 0.58 + sourceBonus + qualityBonus);
+}
+
+function capWeakConfidence(rawScore: number, confidence: number): number {
+  if (rawScore < 0.12) return Math.min(confidence, 0.42);
+  if (rawScore < 0.2) return Math.min(confidence, 0.48);
+  return confidence;
+}
+
+function segmentTextQuality(segment: CurrentVideoTranscriptSegment): number {
+  const textLength = normalizeText(segment.text).length;
+  const duration = segment.endSeconds - segment.startSeconds;
+  let quality = 0;
+  if (textLength >= 18) quality += 0.04;
+  if (textLength >= 40) quality += 0.03;
+  if (duration >= 1 && duration <= 30) quality += 0.03;
+  return quality;
+}
+
+function sourceLabel(source: CurrentVideoSegmentRetrievalCandidateSource): string {
+  switch (source) {
+    case 'transcript_segment':
+      return '可定位字幕证据';
+    case 'transcript_node':
+      return '本地字幕节点';
+    case 'chapter_node':
+      return '章节弱提示';
+    case 'page_node':
+      return '分 P 弱提示';
+    case 'metadata_hint':
+      return '视频信息弱提示';
+    case 'description_hint':
+      return '简介弱提示';
+    default:
+      return '本地证据';
+  }
+}
+
+function preferSource(
+  a: CurrentVideoSegmentRetrievalCandidateSource,
+  b: CurrentVideoSegmentRetrievalCandidateSource,
+): CurrentVideoSegmentRetrievalCandidateSource {
+  const priority: CurrentVideoSegmentRetrievalCandidateSource[] = [
+    'transcript_segment',
+    'transcript_node',
+    'chapter_node',
+    'page_node',
+    'description_hint',
+    'metadata_hint',
+  ];
+  return priority.indexOf(a) <= priority.indexOf(b) ? a : b;
+}
+
+function confidenceLabel(confidence: number): CurrentVideoSegmentRetrievalConfidenceLabel {
+  if (confidence >= HIGH_CONFIDENCE_THRESHOLD) return '高';
+  if (confidence >= MEDIUM_CONFIDENCE_THRESHOLD) return '中';
+  return '低';
+}
+
+function formatTimeRange(start: number | null, end: number | null): string {
+  if (start === null) return '无法定位具体时间';
+  if (typeof end === 'number' && end > start) {
+    return `${formatDuration(start)}-${formatDuration(end)}`;
+  }
+  return formatDuration(start);
+}
+
+function formatDuration(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+  const rest = safe % 60;
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(rest).padStart(2, '0')}`;
+  }
+  return `${minutes}:${String(rest).padStart(2, '0')}`;
+}
+
+function termWeight(term: string): number {
+  if (/^[a-z0-9.]+$/i.test(term)) return Math.min(4, Math.max(1.4, term.length / 2));
+  return Math.min(4, Math.max(1, term.length - 1));
+}
+
+function uniqueTerms(values: string[]): string[] {
+  return Array.from(new Set(values.map(value => value.trim()).filter(Boolean)));
+}
+
+function uniqueReasons(values: string[]): string[] {
+  return Array.from(new Set(values.map(value => value.trim()).filter(Boolean)));
+}
+
+function normalizeSearchText(value: string): string {
+  return normalizeText(value).normalize('NFKC').toLowerCase();
+}
+
+function normalizeText(value: string | null | undefined): string {
+  return (value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function compactText(value: string): string {
+  return normalizeSearchText(value).replace(/[^\p{Script=Han}a-z0-9.]+/gu, '');
+}
+
+function limitText(value: string, maxLength: number): string {
+  const normalized = normalizeText(value);
+  if (normalized.length <= maxLength) return normalized;
+  if (maxLength <= 3) return normalized.slice(0, maxLength);
+  return `${normalized.slice(0, maxLength - 3)}...`;
+}
+
+function roundScore(value: number): number {
+  return Math.round(Math.max(0, Math.min(1, value)) * 100) / 100;
+}
+
+function languageKey(value: string | null | undefined): string {
+  return (value ?? 'unknown').trim().toLowerCase() || 'unknown';
+}

--- a/src/shared/types/current-video-segment-retrieval.ts
+++ b/src/shared/types/current-video-segment-retrieval.ts
@@ -1,0 +1,58 @@
+export type CurrentVideoSegmentRetrievalStatus =
+  | 'ready'
+  | 'empty_query'
+  | 'no_context'
+  | 'stale_context'
+  | 'no_evidence'
+  | 'metadata_only'
+  | 'low_confidence';
+
+export type CurrentVideoSegmentRetrievalCandidateSource =
+  | 'transcript_segment'
+  | 'transcript_node'
+  | 'chapter_node'
+  | 'page_node'
+  | 'metadata_hint'
+  | 'description_hint';
+
+export type CurrentVideoSegmentRetrievalConfidenceLabel = '高' | '中' | '低';
+
+export interface CurrentVideoSegmentRetrievalCandidateBinding {
+  kind: 'transcript_segment' | 'video_knowledge_node' | 'metadata_hint';
+  segmentId?: string | null;
+  nodeId?: string | null;
+}
+
+export interface CurrentVideoSegmentRetrievalCandidate {
+  id: string;
+  binding: CurrentVideoSegmentRetrievalCandidateBinding;
+  source: CurrentVideoSegmentRetrievalCandidateSource;
+  sourceLabel: string;
+  startSeconds: number | null;
+  endSeconds: number | null;
+  timeRangeLabel: string;
+  evidenceText: string;
+  matchReasons: string[];
+  confidence: number;
+  confidenceLabel: CurrentVideoSegmentRetrievalConfidenceLabel;
+  note: string | null;
+}
+
+export interface CurrentVideoSegmentRetrievalEvidenceState {
+  transcriptSegmentCount: number;
+  timedKnowledgeNodeCount: number;
+  metadataHintAvailable: boolean;
+  contextFresh: boolean;
+}
+
+export interface CurrentVideoSegmentRetrievalResult {
+  status: CurrentVideoSegmentRetrievalStatus;
+  query: string;
+  normalizedQuery: string;
+  title: string;
+  generatedAt: number;
+  candidates: CurrentVideoSegmentRetrievalCandidate[];
+  summary: string;
+  limitations: string[];
+  evidenceState: CurrentVideoSegmentRetrievalEvidenceState;
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -2,6 +2,7 @@ export * from './watch-event';
 export * from './video-info';
 export * from './current-video-context';
 export * from './current-video-transcript';
+export * from './current-video-segment-retrieval';
 export * from './analytics';
 export * from './messages';
 export * from './config';

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -29,6 +29,7 @@ import type {
 } from './favorite';
 import type { CurrentVideoContextResult, CurrentVideoSubtitleSourceState } from './current-video-context';
 import type { CurrentVideoTranscriptEvidenceState } from './current-video-transcript';
+import type { CurrentVideoSegmentRetrievalResult } from './current-video-segment-retrieval';
 import type { CurrentVideoSummaryResult } from './current-video-summary';
 import type { VideoKnowledgeJumpResponse, VideoKnowledgeResult } from './video-knowledge';
 import type { HistoryTailProbeReport } from './history-tail-probe';
@@ -56,6 +57,7 @@ export type RequestAction =
   | 'GET_CURRENT_VIDEO_TRANSCRIPT_EVIDENCE'
   | 'GET_CURRENT_VIDEO_SUMMARY'
   | 'GET_VIDEO_KNOWLEDGE'
+  | 'SEARCH_CURRENT_VIDEO_SEGMENTS'
   | 'REQUEST_VIDEO_KNOWLEDGE_JUMP'
   | 'GET_SMART_FAVORITES'
   | 'GET_SMART_FAVORITES_BY_PATH'
@@ -177,6 +179,7 @@ export type CurrentVideoSubtitleSourceResponse = BiliVizResponse<CurrentVideoSub
 export type CurrentVideoTranscriptEvidenceResponse = BiliVizResponse<CurrentVideoTranscriptEvidenceState>;
 export type CurrentVideoSummaryResponse = BiliVizResponse<CurrentVideoSummaryResult>;
 export type VideoKnowledgeResponse = BiliVizResponse<VideoKnowledgeResult>;
+export type CurrentVideoSegmentRetrievalResponse = BiliVizResponse<CurrentVideoSegmentRetrievalResult>;
 export type VideoKnowledgeJumpMessageResponse = BiliVizResponse<VideoKnowledgeJumpResponse>;
 export type DynamicBillOverviewResponse = BiliVizResponse<DynamicBillOverview>;
 export type DynamicSyncResponse = BiliVizResponse<DynamicSyncResult>;

--- a/tests/current-video-segment-retrieval.mock.html
+++ b/tests/current-video-segment-retrieval.mock.html
@@ -1,0 +1,167 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <title>Current Video Segment Retrieval Mock QA</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --panel: rgba(0, 161, 214, 0.08);
+      --line: rgba(127, 219, 255, 0.22);
+      --text: #f4f7fb;
+      --muted: #aeb4c4;
+      --blue: #c8e6ff;
+      --green: #a0e7a0;
+      --warn: #ffcf8a;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      width: 360px;
+      background: #161824;
+      color: var(--text);
+      font-family: Arial, "Microsoft YaHei", sans-serif;
+    }
+
+    main {
+      padding: 18px;
+      display: grid;
+      gap: 12px;
+    }
+
+    section {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--panel);
+      padding: 12px;
+    }
+
+    h1 {
+      margin: 0 0 8px;
+      color: var(--blue);
+      font-size: 13px;
+    }
+
+    .status {
+      color: var(--green);
+      font-size: 11px;
+      line-height: 1.5;
+    }
+
+    .candidate {
+      margin-top: 8px;
+      padding-top: 8px;
+      border-top: 1px solid rgba(255, 255, 255, 0.1);
+    }
+
+    .row {
+      display: flex;
+      justify-content: space-between;
+      gap: 8px;
+    }
+
+    .title {
+      min-width: 0;
+      font-size: 12px;
+      font-weight: 700;
+      line-height: 1.35;
+    }
+
+    .confidence {
+      flex: 0 0 auto;
+      color: var(--green);
+      font-size: 11px;
+    }
+
+    .confidence.low,
+    .warning {
+      color: var(--warn);
+    }
+
+    .meta,
+    .reason,
+    .evidence {
+      margin-top: 4px;
+      font-size: 11px;
+      line-height: 1.45;
+    }
+
+    .meta {
+      color: var(--muted);
+    }
+
+    .evidence {
+      color: var(--blue);
+    }
+
+    .reason {
+      color: #cfd3df;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section data-testid="retrieval-ready">
+      <h1>本地片段检索</h1>
+      <div class="status">找到 2 个基于当前视频本地证据的候选片段。</div>
+      <article class="candidate" data-testid="candidate-card">
+        <div class="row">
+          <div class="title">候选 1 · 0:24-0:32</div>
+          <div class="confidence">高 86%</div>
+        </div>
+        <div class="meta">来源 可定位字幕证据</div>
+        <div class="evidence">证据片段：接下来讲模型的整体架构，包括专家路由和参数组织。</div>
+        <div class="reason">匹配原因：和问题词有重叠：模型、架构；中文短语有连续重叠</div>
+      </article>
+      <article class="candidate" data-testid="node-card">
+        <div class="row">
+          <div class="title">候选 2 · 2:00</div>
+          <div class="confidence">中 68%</div>
+        </div>
+        <div class="meta">来源 章节弱提示</div>
+        <div class="evidence">证据片段：模型架构章节</div>
+        <div class="reason">匹配原因：命中当前视频本地节点提示</div>
+      </article>
+    </section>
+
+    <section data-testid="retrieval-low-confidence">
+      <h1>低置信状态</h1>
+      <div class="status warning">只找到低置信候选，请把问题写得更接近字幕原文或章节标题。</div>
+      <article class="candidate">
+        <div class="row">
+          <div class="title">候选 1 · 1:20-1:26</div>
+          <div class="confidence low">低 42%</div>
+        </div>
+        <div class="meta">来源 可定位字幕证据</div>
+        <div class="evidence">证据片段：最后补充一点模型之外的部署注意事项。</div>
+        <div class="reason">匹配原因：和问题词有重叠：模型</div>
+        <div class="warning">匹配较弱，建议换成更具体的关键词。</div>
+      </article>
+    </section>
+
+    <section data-testid="retrieval-no-evidence">
+      <h1>无证据状态</h1>
+      <div class="status warning">没有找到可用的本地证据。</div>
+      <div class="reason">没有字幕片段或本地关键节点时，不会编造时间点。</div>
+    </section>
+
+    <section data-testid="retrieval-metadata-only">
+      <h1>仅弱匹配</h1>
+      <div class="status warning">仅找到视频信息或简介中的弱匹配，无法定位到具体时间点。</div>
+      <article class="candidate">
+        <div class="row">
+          <div class="title">候选 1 · 无法定位具体时间</div>
+          <div class="confidence low">低 35%</div>
+        </div>
+        <div class="meta">来源 视频信息弱提示</div>
+        <div class="evidence">证据片段：DeepSeek V3.2 发布会重点回顾</div>
+        <div class="reason">匹配原因：这只是视频信息中的弱提示</div>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/tests/current-video-segment-retrieval.test.ts
+++ b/tests/current-video-segment-retrieval.test.ts
@@ -1,0 +1,275 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { searchCurrentVideoSegments } from '../src/shared/current-video-segment-retrieval.ts';
+import { buildVideoKnowledgeResult } from '../src/shared/video-knowledge.ts';
+import type { CurrentVideoContext, CurrentVideoContextResult } from '../src/shared/types/current-video-context.ts';
+import type { CurrentVideoTranscriptSegment } from '../src/shared/types/current-video-transcript.ts';
+
+test('returns an exact local transcript keyword match without inventing timestamps', () => {
+  const context = withTranscriptEvidence(videoContext());
+  const segments = transcriptSegments();
+  const result = searchCurrentVideoSegments(context, {
+    query: 'DeepSeek V3.2 那段',
+    transcriptSegments: segments,
+    videoKnowledge: buildVideoKnowledgeResult(context, { transcriptSegments: segments, now: 3000 }),
+    now: 3000,
+  });
+
+  assert.equal(result.status, 'ready');
+  assert.equal(result.candidates[0].binding.segmentId, segments[0].segmentId);
+  assert.equal(result.candidates[0].timeRangeLabel, '0:12-0:18');
+  assert.equal(result.candidates[0].sourceLabel, '可定位字幕证据');
+  assert.ok(result.candidates[0].confidence >= 0.78);
+  assert.ok(result.candidates[0].matchReasons.some(reason => reason.includes('deepseek')));
+  assert.equal(result.candidates[0].binding.segmentId?.startsWith('transcript:'), true);
+  assert.doesNotMatch(JSON.stringify(result), /watchHistory|favorites|following|feedback|Cookie|Key\.txt|Chrome\\User Data/i);
+});
+
+test('matches a Chinese fuzzy phrase by token and n-gram overlap', () => {
+  const context = withTranscriptEvidence(videoContext());
+  const segments = transcriptSegments();
+  const result = searchCurrentVideoSegments(context, {
+    query: '讲模型架构的地方',
+    transcriptSegments: segments,
+    videoKnowledge: buildVideoKnowledgeResult(context, { transcriptSegments: segments, now: 3000 }),
+    now: 3000,
+  });
+
+  assert.equal(result.status, 'ready');
+  assert.equal(result.candidates[0].binding.segmentId, segments[1].segmentId);
+  assert.equal(result.candidates[0].timeRangeLabel, '0:24-0:32');
+  assert.ok(result.candidates[0].evidenceText.includes('模型'));
+  assert.ok(result.candidates[0].matchReasons.some(reason => reason.includes('中文短语') || reason.includes('模型')));
+});
+
+test('uses a weak metadata helper only when no timed evidence is available', () => {
+  const context = videoContext({
+    title: 'DeepSeek V3.2 发布会重点回顾',
+    descriptionText: '简介提到 DeepSeek V3.2 与模型架构，但没有本地字幕正文。',
+  });
+  const result = searchCurrentVideoSegments(context, {
+    query: 'DeepSeek V3.2',
+    transcriptSegments: [],
+    videoKnowledge: buildVideoKnowledgeResult(context, { transcriptSegments: [], now: 3000 }),
+    now: 3000,
+  });
+
+  assert.equal(result.status, 'metadata_only');
+  assert.equal(result.candidates[0].startSeconds, null);
+  assert.equal(result.candidates[0].timeRangeLabel, '无法定位具体时间');
+  assert.equal(result.candidates[0].binding.kind, 'metadata_hint');
+  assert.ok(result.summary.includes('无法定位到具体时间点'));
+  assert.ok(result.candidates[0].note?.includes('无法定位到具体时间点'));
+});
+
+test('returns no evidence when neither transcript nor metadata matches', () => {
+  const context = videoContext({
+    title: '烘焙经验分享',
+    descriptionText: null,
+  });
+  const result = searchCurrentVideoSegments(context, {
+    query: '模型架构',
+    transcriptSegments: [],
+    videoKnowledge: buildVideoKnowledgeResult(context, { transcriptSegments: [], now: 3000 }),
+    now: 3000,
+  });
+
+  assert.equal(result.status, 'no_evidence');
+  assert.equal(result.candidates.length, 0);
+  assert.ok(result.limitations.some(item => item.includes('不会编造时间点')));
+});
+
+test('marks weak transcript overlap as low confidence', () => {
+  const context = withTranscriptEvidence(videoContext({
+    title: '部署注意事项',
+    descriptionText: null,
+  }));
+  const [first] = transcriptSegments();
+  const weakSegment: CurrentVideoTranscriptSegment = {
+    ...first,
+    segmentId: 'transcript:BV1Segment00:101:1:zh-cn:hash123:weak',
+    startSeconds: 80,
+    endSeconds: 86,
+    text: '最后补充一点模型之外的部署注意事项。',
+  };
+  const result = searchCurrentVideoSegments(context, {
+    query: '模型架构',
+    transcriptSegments: [weakSegment],
+    videoKnowledge: null,
+    now: 3000,
+  });
+
+  assert.equal(result.status, 'low_confidence');
+  assert.equal(result.candidates[0].confidenceLabel, '低');
+  assert.ok(result.candidates[0].note?.includes('匹配较弱'));
+});
+
+test('rejects stale current-video context', () => {
+  const context = withTranscriptEvidence(videoContext());
+  const result = searchCurrentVideoSegments(context, {
+    query: 'DeepSeek',
+    transcriptSegments: transcriptSegments(),
+    videoKnowledge: null,
+    now: 1000 + 10 * 60 * 1000 + 1,
+  });
+
+  assert.equal(result.status, 'stale_context');
+  assert.equal(result.candidates.length, 0);
+  assert.ok(result.summary.includes('已过期'));
+});
+
+test('does not use transcript segments when active evidence is absent', () => {
+  const context = videoContext({
+    title: 'Current local video',
+    descriptionText: null,
+  });
+  const result = searchCurrentVideoSegments(context, {
+    query: 'DeepSeek V3.2',
+    transcriptSegments: transcriptSegments(),
+    videoKnowledge: null,
+    now: 3000,
+  });
+
+  assert.equal(result.status, 'no_evidence');
+  assert.equal(result.candidates.length, 0);
+});
+
+test('uses current-video knowledge node matches without adding a jump action', () => {
+  const context = videoContext({
+    chapters: [{ title: '模型架构章节', startSeconds: 120 }],
+  });
+  const knowledge = buildVideoKnowledgeResult(context, { transcriptSegments: [], now: 3000 });
+  const result = searchCurrentVideoSegments(context, {
+    query: '模型架构',
+    transcriptSegments: [],
+    videoKnowledge: knowledge,
+    now: 3000,
+  });
+
+  assert.equal(result.status, 'ready');
+  assert.equal(result.candidates[0].binding.kind, 'video_knowledge_node');
+  assert.equal(result.candidates[0].sourceLabel, '章节弱提示');
+  assert.equal(result.candidates[0].timeRangeLabel, '2:00');
+  assert.equal('jumpAction' in result.candidates[0], false);
+});
+
+test('returns no context without reading broader local data', () => {
+  const context: CurrentVideoContextResult = {
+    kind: 'no_context',
+    url: 'https://www.bilibili.com/',
+    collectedAt: 1000,
+    reason: 'non_video_page',
+    pageType: 'non_video',
+  };
+  const result = searchCurrentVideoSegments(context, {
+    query: 'DeepSeek',
+    now: 3000,
+  });
+
+  assert.equal(result.status, 'no_context');
+  assert.equal(result.candidates.length, 0);
+  assert.ok(result.limitations.some(item => item.includes('不会从历史、收藏或账号资料')));
+});
+
+function videoContext(options: {
+  title?: string;
+  descriptionText?: string | null;
+  chapters?: CurrentVideoContext['chapters'];
+} = {}): CurrentVideoContext {
+  const descriptionText = 'descriptionText' in options
+    ? options.descriptionText
+    : '这是一段可见简介，提到模型架构和发布会背景。';
+  return {
+    kind: 'video',
+    url: 'https://www.bilibili.com/video/BV1Segment00',
+    collectedAt: 1000,
+    bvid: 'BV1Segment00',
+    cid: 101,
+    title: options.title ?? 'DeepSeek V3.2 技术解析',
+    authorName: 'Local UP',
+    authorMid: 42,
+    durationSeconds: 600,
+    currentPart: {
+      page: 1,
+      title: '正片',
+      total: 1,
+    },
+    parts: [{ page: 1, cid: 101, title: '正片', durationSeconds: 600 }],
+    chapters: options.chapters ?? [],
+    description: {
+      availability: descriptionText ? 'available' : 'unavailable',
+      text: descriptionText,
+      length: descriptionText?.length ?? null,
+    },
+    sources: {
+      metadata: 'available',
+      description: descriptionText ? 'available' : 'unavailable',
+      pages: 'available',
+      chapters: options.chapters?.length ? 'available' : 'unknown',
+      transcript: 'unavailable',
+      contentText: 'unavailable',
+    },
+    warnings: ['transcript_unavailable'],
+  };
+}
+
+function withTranscriptEvidence(context: CurrentVideoContext): CurrentVideoContext {
+  context.sources.transcript = 'available';
+  context.transcriptEvidence = {
+    status: 'cached',
+    active: true,
+    checkedAt: 2000,
+    bvid: context.bvid,
+    cid: context.cid,
+    page: context.currentPart.page,
+    language: 'zh-CN',
+    source: 'bilibili_subtitle',
+    sourceType: 'bilibili_player_wbi_v2',
+    sourceHash: 'hash123',
+    segmentCount: 3,
+    staleSegmentCount: 0,
+    coverageStartSeconds: 12,
+    coverageEndSeconds: 40,
+    fetchedAt: 2000,
+    updatedAt: 2000,
+    reason: 'transcript_segments_cached',
+    message: '已缓存字幕正文证据，仅作为本地证据状态展示。',
+    warnings: [],
+  };
+  return context;
+}
+
+function transcriptSegments(): CurrentVideoTranscriptSegment[] {
+  return [
+    {
+      segmentId: 'transcript:BV1Segment00:101:1:zh-cn:hash123:0',
+      startSeconds: 12,
+      endSeconds: 18,
+      text: 'DeepSeek V3.2 这一段先解释更新目标和上下文。',
+    },
+    {
+      segmentId: 'transcript:BV1Segment00:101:1:zh-cn:hash123:1',
+      startSeconds: 24,
+      endSeconds: 32,
+      text: '接下来讲模型的整体架构，包括专家路由和参数组织。',
+    },
+    {
+      segmentId: 'transcript:BV1Segment00:101:1:zh-cn:hash123:2',
+      startSeconds: 36,
+      endSeconds: 40,
+      text: '最后比较推理成本。',
+    },
+  ].map(segment => ({
+    ...segment,
+    bvid: 'BV1Segment00',
+    cid: 101,
+    page: 1,
+    language: 'zh-CN',
+    source: 'bilibili_subtitle' as const,
+    sourceType: 'bilibili_player_wbi_v2' as const,
+    sourceHash: 'hash123',
+    stale: false,
+    fetchedAt: 2000,
+    updatedAt: 2000,
+  }));
+}


### PR DESCRIPTION
﻿## Scope

Refs #103.

Adds local-first fuzzy segment retrieval for the current video:

- New shared retrieval core for current-video transcript segments and Video Knowledge nodes.
- New `SEARCH_CURRENT_VIDEO_SEGMENTS` message action in the service worker.
- Popup input and candidate cards showing time range, evidence text, source label, match reasons, confidence, and Chinese no-evidence / low-confidence states.
- Focused tests for exact keyword, Chinese fuzzy phrase overlap, metadata-only fallback, no evidence, low confidence, stale context, no transcript evidence, and local knowledge-node hits.
- Static mock QA page for candidate rendering states.

## Root Cause / Product Judgment

The previous current-video slices could cache transcript evidence and generate Video Knowledge nodes, but the UI had no local retrieval surface for vague user requests like “DeepSeek V3.2 那段” or “讲模型架构的地方”. This PR keeps the slice bounded and read-only: candidates come only from active current-video transcript segments or existing Video Knowledge node time ranges. Metadata and description can only produce a weak helper result that explicitly says it cannot locate a concrete moment.

## Validation

- `node --test tests/current-video-segment-retrieval.test.ts`
- `npm run test:video-knowledge`
- `npm run test:current-video-transcript`
- `npm run test:current-video-summary`
- `npm run typecheck`
- `npm run build`
  - Passed with existing Vite warnings about dynamic imports and large chunks.
- `git diff --check`
  - Passed; only Windows LF/CRLF normalization warnings appeared before staging, staged check was clean.
- `rg -n "未消费|猜你喜欢" dashboard popup public src README.md tests`
  - No matches.
- `rg -n "transcript:BV|sourceHash|hash123|segmentId" popup dist\popup.js tests\current-video-segment-retrieval.mock.html`
  - No matches in ordinary popup/mock UI output.
- Diff scan for newly added `seek` / jump behavior in this slice:
  - No matches.
- Browser/mock QA:
  - Served `tests/current-video-segment-retrieval.mock.html` locally and verified candidate, low-confidence, no-evidence, and metadata-only states.
  - Verified action control count was `0` and forbidden raw/internal text was absent.

## Blocker / Must Fix / Follow-up

- Blocker: none.
- Must fix before merge: none known.
- Follow-up: #104 can add explicit player navigation if desired; #105 can add AI rerank. This PR intentionally does neither.

## Privacy Boundaries

- Local-first only; no AI call or upload path was added.
- Did not read Cookie files, browser profiles, login-state files, local key files, feedback, full history, full favorites, or full following data.
- The retrieval core only receives current-video bounded evidence: active cached transcript segments, current Video Knowledge nodes, and visible current-video metadata/description/page/chapter hints.
- Internal `segmentId` / `sourceHash` can remain in bindings for tests and background logic, but the popup candidate cards do not display raw internal evidence IDs.
