### PR TITLE
[codex] Add confirmed current-video timestamp jump

### DIFF
--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -13,6 +13,8 @@ import type { CurrentVideoTranscriptEvidenceState } from '../src/shared/types/cu
 import type {
   CurrentVideoSegmentRetrievalCandidate,
   CurrentVideoSegmentRetrievalResult,
+  CurrentVideoTimestampJumpResponse,
+  CurrentVideoTimestampReturnResponse,
 } from '../src/shared/types/current-video-segment-retrieval';
 import type { CurrentVideoSummaryResult } from '../src/shared/types/current-video-summary';
 import type { VideoKnowledgeJumpResponse, VideoKnowledgeNode, VideoKnowledgeResult } from '../src/shared/types/video-knowledge';
@@ -539,17 +541,26 @@ function CurrentVideoAssistantStatus({
   const [segmentResult, setSegmentResult] = useState<CurrentVideoSegmentRetrievalResult | null>(null);
   const [segmentLoading, setSegmentLoading] = useState(false);
   const [segmentError, setSegmentError] = useState<string | null>(null);
+  const [segmentPreviewCandidateId, setSegmentPreviewCandidateId] = useState<string | null>(null);
+  const [segmentJumpStatus, setSegmentJumpStatus] = useState<string | null>(null);
+  const [segmentReturnAvailable, setSegmentReturnAvailable] = useState(false);
 
   async function searchCurrentVideoSegments() {
     const query = segmentQuery.trim();
     if (!query) {
       setSegmentError('请输入想查找的片段内容。');
       setSegmentResult(null);
+      setSegmentPreviewCandidateId(null);
+      setSegmentJumpStatus(null);
+      setSegmentReturnAvailable(false);
       return;
     }
 
     setSegmentLoading(true);
     setSegmentError(null);
+    setSegmentPreviewCandidateId(null);
+    setSegmentJumpStatus(null);
+    setSegmentReturnAvailable(false);
     try {
       const result = await requestSW<CurrentVideoSegmentRetrievalResult>('SEARCH_CURRENT_VIDEO_SEGMENTS', {
         query,
@@ -560,6 +571,39 @@ function CurrentVideoAssistantStatus({
       setSegmentResult(null);
     } finally {
       setSegmentLoading(false);
+    }
+  }
+
+  async function confirmSegmentJump(candidate: CurrentVideoSegmentRetrievalCandidate) {
+    if (!segmentResult) return;
+    if (!candidate.jumpPreview.canJump) {
+      setSegmentJumpStatus(candidate.jumpPreview.message);
+      return;
+    }
+
+    setSegmentJumpStatus('正在确认跳转...');
+    try {
+      const result = await requestSW<CurrentVideoTimestampJumpResponse>('REQUEST_CURRENT_VIDEO_SEGMENT_JUMP', {
+        query: segmentResult.query,
+        candidateId: candidate.id,
+        confirmed: true,
+      });
+      setSegmentJumpStatus(result.message);
+      setSegmentReturnAvailable(result.ok && result.returnPointSeconds !== null);
+    } catch (e) {
+      setSegmentJumpStatus((e as Error).message);
+      setSegmentReturnAvailable(false);
+    }
+  }
+
+  async function returnSegmentJump() {
+    setSegmentJumpStatus('正在返回原位置...');
+    try {
+      const result = await requestSW<CurrentVideoTimestampReturnResponse>('RETURN_CURRENT_VIDEO_SEGMENT_JUMP');
+      setSegmentJumpStatus(result.message);
+      if (result.ok) setSegmentReturnAvailable(false);
+    } catch (e) {
+      setSegmentJumpStatus((e as Error).message);
     }
   }
 
@@ -677,8 +721,14 @@ function CurrentVideoAssistantStatus({
             result={segmentResult}
             loading={segmentLoading}
             error={segmentError}
+            previewCandidateId={segmentPreviewCandidateId}
+            jumpStatus={segmentJumpStatus}
+            returnAvailable={segmentReturnAvailable}
             onQueryChange={setSegmentQuery}
             onSearch={searchCurrentVideoSegments}
+            onPreviewCandidate={setSegmentPreviewCandidateId}
+            onConfirmJump={confirmSegmentJump}
+            onReturn={returnSegmentJump}
           />
           <div style={{ display: 'flex', gap: '6px', marginTop: '8px' }}>
             <button
@@ -738,16 +788,29 @@ function CurrentVideoSegmentRetrievalPanel({
   result,
   loading,
   error,
+  previewCandidateId,
+  jumpStatus,
+  returnAvailable,
   onQueryChange,
   onSearch,
+  onPreviewCandidate,
+  onConfirmJump,
+  onReturn,
 }: {
   query: string;
   result: CurrentVideoSegmentRetrievalResult | null;
   loading: boolean;
   error: string | null;
+  previewCandidateId: string | null;
+  jumpStatus: string | null;
+  returnAvailable: boolean;
   onQueryChange: (query: string) => void;
   onSearch: () => void;
+  onPreviewCandidate: (candidateId: string | null) => void;
+  onConfirmJump: (candidate: CurrentVideoSegmentRetrievalCandidate) => void;
+  onReturn: () => void;
 }) {
+  const previewCandidate = result?.candidates.find(candidate => candidate.id === previewCandidateId) ?? null;
   return (
     <div style={{
       marginTop: '8px',
@@ -800,7 +863,7 @@ function CurrentVideoSegmentRetrievalPanel({
         </button>
       </form>
       <div style={{ color: '#A0A0B0', fontSize: '9px', lineHeight: 1.45, marginTop: '5px' }}>
-        只查当前视频本地已有证据；结果只展示候选时间和证据，不提供跳转。
+        只查当前视频本地已有证据；候选必须预览并确认后才会跳转，不会自动改变播放位置。
       </div>
       {error && (
         <div style={{ color: '#FFB347', fontSize: '10px', lineHeight: 1.45, marginTop: '6px' }}>
@@ -818,8 +881,46 @@ function CurrentVideoSegmentRetrievalPanel({
             </div>
           ) : (
             result.candidates.map((candidate, index) => (
-              <SegmentCandidateCard key={candidate.id} candidate={candidate} index={index} />
+              <SegmentCandidateCard
+                key={candidate.id}
+                candidate={candidate}
+                index={index}
+                selected={candidate.id === previewCandidateId}
+                onPreview={onPreviewCandidate}
+              />
             ))
+          )}
+          {previewCandidate && (
+            <SegmentJumpPreview
+              candidate={previewCandidate}
+              onConfirm={onConfirmJump}
+              onCancel={() => onPreviewCandidate(null)}
+            />
+          )}
+          {jumpStatus && (
+            <div style={{ color: jumpStatus.includes('不能') || jumpStatus.includes('不可') || jumpStatus.includes('过期') ? '#FFCF8A' : '#A0E7A0', fontSize: '10px', lineHeight: 1.45, marginTop: '6px' }}>
+              {jumpStatus}
+            </div>
+          )}
+          {returnAvailable && (
+            <button
+              type="button"
+              onClick={onReturn}
+              style={{
+                marginTop: '6px',
+                width: '100%',
+                background: 'rgba(255, 179, 71, 0.18)',
+                color: '#FFCF8A',
+                border: '1px solid rgba(255, 179, 71, 0.34)',
+                borderRadius: '6px',
+                cursor: 'pointer',
+                fontSize: '10px',
+                fontWeight: 700,
+                padding: '5px 7px',
+              }}
+            >
+              返回原位置
+            </button>
           )}
         </div>
       )}
@@ -830,10 +931,15 @@ function CurrentVideoSegmentRetrievalPanel({
 function SegmentCandidateCard({
   candidate,
   index,
+  selected,
+  onPreview,
 }: {
   candidate: CurrentVideoSegmentRetrievalCandidate;
   index: number;
+  selected: boolean;
+  onPreview: (candidateId: string | null) => void;
 }) {
+  const canJump = candidate.jumpPreview.canJump;
   return (
     <div style={{
       marginTop: '6px',
@@ -867,6 +973,99 @@ function SegmentCandidateCard({
           {candidate.note}
         </div>
       )}
+      <div style={{ color: canJump ? '#A0E7A0' : '#FFCF8A', fontSize: '9px', lineHeight: 1.4, marginTop: '3px' }}>
+        {candidate.jumpPreview.message}
+      </div>
+      <button
+        type="button"
+        disabled={!canJump}
+        onClick={() => onPreview(selected ? null : candidate.id)}
+        style={{
+          marginTop: '5px',
+          background: canJump ? 'rgba(0, 161, 214, 0.20)' : 'rgba(255, 255, 255, 0.06)',
+          color: canJump ? '#C8E6FF' : '#9090A0',
+          border: canJump ? '1px solid rgba(127, 219, 255, 0.32)' : '1px solid rgba(255,255,255,0.10)',
+          borderRadius: '6px',
+          cursor: canJump ? 'pointer' : 'default',
+          fontSize: '10px',
+          padding: '4px 7px',
+          opacity: canJump ? 1 : 0.75,
+        }}
+      >
+        {canJump ? (selected ? '收起预览' : '预览跳转') : '不可跳转'}
+      </button>
+    </div>
+  );
+}
+
+function SegmentJumpPreview({
+  candidate,
+  onConfirm,
+  onCancel,
+}: {
+  candidate: CurrentVideoSegmentRetrievalCandidate;
+  onConfirm: (candidate: CurrentVideoSegmentRetrievalCandidate) => void;
+  onCancel: () => void;
+}) {
+  const preview = candidate.jumpPreview;
+  return (
+    <div style={{
+      marginTop: '8px',
+      padding: '8px',
+      border: '1px solid rgba(255,179,71,0.28)',
+      borderRadius: '6px',
+      background: 'rgba(255,179,71,0.08)',
+    }}>
+      <div style={{ color: '#FFCF8A', fontSize: '10px', lineHeight: 1.45, fontWeight: 700 }}>
+        确认跳转前预览
+      </div>
+      <div style={{ color: '#E8E8F2', fontSize: '10px', lineHeight: 1.45, marginTop: '4px' }}>
+        目标时间：{preview.targetTimeLabel ?? candidate.timeRangeLabel}
+      </div>
+      <div style={{ color: '#A0A0B0', fontSize: '9px', lineHeight: 1.45, marginTop: '2px' }}>
+        来源：{preview.sourceLabel}；置信度：{preview.confidenceLabel} {Math.round(preview.confidence * 100)}%
+      </div>
+      <div style={{ color: '#C8E6FF', fontSize: '9px', lineHeight: 1.45, marginTop: '3px' }}>
+        证据预览：{preview.evidencePreview || '暂无可展示文本'}
+      </div>
+      <div style={{ color: preview.canJump ? '#A0E7A0' : '#FFCF8A', fontSize: '9px', lineHeight: 1.45, marginTop: '3px' }}>
+        {preview.message}
+      </div>
+      <div style={{ display: 'flex', gap: '6px', marginTop: '6px' }}>
+        <button
+          type="button"
+          disabled={!preview.canJump}
+          onClick={() => onConfirm(candidate)}
+          style={{
+            flex: 1,
+            background: preview.canJump ? '#FFB347' : 'rgba(255,255,255,0.08)',
+            color: preview.canJump ? '#1A1A2E' : '#9090A0',
+            border: 'none',
+            borderRadius: '6px',
+            cursor: preview.canJump ? 'pointer' : 'default',
+            fontSize: '10px',
+            fontWeight: 700,
+            padding: '5px 7px',
+          }}
+        >
+          确认跳转
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          style={{
+            background: 'transparent',
+            color: '#C8C8D8',
+            border: '1px solid rgba(255,255,255,0.14)',
+            borderRadius: '6px',
+            cursor: 'pointer',
+            fontSize: '10px',
+            padding: '5px 7px',
+          }}
+        >
+          取消
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -7,6 +7,10 @@ import type {
   CurrentVideoSubtitleSourceState,
 } from '../../shared/types/current-video-context';
 import type { CurrentVideoTranscriptEvidenceState } from '../../shared/types/current-video-transcript';
+import type {
+  CurrentVideoTimestampJumpResponse,
+  CurrentVideoTimestampReturnResponse,
+} from '../../shared/types/current-video-segment-retrieval';
 import type { VideoKnowledgeJumpResponse } from '../../shared/types/video-knowledge';
 import type { DynamicBillFeedbackScope, DynamicBillStatusFilter } from '../../shared/types/dynamic-bill';
 import { normalizePageLimit, runInitialBackfill } from '../sync/initial-backfill';
@@ -35,6 +39,11 @@ import {
   withTranscriptEvidenceState,
 } from '../../shared/current-video-transcript-cache';
 import { searchCurrentVideoSegments } from '../../shared/current-video-segment-retrieval';
+import {
+  blockedTimestampJumpResponse,
+  blockedTimestampReturnResponse,
+  formatTimestampJumpFailureReason,
+} from '../../shared/current-video-timestamp-jump';
 import { buildVideoKnowledgeResult, findVideoKnowledgeNode } from '../../shared/video-knowledge';
 import {
   getQuickStats,
@@ -327,6 +336,10 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
         }) as T,
       };
     }
+    case 'REQUEST_CURRENT_VIDEO_SEGMENT_JUMP':
+      return { success: true, data: await requestCurrentVideoSegmentJump(request.params) as T };
+    case 'RETURN_CURRENT_VIDEO_SEGMENT_JUMP':
+      return { success: true, data: await returnCurrentVideoSegmentJump() as T };
     case 'REQUEST_VIDEO_KNOWLEDGE_JUMP':
       return { success: true, data: await requestVideoKnowledgeJump(request.params) as T };
     case 'GET_SMART_FAVORITES':
@@ -465,6 +478,113 @@ async function requestVideoKnowledgeJump(params: Record<string, unknown> | undef
       confirmed: true,
     },
   });
+}
+
+async function requestCurrentVideoSegmentJump(
+  params: Record<string, unknown> | undefined,
+): Promise<CurrentVideoTimestampJumpResponse> {
+  const candidateId = requireStringParam(params?.candidateId, 'candidateId');
+  const query = requireStringParam(params?.query, 'query');
+  const confirmed = params?.confirmed === true;
+  if (!confirmed) {
+    return blockedTimestampJumpResponse(
+      candidateId,
+      'confirmation_required',
+      formatTimestampJumpFailureReason('confirmation_required'),
+    );
+  }
+
+  const target = await resolveCurrentVideoLookupState();
+  const tabId = target.tab?.id ?? 0;
+  if (!target.tab?.url || tabId <= 0 || !isBilibiliVideoUrl(target.tab.url)) {
+    return blockedTimestampJumpResponse(
+      candidateId,
+      'no_context',
+      formatTimestampJumpFailureReason('no_context'),
+    );
+  }
+
+  const context = await getCurrentVideoContextForActiveTab();
+  if (context.kind !== 'video') {
+    return blockedTimestampJumpResponse(
+      candidateId,
+      'no_context',
+      formatTimestampJumpFailureReason('no_context'),
+    );
+  }
+
+  const transcriptSegments = await getActiveCurrentVideoTranscriptSegments(context);
+  const videoKnowledge = buildVideoKnowledgeResult(context, { transcriptSegments });
+  const result = searchCurrentVideoSegments(context, {
+    query,
+    transcriptSegments,
+    videoKnowledge,
+  });
+  const candidate = result.candidates.find(item => item.id === candidateId);
+  if (!candidate) {
+    const reason = result.status === 'stale_context'
+      ? 'stale_context'
+      : result.status === 'no_context'
+        ? 'no_context'
+        : 'candidate_not_found';
+    return blockedTimestampJumpResponse(
+      candidateId,
+      reason,
+      formatTimestampJumpFailureReason(reason),
+    );
+  }
+
+  const preview = candidate.jumpPreview;
+  if (!preview.canJump || preview.targetSeconds === null || preview.targetTimeLabel === null) {
+    const reason = preview.disabledReason ?? 'invalid_timestamp';
+    return blockedTimestampJumpResponse(candidateId, reason, preview.message);
+  }
+
+  try {
+    const response = await chrome.tabs.sendMessage(tabId, {
+      action: 'CURRENT_VIDEO_TIMESTAMP_JUMP',
+      payload: {
+        candidateId,
+        confirmed: true,
+        contextBvid: context.bvid,
+        contextCid: context.cid,
+        contextPage: context.currentPart.page,
+        contextUrl: context.url,
+        contextCollectedAt: context.collectedAt,
+        targetSeconds: preview.targetSeconds,
+        targetTimeLabel: preview.targetTimeLabel,
+        sourceLabel: preview.sourceLabel,
+        confidence: preview.confidence,
+        confidenceLabel: preview.confidenceLabel,
+        evidencePreview: preview.evidencePreview,
+      },
+    });
+    return response as CurrentVideoTimestampJumpResponse;
+  } catch {
+    return blockedTimestampJumpResponse(
+      candidateId,
+      'player_unavailable',
+      formatTimestampJumpFailureReason('player_unavailable'),
+    );
+  }
+}
+
+async function returnCurrentVideoSegmentJump(): Promise<CurrentVideoTimestampReturnResponse> {
+  const target = await resolveCurrentVideoLookupState();
+  const tabId = target.tab?.id ?? 0;
+  if (!target.tab?.url || tabId <= 0 || !isBilibiliVideoUrl(target.tab.url)) {
+    return blockedTimestampReturnResponse(formatTimestampJumpFailureReason('no_context'));
+  }
+
+  try {
+    const response = await chrome.tabs.sendMessage(tabId, {
+      action: 'CURRENT_VIDEO_TIMESTAMP_RETURN',
+      payload: {},
+    });
+    return response as CurrentVideoTimestampReturnResponse;
+  } catch {
+    return blockedTimestampReturnResponse(formatTimestampJumpFailureReason('player_unavailable'));
+  }
 }
 
 async function markConsumedFromPlayerEvent(

--- a/src/content/player-monitor/index.ts
+++ b/src/content/player-monitor/index.ts
@@ -2,8 +2,18 @@ import { renderCurrentVideoAssistant } from './assistant-status';
 import { collectCurrentVideoContext, isVideoPage, withVideoElementDuration } from './current-video-context';
 import { attachEventListeners, type VideoContext } from './event-capture';
 import { startHeartbeat } from './heartbeat';
+import {
+  performConfirmedTimestampJump,
+  performTimestampReturn,
+  type CurrentVideoTimestampReturnPoint,
+} from './timestamp-jump';
 import { detectVideo } from './video-detector';
 import type { BiliVizContentMessage } from '../../shared/types/messages';
+import type {
+  CurrentVideoTimestampJumpContentPayload,
+  CurrentVideoTimestampJumpResponse,
+  CurrentVideoTimestampReturnResponse,
+} from '../../shared/types/current-video-segment-retrieval';
 import type { CurrentVideoContextResult } from '../../shared/types/current-video-context';
 import type { VideoKnowledgeJumpResponse, VideoKnowledgeNode } from '../../shared/types/video-knowledge';
 
@@ -11,6 +21,7 @@ let cleanup: (() => void) | null = null;
 let lastContextKey = '';
 let retryTimer: number | null = null;
 let latestContext: CurrentVideoContextResult | null = null;
+let currentVideoTimestampReturnPoint: CurrentVideoTimestampReturnPoint | null = null;
 
 const RETURN_TOAST_ID = 'bdc-video-knowledge-return';
 const PAGE_RETURN_KEY = 'bdc-video-knowledge-return-point';
@@ -90,19 +101,50 @@ async function initializeMonitor(): Promise<void> {
 }
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-  if (message?.action !== 'VIDEO_KNOWLEDGE_MANUAL_JUMP') return false;
+  if (message?.action === 'VIDEO_KNOWLEDGE_MANUAL_JUMP') {
+    handleVideoKnowledgeManualJump(message.payload).then(sendResponse).catch((error) => {
+      sendResponse({
+        ok: false,
+        message: error instanceof Error ? error.message : String(error),
+        nodeId: String(message.payload?.node?.id ?? ''),
+        previousPositionSeconds: null,
+        targetSeconds: null,
+        targetPage: null,
+      } satisfies VideoKnowledgeJumpResponse);
+    });
+    return true;
+  }
 
-  handleVideoKnowledgeManualJump(message.payload).then(sendResponse).catch((error) => {
-    sendResponse({
-      ok: false,
-      message: error instanceof Error ? error.message : String(error),
-      nodeId: String(message.payload?.node?.id ?? ''),
-      previousPositionSeconds: null,
-      targetSeconds: null,
-      targetPage: null,
-    } satisfies VideoKnowledgeJumpResponse);
-  });
-  return true;
+  if (message?.action === 'CURRENT_VIDEO_TIMESTAMP_JUMP') {
+    handleCurrentVideoTimestampJump(message.payload).then(sendResponse).catch((error) => {
+      sendResponse({
+        ok: false,
+        message: error instanceof Error ? error.message : String(error),
+        candidateId: String(message.payload?.candidateId ?? ''),
+        targetSeconds: null,
+        targetTimeLabel: null,
+        returnPointSeconds: null,
+        sourceLabel: null,
+        confidence: null,
+      } satisfies CurrentVideoTimestampJumpResponse);
+    });
+    return true;
+  }
+
+  if (message?.action === 'CURRENT_VIDEO_TIMESTAMP_RETURN') {
+    handleCurrentVideoTimestampReturn().then(sendResponse).catch((error) => {
+      sendResponse({
+        ok: false,
+        message: error instanceof Error ? error.message : String(error),
+        candidateId: null,
+        returnPointSeconds: null,
+        targetSeconds: null,
+      } satisfies CurrentVideoTimestampReturnResponse);
+    });
+    return true;
+  }
+
+  return false;
 });
 
 async function handleVideoKnowledgeManualJump(payload: {
@@ -157,8 +199,41 @@ async function handleVideoKnowledgeManualJump(payload: {
   };
 }
 
+async function handleCurrentVideoTimestampJump(
+  payload: CurrentVideoTimestampJumpContentPayload,
+): Promise<CurrentVideoTimestampJumpResponse> {
+  const result = await performConfirmedTimestampJump({
+    payload,
+    latestContext,
+    video: currentUsableVideoElement(),
+  });
+  if (result.returnPoint) {
+    currentVideoTimestampReturnPoint = result.returnPoint;
+    showReturnToast(result.response.returnPointSeconds, undefined, handleCurrentVideoTimestampReturn);
+  }
+  return result.response;
+}
+
+async function handleCurrentVideoTimestampReturn(): Promise<CurrentVideoTimestampReturnResponse> {
+  const result = await performTimestampReturn({
+    returnPoint: currentVideoTimestampReturnPoint,
+    latestContext,
+    video: currentUsableVideoElement(),
+  });
+  if (result.clearReturnPoint) {
+    currentVideoTimestampReturnPoint = null;
+  }
+  return result.response;
+}
+
 function currentVideoElement(): HTMLVideoElement | null {
   return document.querySelector('video');
+}
+
+function currentUsableVideoElement(): HTMLVideoElement | null {
+  const video = currentVideoElement();
+  if (!video) return null;
+  return video;
 }
 
 function urlForPage(page: number): string {
@@ -195,7 +270,11 @@ function showStoredPageReturnIfAvailable(context: CurrentVideoContextResult): vo
   }
 }
 
-function showReturnToast(seconds: number | null, url?: string): void {
+function showReturnToast(
+  seconds: number | null,
+  url?: string,
+  onReturn?: () => Promise<CurrentVideoTimestampReturnResponse>,
+): void {
   const existing = document.getElementById(RETURN_TOAST_ID);
   existing?.remove();
 
@@ -234,6 +313,11 @@ function showReturnToast(seconds: number | null, url?: string): void {
       location.assign(url);
       return;
     }
+    if (onReturn) {
+      await onReturn();
+      toast.remove();
+      return;
+    }
     if (seconds !== null) {
       const video = await detectVideo();
       video.currentTime = Math.max(0, seconds);
@@ -243,7 +327,7 @@ function showReturnToast(seconds: number | null, url?: string): void {
 
   const dismiss = document.createElement('button');
   dismiss.type = 'button';
-  dismiss.textContent = 'Dismiss';
+  dismiss.textContent = '关闭';
   dismiss.style.cssText = 'border:1px solid rgba(255,255,255,0.16);border-radius:6px;background:transparent;color:#c8c8d8;font-size:12px;padding:6px 8px;cursor:pointer';
   dismiss.addEventListener('click', () => toast.remove());
   actions.append(back, dismiss);

--- a/src/content/player-monitor/timestamp-jump.ts
+++ b/src/content/player-monitor/timestamp-jump.ts
@@ -1,0 +1,263 @@
+import type { CurrentVideoContextResult } from '../../shared/types/current-video-context';
+import type {
+  CurrentVideoTimestampJumpContentPayload,
+  CurrentVideoTimestampJumpResponse,
+  CurrentVideoTimestampReturnResponse,
+} from '../../shared/types/current-video-segment-retrieval';
+import {
+  blockedTimestampReturnResponse,
+  formatTimestampJumpFailureReason,
+} from '../../shared/current-video-timestamp-jump.ts';
+
+const RETURN_POINT_TTL_MS = 10 * 60 * 1000;
+
+export interface TimestampJumpVideoLike {
+  currentTime: number;
+  duration: number;
+  paused: boolean;
+  pause: () => void;
+  play: () => Promise<void> | void;
+}
+
+export interface CurrentVideoTimestampReturnPoint {
+  candidateId: string;
+  bvid: string;
+  cid: number | null;
+  page: number;
+  url: string;
+  seconds: number;
+  targetSeconds: number;
+  savedAt: number;
+  wasPaused: boolean;
+}
+
+export async function performConfirmedTimestampJump(input: {
+  payload: CurrentVideoTimestampJumpContentPayload;
+  latestContext: CurrentVideoContextResult | null;
+  video: TimestampJumpVideoLike | null;
+  now?: number;
+}): Promise<{
+  response: CurrentVideoTimestampJumpResponse;
+  returnPoint: CurrentVideoTimestampReturnPoint | null;
+}> {
+  const now = input.now ?? Date.now();
+  const payload = input.payload;
+
+  const blocked = validateTimestampJump(payload, input.latestContext, input.video);
+  if (blocked) {
+    return {
+      response: {
+        ok: false,
+        message: blocked,
+        candidateId: payload.candidateId,
+        targetSeconds: null,
+        targetTimeLabel: null,
+        returnPointSeconds: null,
+        sourceLabel: payload.sourceLabel,
+        confidence: payload.confidence,
+      },
+      returnPoint: null,
+    };
+  }
+
+  const context = input.latestContext;
+  const video = input.video;
+  if (context?.kind !== 'video' || !video) {
+    return {
+      response: {
+        ok: false,
+        message: formatTimestampJumpFailureReason('context_mismatch'),
+        candidateId: payload.candidateId,
+        targetSeconds: null,
+        targetTimeLabel: null,
+        returnPointSeconds: null,
+        sourceLabel: payload.sourceLabel,
+        confidence: payload.confidence,
+      },
+      returnPoint: null,
+    };
+  }
+
+  const returnPointSeconds = Math.max(0, video.currentTime);
+  const wasPaused = video.paused;
+  await seekPreservingPlaybackIntent(video, payload.targetSeconds, wasPaused);
+
+  return {
+    response: {
+      ok: true,
+      message: `已跳到 ${payload.targetTimeLabel}，可返回 ${formatDuration(returnPointSeconds)}。`,
+      candidateId: payload.candidateId,
+      targetSeconds: payload.targetSeconds,
+      targetTimeLabel: payload.targetTimeLabel,
+      returnPointSeconds,
+      sourceLabel: payload.sourceLabel,
+      confidence: payload.confidence,
+    },
+    returnPoint: {
+      candidateId: payload.candidateId,
+      bvid: context.bvid,
+      cid: context.cid,
+      page: context.currentPart.page,
+      url: context.url,
+      seconds: returnPointSeconds,
+      targetSeconds: payload.targetSeconds,
+      savedAt: now,
+      wasPaused,
+    },
+  };
+}
+
+export async function performTimestampReturn(input: {
+  returnPoint: CurrentVideoTimestampReturnPoint | null;
+  latestContext: CurrentVideoContextResult | null;
+  video: TimestampJumpVideoLike | null;
+  now?: number;
+}): Promise<{
+  response: CurrentVideoTimestampReturnResponse;
+  clearReturnPoint: boolean;
+}> {
+  const now = input.now ?? Date.now();
+  const returnPoint = input.returnPoint;
+  if (!returnPoint) {
+    return {
+      response: blockedTimestampReturnResponse('没有可返回的播放位置。'),
+      clearReturnPoint: false,
+    };
+  }
+
+  if (now - returnPoint.savedAt > RETURN_POINT_TTL_MS) {
+    return {
+      response: blockedTimestampReturnResponse('返回位置已过期，请重新检索并跳转。'),
+      clearReturnPoint: true,
+    };
+  }
+
+  if (!contextMatchesReturnPoint(input.latestContext, returnPoint)) {
+    return {
+      response: {
+        ok: false,
+        message: formatTimestampJumpFailureReason('context_mismatch'),
+        candidateId: returnPoint.candidateId,
+        returnPointSeconds: returnPoint.seconds,
+        targetSeconds: returnPoint.targetSeconds,
+      },
+      clearReturnPoint: true,
+    };
+  }
+
+  const videoProblem = validateVideoElement(input.video, returnPoint.seconds);
+  if (videoProblem) {
+    return {
+      response: {
+        ok: false,
+        message: videoProblem,
+        candidateId: returnPoint.candidateId,
+        returnPointSeconds: returnPoint.seconds,
+        targetSeconds: returnPoint.targetSeconds,
+      },
+      clearReturnPoint: false,
+    };
+  }
+
+  await seekPreservingPlaybackIntent(input.video!, returnPoint.seconds, returnPoint.wasPaused);
+  return {
+    response: {
+      ok: true,
+      message: `已返回 ${formatDuration(returnPoint.seconds)}。`,
+      candidateId: returnPoint.candidateId,
+      returnPointSeconds: returnPoint.seconds,
+      targetSeconds: returnPoint.targetSeconds,
+    },
+    clearReturnPoint: true,
+  };
+}
+
+function validateTimestampJump(
+  payload: CurrentVideoTimestampJumpContentPayload,
+  latestContext: CurrentVideoContextResult | null,
+  video: TimestampJumpVideoLike | null,
+): string | null {
+  if (!payload.confirmed) {
+    return formatTimestampJumpFailureReason('confirmation_required');
+  }
+
+  if (!contextMatchesPayload(latestContext, payload)) {
+    return formatTimestampJumpFailureReason('context_mismatch');
+  }
+
+  return validateVideoElement(video, payload.targetSeconds);
+}
+
+function contextMatchesPayload(
+  context: CurrentVideoContextResult | null,
+  payload: CurrentVideoTimestampJumpContentPayload,
+): boolean {
+  if (context?.kind !== 'video') return false;
+  if (context.bvid !== payload.contextBvid) return false;
+  if (context.currentPart.page !== payload.contextPage) return false;
+  if (typeof payload.contextCid === 'number' && context.cid !== payload.contextCid) {
+    return false;
+  }
+  return true;
+}
+
+function contextMatchesReturnPoint(
+  context: CurrentVideoContextResult | null,
+  returnPoint: CurrentVideoTimestampReturnPoint,
+): boolean {
+  if (context?.kind !== 'video') return false;
+  if (context.bvid !== returnPoint.bvid) return false;
+  if (context.currentPart.page !== returnPoint.page) return false;
+  if (typeof returnPoint.cid === 'number' && context.cid !== returnPoint.cid) {
+    return false;
+  }
+  return true;
+}
+
+function validateVideoElement(video: TimestampJumpVideoLike | null, targetSeconds: number): string | null {
+  if (!video) {
+    return formatTimestampJumpFailureReason('player_unavailable');
+  }
+  if (!Number.isFinite(targetSeconds) || targetSeconds < 0) {
+    return formatTimestampJumpFailureReason('invalid_timestamp');
+  }
+  if (video.duration === Infinity) {
+    return formatTimestampJumpFailureReason('unsupported_player');
+  }
+  if (!Number.isFinite(video.duration) || video.duration <= 0) {
+    return formatTimestampJumpFailureReason('player_unavailable');
+  }
+  if (targetSeconds > video.duration + 0.5) {
+    return formatTimestampJumpFailureReason('invalid_timestamp');
+  }
+  return null;
+}
+
+async function seekPreservingPlaybackIntent(
+  video: TimestampJumpVideoLike,
+  targetSeconds: number,
+  wasPaused: boolean,
+): Promise<void> {
+  video.currentTime = Math.max(0, Math.min(targetSeconds, video.duration));
+  if (wasPaused) {
+    video.pause();
+    return;
+  }
+
+  try {
+    await video.play();
+  } catch {
+    // Browser autoplay rules can reject play(); currentTime was still updated.
+  }
+}
+
+function formatDuration(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+  const rest = safe % 60;
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(rest).padStart(2, '0')}`;
+  }
+  return `${minutes}:${String(rest).padStart(2, '0')}`;
+}

--- a/src/shared/current-video-segment-retrieval.ts
+++ b/src/shared/current-video-segment-retrieval.ts
@@ -8,6 +8,7 @@ import type {
   CurrentVideoSegmentRetrievalStatus,
 } from './types/current-video-segment-retrieval';
 import type { VideoKnowledgeNode, VideoKnowledgeResult } from './types/video-knowledge';
+import { buildCurrentVideoTimestampJumpPreview } from './current-video-timestamp-jump.ts';
 
 const DEFAULT_CONTEXT_MAX_AGE_MS = 10 * 60 * 1000;
 const DEFAULT_LIMIT = 5;
@@ -150,7 +151,7 @@ export function searchCurrentVideoSegments(
         : '只找到低置信候选，请把问题写得更接近字幕原文或章节标题。',
       limitations: [
         '候选时间只来自当前视频已有字幕片段或本地关键节点，不会推测新时间点。',
-        '当前结果只展示证据和时间范围，不提供播放器跳转。',
+        '候选必须预览并确认后才会请求播放器跳转，默认不会自动改变播放位置。',
       ],
       evidenceState,
       contextFresh,
@@ -515,6 +516,18 @@ function candidate(input: {
     confidence,
     confidenceLabel: confidenceLabel(confidence),
     note: input.note ?? (confidence < LOW_CONFIDENCE_THRESHOLD ? '匹配较弱，建议换成更具体的关键词。' : null),
+    jumpPreview: {
+      canJump: false,
+      requiresConfirmation: true,
+      disabledReason: 'candidate_not_found',
+      message: '候选需要重新验证后才能跳转。',
+      targetSeconds: null,
+      targetTimeLabel: null,
+      sourceLabel: sourceLabel(input.source),
+      confidence,
+      confidenceLabel: confidenceLabel(confidence),
+      evidencePreview: limitText(input.evidenceText, 140),
+    },
   };
 }
 
@@ -550,7 +563,12 @@ function result(input: {
     normalizedQuery: input.profile.normalized,
     title: videoContext?.title ?? videoContext?.bvid ?? '当前视频',
     generatedAt: input.now,
-    candidates: input.candidates,
+    candidates: input.candidates.map(candidate => ({
+      ...candidate,
+      jumpPreview: buildCurrentVideoTimestampJumpPreview(input.context, candidate, {
+        now: input.now,
+      }),
+    })),
     summary: input.summary,
     limitations: input.limitations,
     evidenceState: {

--- a/src/shared/current-video-timestamp-jump.ts
+++ b/src/shared/current-video-timestamp-jump.ts
@@ -1,0 +1,163 @@
+import type { CurrentVideoContextResult } from './types/current-video-context';
+import type {
+  CurrentVideoSegmentRetrievalCandidate,
+  CurrentVideoTimestampJumpDisabledReason,
+  CurrentVideoTimestampJumpPreview,
+  CurrentVideoTimestampJumpResponse,
+  CurrentVideoTimestampReturnResponse,
+} from './types/current-video-segment-retrieval';
+
+export const CURRENT_VIDEO_TIMESTAMP_CONTEXT_MAX_AGE_MS = 10 * 60 * 1000;
+export const CURRENT_VIDEO_TIMESTAMP_JUMP_MIN_CONFIDENCE = 0.62;
+
+export function buildCurrentVideoTimestampJumpPreview(
+  context: CurrentVideoContextResult,
+  candidate: Omit<CurrentVideoSegmentRetrievalCandidate, 'jumpPreview'>,
+  options: {
+    now?: number;
+    contextMaxAgeMs?: number;
+  } = {},
+): CurrentVideoTimestampJumpPreview {
+  const now = options.now ?? Date.now();
+  const evidencePreview = limitText(candidate.evidenceText, 140);
+  const base = {
+    requiresConfirmation: true as const,
+    targetSeconds: null,
+    targetTimeLabel: null,
+    sourceLabel: candidate.sourceLabel,
+    confidence: candidate.confidence,
+    confidenceLabel: candidate.confidenceLabel,
+    evidencePreview,
+  };
+
+  if (context.kind !== 'video') {
+    return disabledPreview(base, 'no_context', '当前没有可用的视频页，不能跳转。');
+  }
+
+  const contextMaxAgeMs = options.contextMaxAgeMs ?? CURRENT_VIDEO_TIMESTAMP_CONTEXT_MAX_AGE_MS;
+  if (now - context.collectedAt > contextMaxAgeMs) {
+    return disabledPreview(base, 'stale_context', '当前视频上下文已过期，请刷新视频页或重新打开弹窗后再跳转。');
+  }
+
+  if (candidate.binding.kind === 'metadata_hint' || candidate.source === 'metadata_hint' || candidate.source === 'description_hint') {
+    return disabledPreview(base, 'metadata_only', '该候选只来自视频信息或简介，无法定位到具体播放时间。');
+  }
+
+  if (candidate.confidence < CURRENT_VIDEO_TIMESTAMP_JUMP_MIN_CONFIDENCE) {
+    return disabledPreview(base, 'low_confidence', '匹配置信度较低，默认不允许直接跳转。请换更具体的关键词后再试。');
+  }
+
+  const targetSeconds = candidate.startSeconds;
+  if (targetSeconds === null) {
+    return disabledPreview(base, 'not_timed_candidate', '该候选没有可定位时间点，不能跳转。');
+  }
+
+  if (!Number.isFinite(targetSeconds) || targetSeconds < 0) {
+    return disabledPreview(base, 'invalid_timestamp', '候选时间点无效，不能跳转。');
+  }
+
+  if (
+    typeof context.durationSeconds === 'number'
+    && Number.isFinite(context.durationSeconds)
+    && context.durationSeconds > 0
+    && targetSeconds > context.durationSeconds + 1
+  ) {
+    return disabledPreview(base, 'invalid_timestamp', '候选时间点超出当前视频时长，不能跳转。');
+  }
+
+  const targetTimeLabel = formatDuration(targetSeconds);
+  return {
+    ...base,
+    canJump: true,
+    disabledReason: null,
+    targetSeconds,
+    targetTimeLabel,
+    message: `确认后会跳到 ${targetTimeLabel}，并记录当前播放位置用于返回。`,
+  };
+}
+
+export function blockedTimestampJumpResponse(
+  candidateId: string,
+  reason: CurrentVideoTimestampJumpDisabledReason,
+  message: string,
+): CurrentVideoTimestampJumpResponse {
+  return {
+    ok: false,
+    message,
+    candidateId,
+    targetSeconds: null,
+    targetTimeLabel: null,
+    returnPointSeconds: null,
+    sourceLabel: null,
+    confidence: null,
+  };
+}
+
+export function blockedTimestampReturnResponse(message: string): CurrentVideoTimestampReturnResponse {
+  return {
+    ok: false,
+    message,
+    candidateId: null,
+    returnPointSeconds: null,
+    targetSeconds: null,
+  };
+}
+
+export function formatTimestampJumpFailureReason(reason: CurrentVideoTimestampJumpDisabledReason): string {
+  switch (reason) {
+    case 'confirmation_required':
+      return '需要先确认跳转。';
+    case 'no_context':
+      return '当前没有可用的视频页，不能跳转。';
+    case 'stale_context':
+      return '当前视频上下文已过期，请刷新视频页或重新打开弹窗后再跳转。';
+    case 'not_timed_candidate':
+      return '该候选没有可定位时间点，不能跳转。';
+    case 'metadata_only':
+      return '该候选只来自视频信息或简介，无法定位到具体播放时间。';
+    case 'low_confidence':
+      return '匹配置信度较低，默认不允许直接跳转。请换更具体的关键词后再试。';
+    case 'invalid_timestamp':
+      return '候选时间点无效，不能跳转。';
+    case 'candidate_not_found':
+      return '候选已变化，请重新检索后再跳转。';
+    case 'context_mismatch':
+      return '当前视频已经变化，为避免跳错视频，本次跳转已取消。';
+    case 'player_unavailable':
+      return '没有找到可控制的视频播放器，请保持 B 站视频页打开后再试。';
+    case 'unsupported_player':
+      return '当前播放器不支持精确跳转，直播或无时长视频不能使用此功能。';
+    default:
+      return '当前候选不能跳转。';
+  }
+}
+
+function disabledPreview(
+  base: Omit<CurrentVideoTimestampJumpPreview, 'canJump' | 'disabledReason' | 'message'>,
+  disabledReason: CurrentVideoTimestampJumpDisabledReason,
+  message: string,
+): CurrentVideoTimestampJumpPreview {
+  return {
+    ...base,
+    canJump: false,
+    disabledReason,
+    message,
+  };
+}
+
+function formatDuration(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+  const rest = safe % 60;
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(rest).padStart(2, '0')}`;
+  }
+  return `${minutes}:${String(rest).padStart(2, '0')}`;
+}
+
+function limitText(value: string, maxLength: number): string {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxLength - 3))}...`;
+}

--- a/src/shared/types/current-video-segment-retrieval.ts
+++ b/src/shared/types/current-video-segment-retrieval.ts
@@ -17,6 +17,32 @@ export type CurrentVideoSegmentRetrievalCandidateSource =
 
 export type CurrentVideoSegmentRetrievalConfidenceLabel = '高' | '中' | '低';
 
+export type CurrentVideoTimestampJumpDisabledReason =
+  | 'confirmation_required'
+  | 'no_context'
+  | 'stale_context'
+  | 'not_timed_candidate'
+  | 'metadata_only'
+  | 'low_confidence'
+  | 'invalid_timestamp'
+  | 'candidate_not_found'
+  | 'context_mismatch'
+  | 'player_unavailable'
+  | 'unsupported_player';
+
+export interface CurrentVideoTimestampJumpPreview {
+  canJump: boolean;
+  requiresConfirmation: true;
+  disabledReason: CurrentVideoTimestampJumpDisabledReason | null;
+  message: string;
+  targetSeconds: number | null;
+  targetTimeLabel: string | null;
+  sourceLabel: string;
+  confidence: number;
+  confidenceLabel: CurrentVideoSegmentRetrievalConfidenceLabel;
+  evidencePreview: string;
+}
+
 export interface CurrentVideoSegmentRetrievalCandidateBinding {
   kind: 'transcript_segment' | 'video_knowledge_node' | 'metadata_hint';
   segmentId?: string | null;
@@ -36,6 +62,7 @@ export interface CurrentVideoSegmentRetrievalCandidate {
   confidence: number;
   confidenceLabel: CurrentVideoSegmentRetrievalConfidenceLabel;
   note: string | null;
+  jumpPreview: CurrentVideoTimestampJumpPreview;
 }
 
 export interface CurrentVideoSegmentRetrievalEvidenceState {
@@ -55,4 +82,39 @@ export interface CurrentVideoSegmentRetrievalResult {
   summary: string;
   limitations: string[];
   evidenceState: CurrentVideoSegmentRetrievalEvidenceState;
+}
+
+export interface CurrentVideoTimestampJumpContentPayload {
+  candidateId: string;
+  confirmed: boolean;
+  contextBvid: string;
+  contextCid: number | null;
+  contextPage: number;
+  contextUrl: string;
+  contextCollectedAt: number;
+  targetSeconds: number;
+  targetTimeLabel: string;
+  sourceLabel: string;
+  confidence: number;
+  confidenceLabel: CurrentVideoSegmentRetrievalConfidenceLabel;
+  evidencePreview: string;
+}
+
+export interface CurrentVideoTimestampJumpResponse {
+  ok: boolean;
+  message: string;
+  candidateId: string;
+  targetSeconds: number | null;
+  targetTimeLabel: string | null;
+  returnPointSeconds: number | null;
+  sourceLabel: string | null;
+  confidence: number | null;
+}
+
+export interface CurrentVideoTimestampReturnResponse {
+  ok: boolean;
+  message: string;
+  candidateId: string | null;
+  returnPointSeconds: number | null;
+  targetSeconds: number | null;
 }

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -29,7 +29,11 @@ import type {
 } from './favorite';
 import type { CurrentVideoContextResult, CurrentVideoSubtitleSourceState } from './current-video-context';
 import type { CurrentVideoTranscriptEvidenceState } from './current-video-transcript';
-import type { CurrentVideoSegmentRetrievalResult } from './current-video-segment-retrieval';
+import type {
+  CurrentVideoSegmentRetrievalResult,
+  CurrentVideoTimestampJumpResponse,
+  CurrentVideoTimestampReturnResponse,
+} from './current-video-segment-retrieval';
 import type { CurrentVideoSummaryResult } from './current-video-summary';
 import type { VideoKnowledgeJumpResponse, VideoKnowledgeResult } from './video-knowledge';
 import type { HistoryTailProbeReport } from './history-tail-probe';
@@ -58,6 +62,8 @@ export type RequestAction =
   | 'GET_CURRENT_VIDEO_SUMMARY'
   | 'GET_VIDEO_KNOWLEDGE'
   | 'SEARCH_CURRENT_VIDEO_SEGMENTS'
+  | 'REQUEST_CURRENT_VIDEO_SEGMENT_JUMP'
+  | 'RETURN_CURRENT_VIDEO_SEGMENT_JUMP'
   | 'REQUEST_VIDEO_KNOWLEDGE_JUMP'
   | 'GET_SMART_FAVORITES'
   | 'GET_SMART_FAVORITES_BY_PATH'
@@ -180,6 +186,8 @@ export type CurrentVideoTranscriptEvidenceResponse = BiliVizResponse<CurrentVide
 export type CurrentVideoSummaryResponse = BiliVizResponse<CurrentVideoSummaryResult>;
 export type VideoKnowledgeResponse = BiliVizResponse<VideoKnowledgeResult>;
 export type CurrentVideoSegmentRetrievalResponse = BiliVizResponse<CurrentVideoSegmentRetrievalResult>;
+export type CurrentVideoTimestampJumpMessageResponse = BiliVizResponse<CurrentVideoTimestampJumpResponse>;
+export type CurrentVideoTimestampReturnMessageResponse = BiliVizResponse<CurrentVideoTimestampReturnResponse>;
 export type VideoKnowledgeJumpMessageResponse = BiliVizResponse<VideoKnowledgeJumpResponse>;
 export type DynamicBillOverviewResponse = BiliVizResponse<DynamicBillOverview>;
 export type DynamicSyncResponse = BiliVizResponse<DynamicSyncResult>;

--- a/tests/current-video-segment-retrieval.mock.html
+++ b/tests/current-video-segment-retrieval.mock.html
@@ -101,10 +101,55 @@
     .reason {
       color: #cfd3df;
     }
+
+    button {
+      margin-top: 8px;
+      border: 1px solid rgba(127, 219, 255, 0.32);
+      border-radius: 6px;
+      background: rgba(0, 161, 214, 0.2);
+      color: var(--blue);
+      cursor: pointer;
+      font-size: 11px;
+      padding: 6px 8px;
+    }
+
+    button:disabled {
+      border-color: rgba(255, 255, 255, 0.12);
+      background: rgba(255, 255, 255, 0.06);
+      color: #858a99;
+      cursor: default;
+    }
+
+    .preview {
+      display: none;
+      margin-top: 10px;
+      padding: 10px;
+      border: 1px solid rgba(255, 179, 71, 0.3);
+      border-radius: 6px;
+      background: rgba(255, 179, 71, 0.08);
+    }
+
+    .preview.active {
+      display: block;
+    }
+
+    .confirm {
+      background: #ffb347;
+      color: #1a1a2e;
+      border: 0;
+      font-weight: 700;
+    }
   </style>
 </head>
 <body>
   <main>
+    <section data-testid="mock-player">
+      <h1>模拟播放器</h1>
+      <div class="status" data-testid="player-position">当前位置 0:12</div>
+      <div class="reason" data-testid="jump-status">尚未跳转</div>
+      <button type="button" data-testid="return-button" disabled>返回原位置</button>
+    </section>
+
     <section data-testid="retrieval-ready">
       <h1>本地片段检索</h1>
       <div class="status">找到 2 个基于当前视频本地证据的候选片段。</div>
@@ -116,7 +161,17 @@
         <div class="meta">来源 可定位字幕证据</div>
         <div class="evidence">证据片段：接下来讲模型的整体架构，包括专家路由和参数组织。</div>
         <div class="reason">匹配原因：和问题词有重叠：模型、架构；中文短语有连续重叠</div>
+        <div class="status">确认后会跳到 0:24，并记录当前播放位置用于返回。</div>
+        <button type="button" data-testid="preview-jump">预览跳转</button>
       </article>
+      <div class="preview" data-testid="jump-preview">
+        <h1>确认跳转前预览</h1>
+        <div class="reason">目标时间：0:24</div>
+        <div class="reason">来源：可定位字幕证据；置信度：高 86%</div>
+        <div class="evidence">证据预览：接下来讲模型的整体架构，包括专家路由和参数组织。</div>
+        <button type="button" class="confirm" data-testid="confirm-jump">确认跳转</button>
+        <button type="button" data-testid="cancel-jump">取消</button>
+      </div>
       <article class="candidate" data-testid="node-card">
         <div class="row">
           <div class="title">候选 2 · 2:00</div>
@@ -140,6 +195,7 @@
         <div class="evidence">证据片段：最后补充一点模型之外的部署注意事项。</div>
         <div class="reason">匹配原因：和问题词有重叠：模型</div>
         <div class="warning">匹配较弱，建议换成更具体的关键词。</div>
+        <button type="button" data-testid="low-confidence-jump" disabled>不可跳转</button>
       </article>
     </section>
 
@@ -160,8 +216,41 @@
         <div class="meta">来源 视频信息弱提示</div>
         <div class="evidence">证据片段：DeepSeek V3.2 发布会重点回顾</div>
         <div class="reason">匹配原因：这只是视频信息中的弱提示</div>
+        <button type="button" data-testid="metadata-jump" disabled>不可跳转</button>
       </article>
     </section>
   </main>
+  <script>
+    const preview = document.querySelector('[data-testid="jump-preview"]');
+    const status = document.querySelector('[data-testid="jump-status"]');
+    const position = document.querySelector('[data-testid="player-position"]');
+    const returnButton = document.querySelector('[data-testid="return-button"]');
+    let returnPoint = null;
+
+    document.querySelector('[data-testid="preview-jump"]').addEventListener('click', () => {
+      preview.classList.add('active');
+      status.textContent = '已展示目标时间、来源、置信度和证据预览，等待确认。';
+    });
+
+    document.querySelector('[data-testid="cancel-jump"]').addEventListener('click', () => {
+      preview.classList.remove('active');
+      status.textContent = '已取消，播放位置未改变。';
+    });
+
+    document.querySelector('[data-testid="confirm-jump"]').addEventListener('click', () => {
+      returnPoint = '0:12';
+      position.textContent = '当前位置 0:24';
+      status.textContent = '已确认跳转到 0:24，可返回 0:12。';
+      returnButton.disabled = false;
+    });
+
+    returnButton.addEventListener('click', () => {
+      if (!returnPoint) return;
+      position.textContent = `当前位置 ${returnPoint}`;
+      status.textContent = `已返回 ${returnPoint}。`;
+      returnPoint = null;
+      returnButton.disabled = true;
+    });
+  </script>
 </body>
 </html>

--- a/tests/current-video-segment-retrieval.test.ts
+++ b/tests/current-video-segment-retrieval.test.ts
@@ -19,6 +19,12 @@ test('returns an exact local transcript keyword match without inventing timestam
   assert.equal(result.candidates[0].binding.segmentId, segments[0].segmentId);
   assert.equal(result.candidates[0].timeRangeLabel, '0:12-0:18');
   assert.equal(result.candidates[0].sourceLabel, '可定位字幕证据');
+  assert.equal(result.candidates[0].jumpPreview.canJump, true);
+  assert.equal(result.candidates[0].jumpPreview.requiresConfirmation, true);
+  assert.equal(result.candidates[0].jumpPreview.targetSeconds, 12);
+  assert.equal(result.candidates[0].jumpPreview.targetTimeLabel, '0:12');
+  assert.ok(result.candidates[0].jumpPreview.message.includes('确认后'));
+  assert.ok(result.candidates[0].jumpPreview.evidencePreview.includes('DeepSeek V3.2'));
   assert.ok(result.candidates[0].confidence >= 0.78);
   assert.ok(result.candidates[0].matchReasons.some(reason => reason.includes('deepseek')));
   assert.equal(result.candidates[0].binding.segmentId?.startsWith('transcript:'), true);
@@ -58,6 +64,8 @@ test('uses a weak metadata helper only when no timed evidence is available', () 
   assert.equal(result.candidates[0].startSeconds, null);
   assert.equal(result.candidates[0].timeRangeLabel, '无法定位具体时间');
   assert.equal(result.candidates[0].binding.kind, 'metadata_hint');
+  assert.equal(result.candidates[0].jumpPreview.canJump, false);
+  assert.equal(result.candidates[0].jumpPreview.disabledReason, 'metadata_only');
   assert.ok(result.summary.includes('无法定位到具体时间点'));
   assert.ok(result.candidates[0].note?.includes('无法定位到具体时间点'));
 });
@@ -101,6 +109,8 @@ test('marks weak transcript overlap as low confidence', () => {
 
   assert.equal(result.status, 'low_confidence');
   assert.equal(result.candidates[0].confidenceLabel, '低');
+  assert.equal(result.candidates[0].jumpPreview.canJump, false);
+  assert.equal(result.candidates[0].jumpPreview.disabledReason, 'low_confidence');
   assert.ok(result.candidates[0].note?.includes('匹配较弱'));
 });
 
@@ -134,7 +144,7 @@ test('does not use transcript segments when active evidence is absent', () => {
   assert.equal(result.candidates.length, 0);
 });
 
-test('uses current-video knowledge node matches without adding a jump action', () => {
+test('uses current-video knowledge node matches with manual-only jump preview', () => {
   const context = videoContext({
     chapters: [{ title: '模型架构章节', startSeconds: 120 }],
   });
@@ -151,6 +161,29 @@ test('uses current-video knowledge node matches without adding a jump action', (
   assert.equal(result.candidates[0].sourceLabel, '章节弱提示');
   assert.equal(result.candidates[0].timeRangeLabel, '2:00');
   assert.equal('jumpAction' in result.candidates[0], false);
+  assert.equal(result.candidates[0].jumpPreview.canJump, true);
+  assert.equal(result.candidates[0].jumpPreview.requiresConfirmation, true);
+  assert.equal(result.candidates[0].jumpPreview.targetSeconds, 120);
+});
+
+test('disables jump preview when candidate timestamp exceeds current video duration', () => {
+  const context = withTranscriptEvidence(videoContext());
+  const [first] = transcriptSegments();
+  const result = searchCurrentVideoSegments(context, {
+    query: 'DeepSeek V3.2',
+    transcriptSegments: [{
+      ...first,
+      startSeconds: 700,
+      endSeconds: 706,
+    }],
+    videoKnowledge: null,
+    now: 3000,
+  });
+
+  assert.equal(result.status, 'ready');
+  assert.equal(result.candidates[0].jumpPreview.canJump, false);
+  assert.equal(result.candidates[0].jumpPreview.disabledReason, 'invalid_timestamp');
+  assert.ok(result.candidates[0].jumpPreview.message.includes('超出当前视频时长'));
 });
 
 test('returns no context without reading broader local data', () => {

--- a/tests/current-video-timestamp-jump.test.ts
+++ b/tests/current-video-timestamp-jump.test.ts
@@ -1,0 +1,228 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  performConfirmedTimestampJump,
+  performTimestampReturn,
+  type CurrentVideoTimestampReturnPoint,
+  type TimestampJumpVideoLike,
+} from '../src/content/player-monitor/timestamp-jump.ts';
+import type { CurrentVideoContext } from '../src/shared/types/current-video-context.ts';
+import type { CurrentVideoTimestampJumpContentPayload } from '../src/shared/types/current-video-segment-retrieval.ts';
+
+test('confirmed timestamp jump seeks the player and records a bound return point', async () => {
+  const video = mockVideo({ currentTime: 12, duration: 180, paused: false });
+  const result = await performConfirmedTimestampJump({
+    payload: jumpPayload(),
+    latestContext: videoContext(),
+    video,
+    now: 5000,
+  });
+
+  assert.equal(result.response.ok, true);
+  assert.equal(video.currentTime, 42);
+  assert.equal(video.playCalls, 1);
+  assert.equal(result.response.returnPointSeconds, 12);
+  assert.equal(result.returnPoint?.seconds, 12);
+  assert.equal(result.returnPoint?.bvid, 'BV1Jump000');
+  assert.equal(result.returnPoint?.page, 1);
+});
+
+test('unconfirmed timestamp jump does not seek automatically', async () => {
+  const video = mockVideo({ currentTime: 12, duration: 180, paused: true });
+  const result = await performConfirmedTimestampJump({
+    payload: { ...jumpPayload(), confirmed: false },
+    latestContext: videoContext(),
+    video,
+  });
+
+  assert.equal(result.response.ok, false);
+  assert.equal(video.currentTime, 12);
+  assert.equal(video.pauseCalls, 0);
+  assert.equal(result.returnPoint, null);
+  assert.ok(result.response.message.includes('确认'));
+});
+
+test('return action seeks back to the original position and clears the return point', async () => {
+  const video = mockVideo({ currentTime: 42, duration: 180, paused: false });
+  const returnPoint: CurrentVideoTimestampReturnPoint = {
+    candidateId: 'candidate:segment:safe',
+    bvid: 'BV1Jump000',
+    cid: 101,
+    page: 1,
+    url: 'https://www.bilibili.com/video/BV1Jump000',
+    seconds: 12,
+    targetSeconds: 42,
+    savedAt: 5000,
+    wasPaused: false,
+  };
+
+  const result = await performTimestampReturn({
+    returnPoint,
+    latestContext: videoContext(),
+    video,
+    now: 6000,
+  });
+
+  assert.equal(result.response.ok, true);
+  assert.equal(video.currentTime, 12);
+  assert.equal(video.playCalls, 1);
+  assert.equal(result.clearReturnPoint, true);
+});
+
+test('player unavailable fails safely without changing state', async () => {
+  const result = await performConfirmedTimestampJump({
+    payload: jumpPayload(),
+    latestContext: videoContext(),
+    video: null,
+  });
+
+  assert.equal(result.response.ok, false);
+  assert.equal(result.returnPoint, null);
+  assert.ok(result.response.message.includes('没有找到可控制的视频播放器'));
+});
+
+test('wrong video context blocks cross-video jump', async () => {
+  const video = mockVideo({ currentTime: 12, duration: 180, paused: true });
+  const result = await performConfirmedTimestampJump({
+    payload: jumpPayload(),
+    latestContext: { ...videoContext(), bvid: 'BV1Other000' },
+    video,
+  });
+
+  assert.equal(result.response.ok, false);
+  assert.equal(video.currentTime, 12);
+  assert.ok(result.response.message.includes('当前视频已经变化'));
+});
+
+test('cid mismatch blocks jump even when bvid still matches', async () => {
+  const video = mockVideo({ currentTime: 12, duration: 180, paused: true });
+  const result = await performConfirmedTimestampJump({
+    payload: jumpPayload(),
+    latestContext: { ...videoContext(), cid: 202 },
+    video,
+  });
+
+  assert.equal(result.response.ok, false);
+  assert.equal(video.currentTime, 12);
+  assert.ok(result.response.message.includes('当前视频已经变化'));
+});
+
+test('invalid timestamp and live player are blocked before seek', async () => {
+  const video = mockVideo({ currentTime: 12, duration: 40, paused: true });
+  const invalid = await performConfirmedTimestampJump({
+    payload: { ...jumpPayload(), targetSeconds: 80 },
+    latestContext: videoContext(),
+    video,
+  });
+  assert.equal(invalid.response.ok, false);
+  assert.equal(video.currentTime, 12);
+  assert.ok(invalid.response.message.includes('候选时间点无效'));
+
+  const live = await performConfirmedTimestampJump({
+    payload: jumpPayload(),
+    latestContext: videoContext(),
+    video: mockVideo({ currentTime: 12, duration: Infinity, paused: true }),
+  });
+  assert.equal(live.response.ok, false);
+  assert.ok(live.response.message.includes('直播或无时长视频'));
+});
+
+test('stale return point is not reused across old playback context', async () => {
+  const video = mockVideo({ currentTime: 42, duration: 180, paused: true });
+  const result = await performTimestampReturn({
+    returnPoint: {
+      candidateId: 'candidate:segment:safe',
+      bvid: 'BV1Jump000',
+      cid: 101,
+      page: 1,
+      url: 'https://www.bilibili.com/video/BV1Jump000',
+      seconds: 12,
+      targetSeconds: 42,
+      savedAt: 0,
+      wasPaused: true,
+    },
+    latestContext: videoContext(),
+    video,
+    now: 10 * 60 * 1000 + 1,
+  });
+
+  assert.equal(result.response.ok, false);
+  assert.equal(result.clearReturnPoint, true);
+  assert.equal(video.currentTime, 42);
+  assert.ok(result.response.message.includes('已过期'));
+});
+
+function jumpPayload(): CurrentVideoTimestampJumpContentPayload {
+  return {
+    candidateId: 'candidate:segment:safe',
+    confirmed: true,
+    contextBvid: 'BV1Jump000',
+    contextCid: 101,
+    contextPage: 1,
+    contextUrl: 'https://www.bilibili.com/video/BV1Jump000',
+    contextCollectedAt: 1000,
+    targetSeconds: 42,
+    targetTimeLabel: '0:42',
+    sourceLabel: '可定位字幕证据',
+    confidence: 0.86,
+    confidenceLabel: '高',
+    evidencePreview: '讲到模型架构的字幕片段。',
+  };
+}
+
+function videoContext(): CurrentVideoContext {
+  return {
+    kind: 'video',
+    url: 'https://www.bilibili.com/video/BV1Jump000',
+    collectedAt: 1000,
+    bvid: 'BV1Jump000',
+    cid: 101,
+    title: 'Jump test video',
+    authorName: 'Mock UP',
+    authorMid: 42,
+    durationSeconds: 180,
+    currentPart: {
+      page: 1,
+      title: '正片',
+      total: 1,
+    },
+    parts: [{ page: 1, cid: 101, title: '正片', durationSeconds: 180 }],
+    chapters: [],
+    description: {
+      availability: 'available',
+      text: 'mock description',
+      length: 16,
+    },
+    sources: {
+      metadata: 'available',
+      description: 'available',
+      pages: 'available',
+      chapters: 'unknown',
+      transcript: 'available',
+      contentText: 'unavailable',
+    },
+    warnings: [],
+  };
+}
+
+function mockVideo(input: {
+  currentTime: number;
+  duration: number;
+  paused: boolean;
+}): TimestampJumpVideoLike & { playCalls: number; pauseCalls: number } {
+  return {
+    currentTime: input.currentTime,
+    duration: input.duration,
+    paused: input.paused,
+    playCalls: 0,
+    pauseCalls: 0,
+    play() {
+      this.playCalls += 1;
+      this.paused = false;
+    },
+    pause() {
+      this.pauseCalls += 1;
+      this.paused = true;
+    },
+  };
+}


### PR DESCRIPTION
﻿## Scope

- Adds a current-video timestamp jump contract for #103 fuzzy timestamp candidates: popup preview, explicit confirmation, content-script seek, and return-to-origin action.
- Keeps candidate jumps local-first and current-video bounded. No AI rerank, no AI calls, and no automatic/background seek behavior.
- Blocks unsafe candidates before seek: metadata/description-only fallback, low-confidence candidates, stale/no context, invalid timestamps, context mismatch, unavailable player, and live/unsupported players.
- Keeps the return point bound to the active video context (`bvid` / `cid` / page) so it cannot be reused across another video.

## Root Cause / Product Judgment

#103 intentionally stopped at local fuzzy timestamp candidate retrieval and did not control the player. This PR adds the player-control slice as a separate explicit-confirmation flow: candidate cards reveal jump eligibility, the preview repeats target time/source/confidence/evidence, and the content script only seeks after the user confirms.

Low-confidence and metadata-only candidates are intentionally not directly jumpable. The UI explains why rather than turning weak evidence into a player action.

## Validation

- `npm ci` passed.
- `node --test tests/current-video-segment-retrieval.test.ts tests/current-video-timestamp-jump.test.ts` passed: 18 tests.
- `npm run test:video-knowledge` passed: 12 tests.
- `npm run test:current-video-transcript` passed: 8 tests.
- `npm run test:current-video-summary` passed: 18 tests.
- `npm run typecheck` passed.
- `npm run build` passed. Existing Vite dynamic import / large chunk warnings remain non-blocking.
- `git diff --check` passed with Windows LF/CRLF warnings only.
- `rg -n "未消费|猜你喜欢" dashboard popup public src README.md tests` returned no matches.
- User-visible raw ID scan for popup/mock did not expose `segmentId`, `sourceHash`, `transcript:` IDs, or test hashes.
- Browser/mock QA passed on `tests/current-video-segment-retrieval.mock.html` via localhost: reveal preview, confirm jump `0:12 -> 0:24`, return `0:24 -> 0:12`, low-confidence jump disabled, metadata-only jump disabled.

## Blockers

None.

## Must Fix

None known.

## Follow-up

- Real Bilibili smoke was not run in this delegated local pass because it requires a natural extension runtime session. No Cookie, browser profile, login-state, or local key files were read.
- #105 AI rerank remains intentionally out of scope.

## Privacy Boundary

- No Cookie, browser profile, Bilibili login-state, local key files, or `C:\Users\LittleNub\Desktop\Key.txt` were read.
- No full history, favorites, following list, feedback records, transcript corpus, or local DB export was uploaded.
- No Bilibili server-side relationship or content state is written.

Refs #104
