### PR TITLE
[codex] Fix current-video CID and subtitle detection

### DIFF
--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -31,6 +31,8 @@ export function App() {
   const [jumpPreviewNodeId, setJumpPreviewNodeId] = useState<string | null>(null);
   const [jumpStatus, setJumpStatus] = useState<string | null>(null);
   const [summaryLoading, setSummaryLoading] = useState(false);
+  const [subtitleProbeLoading, setSubtitleProbeLoading] = useState(false);
+  const [subtitleProbeStatus, setSubtitleProbeStatus] = useState<string | null>(null);
   const [tailProbeReport, setTailProbeReport] = useState<HistoryTailProbeReport | null>(null);
   const [tailProbeLoading, setTailProbeLoading] = useState(false);
   const [tailProbeError, setTailProbeError] = useState<string | null>(null);
@@ -117,6 +119,28 @@ export function App() {
         warnings: ['video_knowledge_request_failed'],
         limitations: [(e as Error).message],
       });
+    }
+  }
+
+  async function reprobeCurrentVideoSubtitle() {
+    setSubtitleProbeLoading(true);
+    setSubtitleProbeStatus(null);
+    try {
+      const context = await requestSW<CurrentVideoContextResult>('GET_CURRENT_VIDEO_CONTEXT', {
+        forceContextRefresh: true,
+        forceSubtitleProbe: true,
+      });
+      setCurrentVideoContext(context);
+      setSubtitleProbeStatus(
+        context.kind === 'video' && context.subtitleProbe
+          ? context.subtitleProbe.message
+          : '已重新检测当前视频上下文。',
+      );
+      await fetchVideoKnowledge();
+    } catch (e) {
+      setSubtitleProbeStatus((e as Error).message);
+    } finally {
+      setSubtitleProbeLoading(false);
     }
   }
 
@@ -337,8 +361,11 @@ export function App() {
         previewNodeId={jumpPreviewNodeId}
         jumpStatus={jumpStatus}
         loading={summaryLoading}
+        subtitleProbeLoading={subtitleProbeLoading}
+        subtitleProbeStatus={subtitleProbeStatus}
         onRefresh={fetchCurrentVideoSummary}
         onCancel={cancelCurrentVideoSummary}
+        onReprobeSubtitle={reprobeCurrentVideoSubtitle}
         onRefreshKnowledge={fetchVideoKnowledge}
         onPreviewNode={setJumpPreviewNodeId}
         onConfirmJump={confirmVideoKnowledgeJump}
@@ -518,8 +545,11 @@ function CurrentVideoAssistantStatus({
   previewNodeId,
   jumpStatus,
   loading,
+  subtitleProbeLoading,
+  subtitleProbeStatus,
   onRefresh,
   onCancel,
+  onReprobeSubtitle,
   onRefreshKnowledge,
   onPreviewNode,
   onConfirmJump,
@@ -530,8 +560,11 @@ function CurrentVideoAssistantStatus({
   previewNodeId: string | null;
   jumpStatus: string | null;
   loading: boolean;
+  subtitleProbeLoading: boolean;
+  subtitleProbeStatus: string | null;
   onRefresh: () => void;
   onCancel: () => void;
+  onReprobeSubtitle: () => void;
   onRefreshKnowledge: () => void;
   onPreviewNode: (nodeId: string | null) => void;
   onConfirmJump: (node: VideoKnowledgeNode) => void;
@@ -644,6 +677,39 @@ function CurrentVideoAssistantStatus({
                 <br />
                 {transcriptEvidenceDetail(context.transcriptEvidence)}
               </>
+            )}
+          </div>
+          <div style={{
+            marginTop: '6px',
+            padding: '7px 8px',
+            border: '1px solid rgba(255,179,71,0.24)',
+            borderRadius: '6px',
+            background: 'rgba(255,179,71,0.08)',
+          }}>
+            <div style={{ color: '#FFCF8A', fontSize: '10px', lineHeight: 1.45 }}>
+              如需使用 B 站 AI 字幕，请先在播放器里手动开启中文 AI 字幕，开启后重新检测。
+            </div>
+            <button
+              type="button"
+              onClick={onReprobeSubtitle}
+              disabled={subtitleProbeLoading}
+              style={{
+                marginTop: '6px',
+                background: subtitleProbeLoading ? 'rgba(255,255,255,0.08)' : 'rgba(255,179,71,0.18)',
+                color: subtitleProbeLoading ? '#9090A0' : '#FFCF8A',
+                border: '1px solid rgba(255,179,71,0.32)',
+                borderRadius: '6px',
+                cursor: subtitleProbeLoading ? 'default' : 'pointer',
+                fontSize: '10px',
+                padding: '4px 7px',
+              }}
+            >
+              {subtitleProbeLoading ? '检测中...' : '重新检测字幕'}
+            </button>
+            {subtitleProbeStatus && (
+              <div style={{ color: '#C8E6FF', fontSize: '9px', lineHeight: 1.45, marginTop: '5px' }}>
+                {subtitleProbeStatus}
+              </div>
             )}
           </div>
           {summary && (

--- a/public/content/page-runtime-bridge.js
+++ b/public/content/page-runtime-bridge.js
@@ -1,0 +1,141 @@
+(() => {
+  const REQUEST_TYPE = 'BILI_BILL_PAGE_RUNTIME_REQUEST';
+  const RESPONSE_TYPE = 'BILI_BILL_PAGE_RUNTIME_RESPONSE';
+  const RESPONSE_SOURCE = 'bili-bill-page-runtime';
+
+  function asRecord(value) {
+    return value && typeof value === 'object' ? value : null;
+  }
+
+  function pickNumber(value) {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) && numeric > 0 ? Math.floor(numeric) : undefined;
+  }
+
+  function pickString(value) {
+    if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+    const text = String(value).replace(/\s+/g, ' ').trim();
+    return text || undefined;
+  }
+
+  function pickOwner(value) {
+    const owner = asRecord(value);
+    if (!owner) return undefined;
+    const mid = pickNumber(owner.mid);
+    const name = pickString(owner.name);
+    return mid || name ? { mid, name } : undefined;
+  }
+
+  function pickPart(value, index) {
+    const part = asRecord(value);
+    if (!part) return null;
+    return {
+      page: pickNumber(part.page) ?? index + 1,
+      cid: pickNumber(part.cid),
+      part: pickString(part.part),
+      title: pickString(part.title),
+      duration: pickNumber(part.duration),
+    };
+  }
+
+  function pickParts(value) {
+    if (!Array.isArray(value)) return undefined;
+    return value.map(pickPart).filter(Boolean);
+  }
+
+  function pickChapters(value) {
+    if (!Array.isArray(value)) return undefined;
+    return value.map((item) => {
+      const chapter = asRecord(item);
+      if (!chapter) return null;
+      return {
+        title: pickString(chapter.title),
+        start: pickNumber(chapter.start),
+        startSeconds: pickNumber(chapter.startSeconds),
+        start_time: pickNumber(chapter.start_time),
+      };
+    }).filter(Boolean);
+  }
+
+  function pickVideoData(value) {
+    const data = asRecord(value);
+    if (!data) return null;
+    const videoData = asRecord(data.videoData);
+    const source = videoData ?? data;
+    const picked = {
+      aid: pickNumber(source.aid),
+      avid: pickNumber(source.avid),
+      bvid: pickString(source.bvid),
+      cid: pickNumber(source.cid),
+      p: pickNumber(source.p),
+      page: pickNumber(source.page),
+      title: pickString(source.title),
+      duration: pickNumber(source.duration),
+      desc: pickString(source.desc),
+      description: pickString(source.description),
+      owner: pickOwner(source.owner),
+      currentPart: pickPart(source.currentPart, 0),
+      pages: pickParts(source.pages),
+      chapters: pickChapters(source.chapters),
+    };
+
+    return Object.fromEntries(
+      Object.entries(picked).filter(([, field]) => {
+        if (Array.isArray(field)) return field.length > 0;
+        return field !== undefined && field !== null;
+      }),
+    );
+  }
+
+  function pickInitialState() {
+    const state = asRecord(window.__INITIAL_STATE__);
+    if (!state) return null;
+    const videoData = pickVideoData(state.videoData ?? state);
+    const upData = asRecord(state.upData);
+    return {
+      aid: pickNumber(state.aid),
+      avid: pickNumber(state.avid),
+      bvid: pickString(state.bvid),
+      cid: pickNumber(state.cid),
+      p: pickNumber(state.p),
+      page: pickNumber(state.page),
+      currentPart: pickPart(state.currentPart, 0),
+      videoData,
+      upData: upData
+        ? { mid: pickNumber(upData.mid), name: pickString(upData.name) }
+        : undefined,
+    };
+  }
+
+  async function pickPlayerInfo() {
+    const player = asRecord(window.player);
+    if (!player || typeof player.getVideoInfo !== 'function') return null;
+    try {
+      return pickVideoData(await player.getVideoInfo());
+    } catch {
+      return null;
+    }
+  }
+
+  window.addEventListener('message', async (event) => {
+    const data = asRecord(event.data);
+    if (
+      event.source !== window
+      || data?.source !== 'bili-bill-content-script'
+      || data?.type !== REQUEST_TYPE
+      || typeof data?.requestId !== 'string'
+    ) {
+      return;
+    }
+
+    window.postMessage({
+      source: RESPONSE_SOURCE,
+      type: RESPONSE_TYPE,
+      requestId: data.requestId,
+      payload: {
+        initialState: pickInitialState(),
+        playerInfo: await pickPlayerInfo(),
+      },
+    }, '*');
+  });
+})();

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -36,6 +36,12 @@
   "content_scripts": [
     {
       "matches": ["*://www.bilibili.com/video/*"],
+      "js": ["content/page-runtime-bridge.js"],
+      "run_at": "document_idle",
+      "world": "MAIN"
+    },
+    {
+      "matches": ["*://www.bilibili.com/video/*"],
       "js": ["content/player-monitor.js"],
       "run_at": "document_idle"
     },

--- a/src/background/current-video-subtitle-probe.ts
+++ b/src/background/current-video-subtitle-probe.ts
@@ -27,12 +27,17 @@ const fetchBilibiliPlayerInfo: CurrentVideoSubtitlePlayerInfoFetcher = async (
   target,
   options,
 ) => {
+  const params: Record<string, string> = {
+    bvid: target.bvid,
+    cid: String(target.cid),
+  };
+  if (target.aid) {
+    params.aid = String(target.aid);
+  }
+
   return await biliGet<unknown>(
     options.sourcePath,
-    {
-      bvid: target.bvid,
-      cid: String(target.cid),
-    },
+    params,
     2,
     options.sourceType === "bilibili_player_wbi_v2",
   );

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -91,6 +91,11 @@ const currentVideoContexts = new Map<number, CurrentVideoContextResult>();
 const currentVideoSubtitleProbes = new Map<string, CurrentVideoSubtitleSourceState>();
 const currentVideoSubtitleProbeRequests = new Map<string, Promise<CurrentVideoSubtitleSourceState>>();
 
+interface CurrentVideoLookupOptions {
+  forceContextRefresh?: boolean;
+  forceSubtitleProbe?: boolean;
+}
+
 export function setupMessageHandlers(): void {
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // Handle content script messages
@@ -308,9 +313,9 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
       };
     }
     case 'GET_CURRENT_VIDEO_CONTEXT':
-      return { success: true, data: await getCurrentVideoContextForActiveTab() as T };
+      return { success: true, data: await getCurrentVideoContextForActiveTab(currentVideoLookupOptions(request.params)) as T };
     case 'PROBE_CURRENT_VIDEO_SUBTITLE_SOURCE':
-      return { success: true, data: await probeSubtitleSourceForActiveTab() as T };
+      return { success: true, data: await probeSubtitleSourceForActiveTab(request.params) as T };
     case 'GET_CURRENT_VIDEO_TRANSCRIPT_EVIDENCE':
       return { success: true, data: await getTranscriptEvidenceForActiveTab(request.params) as T };
     case 'GET_CURRENT_VIDEO_SUMMARY': {
@@ -595,19 +600,28 @@ async function markConsumedFromPlayerEvent(
   await markDynamicBillItemsConsumedByBvid(payload.bvid, Date.now());
 }
 
-async function getCurrentVideoContextForActiveTab(): Promise<CurrentVideoContextResult> {
-  const context = await getRawCurrentVideoContextForActiveTab();
+async function getCurrentVideoContextForActiveTab(
+  options: CurrentVideoLookupOptions = {},
+): Promise<CurrentVideoContextResult> {
+  const context = await getRawCurrentVideoContextForActiveTab(options);
   if (context.kind !== 'video') return context;
-  const withSubtitle = await enrichCurrentVideoContextWithSubtitleProbe(context);
+  const withSubtitle = await enrichCurrentVideoContextWithSubtitleProbe(context, options);
   return await enrichCurrentVideoContextWithTranscriptEvidence(withSubtitle);
 }
 
-async function getRawCurrentVideoContextForActiveTab(): Promise<CurrentVideoContextResult> {
+async function getRawCurrentVideoContextForActiveTab(
+  options: CurrentVideoLookupOptions = {},
+): Promise<CurrentVideoContextResult> {
   const { tab, context } = await resolveCurrentVideoLookupState();
   const url = tab?.url ?? null;
 
   if (!url || !isBilibiliVideoUrl(url)) {
     return buildNoContext(url, 'non_video_page', 'non_video');
+  }
+
+  if (tab?.id && (options.forceContextRefresh || context?.kind !== 'video')) {
+    const refreshed = await requestFreshCurrentVideoContext(tab.id, url);
+    if (refreshed) return refreshed;
   }
 
   if (context?.kind === 'video') {
@@ -617,8 +631,15 @@ async function getRawCurrentVideoContextForActiveTab(): Promise<CurrentVideoCont
   return buildNoContext(url, 'video_context_unavailable', 'video');
 }
 
-async function probeSubtitleSourceForActiveTab(): Promise<CurrentVideoSubtitleSourceState> {
-  const context = await getCurrentVideoContextForActiveTab();
+async function probeSubtitleSourceForActiveTab(
+  params: Record<string, unknown> | undefined,
+): Promise<CurrentVideoSubtitleSourceState> {
+  const options = currentVideoLookupOptions({
+    ...params,
+    forceSubtitleProbe: params?.force === true || params?.forceSubtitleProbe === true,
+    forceContextRefresh: params?.force === true || params?.forceContextRefresh === true,
+  });
+  const context = await getCurrentVideoContextForActiveTab(options);
   if (context.kind === 'video' && context.subtitleProbe) {
     return context.subtitleProbe;
   }
@@ -637,20 +658,25 @@ async function getTranscriptEvidenceForActiveTab(
 
 async function enrichCurrentVideoContextWithSubtitleProbe(
   context: CurrentVideoContext,
+  options: CurrentVideoLookupOptions = {},
 ): Promise<CurrentVideoContext> {
+  const cacheKey = subtitleProbeCacheKey(context);
+  if (options.forceSubtitleProbe) {
+    currentVideoSubtitleProbes.delete(cacheKey);
+  }
+
   const existing = context.subtitleProbe;
-  if (existing && Date.now() - existing.checkedAt < SUBTITLE_PROBE_CACHE_MS) {
+  if (!options.forceSubtitleProbe && existing && Date.now() - existing.checkedAt < SUBTITLE_PROBE_CACHE_MS) {
     return withSubtitleSourceState(context, existing);
   }
 
-  const cacheKey = subtitleProbeCacheKey(context);
   const cached = currentVideoSubtitleProbes.get(cacheKey);
-  if (cached && Date.now() - cached.checkedAt < SUBTITLE_PROBE_CACHE_MS) {
+  if (!options.forceSubtitleProbe && cached && Date.now() - cached.checkedAt < SUBTITLE_PROBE_CACHE_MS) {
     return withSubtitleSourceState(context, cached);
   }
 
   const existingRequest = currentVideoSubtitleProbeRequests.get(cacheKey);
-  if (existingRequest) {
+  if (!options.forceSubtitleProbe && existingRequest) {
     const probe = await existingRequest;
     return withSubtitleSourceState(context, probe);
   }
@@ -716,6 +742,33 @@ function subtitleProbeCacheKey(context: CurrentVideoContext): string {
     context.cid ?? 'cid-unknown',
     context.currentPart.page,
   ].join(':');
+}
+
+async function requestFreshCurrentVideoContext(
+  tabId: number,
+  tabUrl: string,
+): Promise<CurrentVideoContextResult | null> {
+  try {
+    const response = await chrome.tabs.sendMessage(tabId, {
+      action: 'COLLECT_CURRENT_VIDEO_CONTEXT',
+      payload: {},
+    }) as CurrentVideoContextResult;
+    if (response?.kind !== 'video') return response ?? null;
+    if (extractBvidFromUrl(tabUrl) !== response.bvid) return null;
+    currentVideoContexts.set(tabId, response);
+    return response;
+  } catch {
+    return null;
+  }
+}
+
+function currentVideoLookupOptions(
+  params: Record<string, unknown> | undefined,
+): CurrentVideoLookupOptions {
+  return {
+    forceContextRefresh: params?.forceContextRefresh === true,
+    forceSubtitleProbe: params?.forceSubtitleProbe === true,
+  };
 }
 
 async function resolveCurrentVideoLookupState(): Promise<{

--- a/src/content/player-monitor/current-video-context.ts
+++ b/src/content/player-monitor/current-video-context.ts
@@ -6,73 +6,198 @@ import type {
 } from '../../shared/types/current-video-context';
 
 const DESCRIPTION_LIMIT = 2000;
+const BILIBILI_API_BASE = 'https://api.bilibili.com';
+const VIEW_INFO_PATH = '/x/web-interface/view';
+const PAGE_RUNTIME_REQUEST_TYPE = 'BILI_BILL_PAGE_RUNTIME_REQUEST';
+const PAGE_RUNTIME_RESPONSE_TYPE = 'BILI_BILL_PAGE_RUNTIME_RESPONSE';
+const PAGE_RUNTIME_SOURCE = 'bili-bill-page-runtime';
+const PAGE_RUNTIME_TIMEOUT_MS = 650;
+
+type UnknownRecord = Record<string, unknown>;
+type CidSource = 'initial_state' | 'player_info' | 'view_api';
 
 interface BiliInitialState {
+  aid?: number;
+  avid?: number;
   bvid?: string;
   cid?: number;
-  videoData?: {
-    bvid?: string;
-    cid?: number;
-    title?: string;
-    duration?: number;
-    desc?: string;
-    description?: string;
-    owner?: { mid?: number; name?: string };
-    pages?: Array<{ page?: number; cid?: number; part?: string; title?: string; duration?: number }>;
-    chapters?: Array<{ title?: string; start?: number; startSeconds?: number; start_time?: number }>;
-    ugc_season?: {
-      sections?: Array<{
-        episodes?: Array<{ title?: string; bvid?: string; cid?: number; page?: number; duration?: number }>;
-      }>;
-    };
-  };
+  p?: number;
+  page?: number;
+  currentPart?: { page?: number; cid?: number; part?: string; title?: string; duration?: number };
+  videoData?: BiliVideoData;
   upData?: { mid?: number; name?: string };
+}
+
+interface BiliVideoData {
+  aid?: number;
+  avid?: number;
+  bvid?: string;
+  cid?: number;
+  p?: number;
+  page?: number;
+  title?: string;
+  duration?: number;
+  desc?: string;
+  description?: string;
+  owner?: { mid?: number; name?: string };
+  currentPart?: { page?: number; cid?: number; part?: string; title?: string; duration?: number };
+  pages?: Array<{ page?: number; cid?: number; part?: string; title?: string; duration?: number }>;
+  chapters?: Array<{ title?: string; start?: number; startSeconds?: number; start_time?: number }>;
+  ugc_season?: {
+    sections?: Array<{
+      episodes?: Array<{ title?: string; bvid?: string; cid?: number; page?: number; duration?: number }>;
+    }>;
+  };
+}
+
+interface BiliPlayerVideoInfo {
+  aid?: number;
+  avid?: number;
+  bvid?: string;
+  cid?: number;
+  p?: number;
+  page?: number;
+  title?: string;
+  duration?: number;
+  pages?: Array<{ page?: number; cid?: number; part?: string; title?: string; duration?: number }>;
+  currentPart?: { page?: number; cid?: number; part?: string; title?: string; duration?: number };
+  videoData?: BiliVideoData;
+}
+
+interface BiliViewInfo {
+  aid?: number;
+  avid?: number;
+  bvid?: string;
+  cid?: number;
+  title?: string;
+  duration?: number;
+  desc?: string;
+  description?: string;
+  owner?: { mid?: number; name?: string };
+  pages?: Array<{ page?: number; cid?: number; part?: string; title?: string; duration?: number }>;
+  chapters?: Array<{ title?: string; start?: number; startSeconds?: number; start_time?: number }>;
+  ugc_season?: BiliVideoData['ugc_season'];
+}
+
+export interface BiliPageRuntimeSnapshot {
+  initialState?: BiliInitialState | null;
+  playerInfo?: BiliPlayerVideoInfo | null;
+}
+
+export type CurrentVideoViewInfoFetcher = (bvid: string) => Promise<BiliViewInfo | null>;
+export type CurrentVideoPageRuntimeReader = () => Promise<BiliPageRuntimeSnapshot | null>;
+
+export interface CollectCurrentVideoContextOptions {
+  now?: () => number;
+  fetchViewInfo?: CurrentVideoViewInfoFetcher;
+  readPageRuntime?: CurrentVideoPageRuntimeReader;
 }
 
 export function isVideoPage(): boolean {
   return location.pathname.startsWith('/video/');
 }
 
-export function collectCurrentVideoContext(): CurrentVideoContext | CurrentVideoNoContext {
+export async function collectCurrentVideoContext(
+  options: CollectCurrentVideoContextOptions = {},
+): Promise<CurrentVideoContext | CurrentVideoNoContext> {
   if (!isVideoPage()) {
-    return buildNoContext('non_video_page', 'non_video');
+    return buildNoContext('non_video_page', 'non_video', options.now?.() ?? Date.now());
   }
 
-  const state = getInitialState();
+  const now = options.now?.() ?? Date.now();
+  const runtime = await readRuntimeSnapshot(options.readPageRuntime);
+  const state = runtime?.initialState ?? getInitialState();
+  const playerInfo = runtime?.playerInfo ?? getPlayerVideoInfo();
   const urlBvid = extractBvidFromUrl();
-  const stateBvid = normalizeString(state?.bvid ?? state?.videoData?.bvid);
-  const bvid = urlBvid || stateBvid;
+  const stateBvid = bvidFromSource(state);
+  const playerBvid = bvidFromSource(playerInfo);
+  const bvid = urlBvid || playerBvid || stateBvid;
 
   if (!bvid) {
-    return buildNoContext('video_context_unavailable', 'video');
+    return buildNoContext('video_context_unavailable', 'video', now);
   }
 
   const pageNumber = extractPageFromUrl();
-  const canTrustState = !urlBvid || !stateBvid || stateBvid === urlBvid;
-  const parts = canTrustState ? collectParts(state) : [];
-  const currentPart = parts.find(part => part.page === pageNumber) ?? parts[0] ?? null;
-  const cid = canTrustState
-    ? currentPart?.cid ?? normalizeNumber(state?.cid ?? state?.videoData?.cid)
-    : null;
-  const title = canTrustState
-    ? normalizeString(state?.videoData?.title) ?? collectTitleFromDocument()
-    : collectTitleFromDocument();
-  const authorName = canTrustState
-    ? normalizeString(state?.videoData?.owner?.name ?? state?.upData?.name)
-    : null;
-  const authorMid = canTrustState
-    ? normalizeNumber(state?.videoData?.owner?.mid ?? state?.upData?.mid)
-    : null;
-  const durationSeconds = canTrustState
-    ? currentPart?.durationSeconds ?? normalizeNumber(state?.videoData?.duration)
-    : null;
-  const descriptionText = canTrustState ? collectDescription(state) : null;
-  const chapters = canTrustState ? collectChapters(state) : [];
+  const canTrustState = canTrustRuntimeSource(urlBvid, stateBvid);
+  const canTrustPlayer = canTrustRuntimeSource(urlBvid, playerBvid);
+  const stateSource = canTrustState ? state : null;
+  const playerSource = canTrustPlayer ? playerInfo : null;
+  let viewInfo: BiliViewInfo | null = null;
+  let viewFetchFailed = false;
+
+  let resolution = resolveIdentity({
+    pageNumber,
+    sources: [
+      { kind: 'initial_state', value: stateSource, allowPageAgnosticCid: false },
+      { kind: 'player_info', value: playerSource, allowPageAgnosticCid: true },
+    ],
+  });
+
+  if (!resolution.cid || resolution.parts.length === 0) {
+    try {
+      viewInfo = await (options.fetchViewInfo ?? fetchBilibiliViewInfo)(bvid);
+    } catch {
+      viewFetchFailed = true;
+    }
+
+    if (viewInfo && canTrustRuntimeSource(urlBvid, bvidFromSource(viewInfo))) {
+      resolution = resolveIdentity({
+        pageNumber,
+        sources: [
+          { kind: 'initial_state', value: stateSource, allowPageAgnosticCid: false },
+          { kind: 'player_info', value: playerSource, allowPageAgnosticCid: true },
+          { kind: 'view_api', value: viewInfo, allowPageAgnosticCid: false },
+        ],
+      });
+    }
+  }
+
+  const parts = resolution.parts;
+  const currentPart = resolution.currentPart;
+  const cid = resolution.cid;
+  const aid = firstNumber(
+    aidFromSource(stateSource),
+    aidFromSource(playerSource),
+    aidFromSource(viewInfo),
+  );
+  const title = firstString(
+    titleFromSource(stateSource),
+    titleFromSource(playerSource),
+    titleFromSource(viewInfo),
+    collectTitleFromDocument(),
+  );
+  const authorName = firstString(
+    ownerNameFromSource(stateSource),
+    ownerNameFromSource(viewInfo),
+  );
+  const authorMid = firstNumber(
+    ownerMidFromSource(stateSource),
+    ownerMidFromSource(viewInfo),
+  );
+  const durationSeconds = firstNumber(
+    currentPart?.durationSeconds,
+    durationFromSource(stateSource),
+    durationFromSource(playerSource),
+    durationFromSource(viewInfo),
+  );
+  const descriptionText = firstString(
+    descriptionFromSource(stateSource),
+    descriptionFromSource(viewInfo),
+    collectDescriptionFromDocument(),
+  )?.slice(0, DESCRIPTION_LIMIT) ?? null;
+  const chapters = firstNonEmptyArray(
+    collectChapters(stateSource),
+    collectChapters(viewInfo),
+  );
   const descriptionAvailability = descriptionText ? 'available' : 'unavailable';
   const pagesAvailability = parts.length > 0 ? 'available' : 'unavailable';
   const chaptersAvailability = chapters.length > 0 ? 'available' : 'unknown';
   const warnings: string[] = [];
 
+  if (urlBvid && stateBvid && stateBvid !== urlBvid) warnings.push('state_bvid_mismatch');
+  if (urlBvid && playerBvid && playerBvid !== urlBvid) warnings.push('player_bvid_mismatch');
+  if (viewFetchFailed) warnings.push('view_api_failed');
+  if (resolution.cidSource) warnings.push(`cid_source_${resolution.cidSource}`);
   if (!cid) warnings.push('cid_unknown');
   if (!title) warnings.push('title_unknown');
   if (!authorName && !authorMid) warnings.push('author_unknown');
@@ -83,8 +208,9 @@ export function collectCurrentVideoContext(): CurrentVideoContext | CurrentVideo
   return {
     kind: 'video',
     url: location.href,
-    collectedAt: Date.now(),
+    collectedAt: now,
     bvid,
+    aid,
     cid,
     title,
     authorName,
@@ -134,22 +260,304 @@ export function withVideoElementDuration(
 function buildNoContext(
   reason: CurrentVideoNoContext['reason'],
   pageType: CurrentVideoNoContext['pageType'],
+  now: number,
 ): CurrentVideoNoContext {
   return {
     kind: 'no_context',
     url: location.href,
-    collectedAt: Date.now(),
+    collectedAt: now,
     reason,
     pageType,
   };
 }
 
+async function readRuntimeSnapshot(
+  reader?: CurrentVideoPageRuntimeReader,
+): Promise<BiliPageRuntimeSnapshot | null> {
+  if (reader) return await reader();
+
+  const directInitialState = getInitialState();
+  const directPlayerInfo = getPlayerVideoInfo();
+  if (directInitialState || directPlayerInfo) {
+    return { initialState: directInitialState, playerInfo: directPlayerInfo };
+  }
+
+  const scriptInitialState = getInitialStateFromScriptTag();
+  const bridged = await readPageRuntimeSnapshotFromBridge();
+  return {
+    initialState: bridged?.initialState ?? scriptInitialState,
+    playerInfo: bridged?.playerInfo ?? null,
+  };
+}
+
 function getInitialState(): BiliInitialState | null {
   try {
-    return (window as any).__INITIAL_STATE__ ?? null;
+    return ((window as unknown as { __INITIAL_STATE__?: BiliInitialState }).__INITIAL_STATE__) ?? null;
   } catch {
     return null;
   }
+}
+
+function getPlayerVideoInfo(): BiliPlayerVideoInfo | null {
+  try {
+    const player = (window as unknown as { player?: { getVideoInfo?: () => unknown } }).player;
+    const info = player?.getVideoInfo?.();
+    return asRecord(info) as BiliPlayerVideoInfo | null;
+  } catch {
+    return null;
+  }
+}
+
+function getInitialStateFromScriptTag(): BiliInitialState | null {
+  const scripts = Array.from(document.querySelectorAll('script'));
+  for (const script of scripts) {
+    const text = script.textContent ?? '';
+    if (!text.includes('__INITIAL_STATE__')) continue;
+    const match = text.match(/(?:window\.)?__INITIAL_STATE__\s*=\s*(\{.*?\})\s*;\s*(?:\(function|\n|$)/s);
+    if (!match?.[1]) continue;
+    try {
+      return JSON.parse(match[1]) as BiliInitialState;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+async function readPageRuntimeSnapshotFromBridge(): Promise<BiliPageRuntimeSnapshot | null> {
+  if (typeof window === 'undefined' || typeof window.postMessage !== 'function') return null;
+
+  const requestId = `bili-bill-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return await new Promise((resolve) => {
+    let settled = false;
+    const cleanup = () => {
+      window.removeEventListener('message', onMessage);
+      window.clearTimeout(timer);
+    };
+    const finish = (value: BiliPageRuntimeSnapshot | null) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+    const onMessage = (event: MessageEvent) => {
+      const data = asRecord(event.data);
+      if (
+        event.source !== window
+        || data?.source !== PAGE_RUNTIME_SOURCE
+        || data?.type !== PAGE_RUNTIME_RESPONSE_TYPE
+        || data?.requestId !== requestId
+      ) {
+        return;
+      }
+      finish(asRecord(data.payload) as BiliPageRuntimeSnapshot | null);
+    };
+    const timer = window.setTimeout(() => finish(null), PAGE_RUNTIME_TIMEOUT_MS);
+    window.addEventListener('message', onMessage);
+    window.postMessage({
+      source: 'bili-bill-content-script',
+      type: PAGE_RUNTIME_REQUEST_TYPE,
+      requestId,
+    }, '*');
+  });
+}
+
+async function fetchBilibiliViewInfo(bvid: string): Promise<BiliViewInfo | null> {
+  const url = new URL(VIEW_INFO_PATH, BILIBILI_API_BASE);
+  url.searchParams.set('bvid', bvid);
+  const response = await fetch(url.toString(), {
+    credentials: 'include',
+    referrer: 'https://www.bilibili.com/',
+    headers: { Accept: 'application/json, text/plain, */*' },
+  });
+  const json = await response.json() as { code?: number; data?: unknown };
+  if (json.code !== 0) return null;
+  return asRecord(json.data) as BiliViewInfo | null;
+}
+
+function resolveIdentity(input: {
+  pageNumber: number;
+  sources: Array<{ kind: CidSource; value: unknown; allowPageAgnosticCid: boolean }>;
+}): {
+  parts: CurrentVideoPart[];
+  currentPart: CurrentVideoPart | null;
+  cid: number | null;
+  cidSource: CidSource | null;
+} {
+  const candidates = input.sources
+    .map(source => ({
+      kind: source.kind,
+      parts: collectParts(source.value),
+      directCid: directCidFromSource(source.value, input.pageNumber, source.allowPageAgnosticCid),
+    }))
+    .filter(candidate => candidate.parts.length > 0 || candidate.directCid !== null);
+
+  const partCandidate = candidates.find(candidate => selectCurrentPart(candidate.parts, input.pageNumber)?.cid)
+    ?? candidates.find(candidate => candidate.parts.length > 0)
+    ?? null;
+  const parts = partCandidate?.parts ?? [];
+  const currentPart = selectCurrentPart(parts, input.pageNumber);
+  const cidFromPart = currentPart?.cid ?? null;
+  if (cidFromPart) {
+    return { parts, currentPart, cid: cidFromPart, cidSource: partCandidate?.kind ?? null };
+  }
+
+  const cidCandidate = candidates.find(candidate => candidate.directCid !== null);
+  return {
+    parts,
+    currentPart,
+    cid: cidCandidate?.directCid ?? null,
+    cidSource: cidCandidate?.kind ?? null,
+  };
+}
+
+function collectParts(source: unknown): CurrentVideoPart[] {
+  const record = asRecord(source);
+  if (!record) return [];
+
+  const videoData = asRecord(record.videoData);
+  const pageSources = [
+    record.pages,
+    videoData?.pages,
+    record.currentPart ? [record.currentPart] : null,
+    videoData?.currentPart ? [videoData.currentPart] : null,
+  ];
+  for (const candidate of pageSources) {
+    if (Array.isArray(candidate) && candidate.length > 0) {
+      return candidate.map((page, index) => normalizePart(page, index));
+    }
+  }
+
+  const season = asRecord(videoData?.ugc_season ?? record.ugc_season);
+  const sections = Array.isArray(season?.sections) ? season.sections : [];
+  const episodes = sections.flatMap(section => {
+    const sectionRecord = asRecord(section);
+    return Array.isArray(sectionRecord?.episodes) ? sectionRecord.episodes : [];
+  });
+  return episodes.map((episode, index) => normalizePart(episode, index));
+}
+
+function normalizePart(value: unknown, index: number): CurrentVideoPart {
+  const part = asRecord(value);
+  return {
+    page: normalizeNumber(part?.page) ?? index + 1,
+    cid: normalizeNumber(part?.cid),
+    title: normalizeString(part?.part ?? part?.title),
+    durationSeconds: normalizeNumber(part?.duration),
+  };
+}
+
+function selectCurrentPart(parts: CurrentVideoPart[], pageNumber: number): CurrentVideoPart | null {
+  return parts.find(part => part.page === pageNumber) ?? parts[0] ?? null;
+}
+
+function directCidFromSource(
+  source: unknown,
+  pageNumber: number,
+  allowPageAgnosticCid: boolean,
+): number | null {
+  const record = asRecord(source);
+  if (!record) return null;
+  const videoData = asRecord(record.videoData);
+  const cid = normalizeNumber(record.cid ?? videoData?.cid);
+  if (!cid) return null;
+
+  const sourcePage = normalizeNumber(
+    record.page
+    ?? record.p
+    ?? asRecord(record.currentPart)?.page
+    ?? videoData?.page
+    ?? videoData?.p
+    ?? asRecord(videoData?.currentPart)?.page,
+  );
+  if (sourcePage !== null) return sourcePage === pageNumber ? cid : null;
+  if (allowPageAgnosticCid) return cid;
+  return pageNumber === 1 ? cid : null;
+}
+
+function collectChapters(source: unknown): CurrentVideoChapter[] {
+  const record = asRecord(source);
+  const videoData = asRecord(record?.videoData);
+  const chapters = record?.chapters ?? videoData?.chapters;
+  if (!Array.isArray(chapters)) return [];
+
+  return chapters
+    .map(chapter => {
+      const item = asRecord(chapter);
+      return {
+        title: normalizeString(item?.title) ?? '',
+        startSeconds: normalizeNumber(item?.startSeconds ?? item?.start ?? item?.start_time),
+      };
+    })
+    .filter(chapter => chapter.title);
+}
+
+function bvidFromSource(source: unknown): string {
+  const record = asRecord(source);
+  const videoData = asRecord(record?.videoData);
+  return normalizeString(record?.bvid ?? videoData?.bvid) ?? '';
+}
+
+function aidFromSource(source: unknown): number | null {
+  const record = asRecord(source);
+  const videoData = asRecord(record?.videoData);
+  return normalizeNumber(record?.aid ?? record?.avid ?? videoData?.aid ?? videoData?.avid);
+}
+
+function titleFromSource(source: unknown): string | null {
+  const record = asRecord(source);
+  const videoData = asRecord(record?.videoData);
+  return normalizeString(record?.title ?? videoData?.title);
+}
+
+function ownerNameFromSource(source: unknown): string | null {
+  const record = asRecord(source);
+  const videoData = asRecord(record?.videoData);
+  const owner = asRecord(record?.owner ?? videoData?.owner);
+  const upData = asRecord(record?.upData);
+  return normalizeString(owner?.name ?? upData?.name);
+}
+
+function ownerMidFromSource(source: unknown): number | null {
+  const record = asRecord(source);
+  const videoData = asRecord(record?.videoData);
+  const owner = asRecord(record?.owner ?? videoData?.owner);
+  const upData = asRecord(record?.upData);
+  return normalizeNumber(owner?.mid ?? upData?.mid);
+}
+
+function durationFromSource(source: unknown): number | null {
+  const record = asRecord(source);
+  const videoData = asRecord(record?.videoData);
+  return normalizeNumber(record?.duration ?? videoData?.duration);
+}
+
+function descriptionFromSource(source: unknown): string | null {
+  const record = asRecord(source);
+  const videoData = asRecord(record?.videoData);
+  return normalizeString(record?.desc ?? record?.description ?? videoData?.desc ?? videoData?.description);
+}
+
+function collectDescriptionFromDocument(): string | null {
+  const fromMeta = normalizeString(
+    document.querySelector<HTMLMetaElement>('meta[name="description"]')?.content,
+  );
+  const fromDom = normalizeString(
+    document.querySelector<HTMLElement>('.desc-info-text, .video-desc-container, #v_desc .desc-info')?.textContent,
+  );
+  return fromDom ?? fromMeta;
+}
+
+function collectTitleFromDocument(): string | null {
+  const rawTitle = normalizeString(document.title);
+  if (!rawTitle) return null;
+  return rawTitle
+    .replace(/_bilibili$/iu, '')
+    .trim() || rawTitle;
+}
+
+function canTrustRuntimeSource(urlBvid: string, sourceBvid: string): boolean {
+  return !urlBvid || !sourceBvid || sourceBvid === urlBvid;
 }
 
 function extractBvidFromUrl(): string {
@@ -162,61 +570,25 @@ function extractPageFromUrl(): number {
   return Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
 }
 
-function collectParts(state: BiliInitialState | null): CurrentVideoPart[] {
-  const pages = state?.videoData?.pages;
-  if (Array.isArray(pages) && pages.length > 0) {
-    return pages.map((page, index) => ({
-      page: normalizeNumber(page.page) ?? index + 1,
-      cid: normalizeNumber(page.cid),
-      title: normalizeString(page.part ?? page.title),
-      durationSeconds: normalizeNumber(page.duration),
-    }));
-  }
-
-  const episodes = state?.videoData?.ugc_season?.sections?.flatMap(section => section.episodes ?? []) ?? [];
-  return episodes.map((episode, index) => ({
-    page: normalizeNumber(episode.page) ?? index + 1,
-    cid: normalizeNumber(episode.cid),
-    title: normalizeString(episode.title),
-    durationSeconds: normalizeNumber(episode.duration),
-  }));
+function firstString(...values: Array<string | null | undefined>): string | null {
+  return values.find((value): value is string => Boolean(value)) ?? null;
 }
 
-function collectChapters(state: BiliInitialState | null): CurrentVideoChapter[] {
-  const chapters = state?.videoData?.chapters;
-  if (!Array.isArray(chapters)) return [];
-
-  return chapters
-    .map(chapter => ({
-      title: normalizeString(chapter.title) ?? '',
-      startSeconds: normalizeNumber(chapter.startSeconds ?? chapter.start ?? chapter.start_time),
-    }))
-    .filter(chapter => chapter.title);
+function firstNumber(...values: Array<number | null | undefined>): number | null {
+  return values.find((value): value is number => typeof value === 'number') ?? null;
 }
 
-function collectDescription(state: BiliInitialState | null): string | null {
-  const fromState = normalizeString(state?.videoData?.desc ?? state?.videoData?.description);
-  const fromMeta = normalizeString(
-    document.querySelector<HTMLMetaElement>('meta[name="description"]')?.content,
-  );
-  const fromDom = normalizeString(
-    document.querySelector<HTMLElement>('.desc-info-text, .video-desc-container, #v_desc .desc-info')?.textContent,
-  );
-  const text = fromState ?? fromDom ?? fromMeta;
-  return text ? text.slice(0, DESCRIPTION_LIMIT) : null;
+function firstNonEmptyArray<T>(...values: T[][]): T[] {
+  return values.find(value => value.length > 0) ?? [];
 }
 
-function collectTitleFromDocument(): string | null {
-  const rawTitle = normalizeString(document.title);
-  if (!rawTitle) return null;
-  return rawTitle
-    .replace(/_bilibili$/iu, '')
-    .trim() || rawTitle;
+function asRecord(value: unknown): UnknownRecord | null {
+  return value && typeof value === 'object' ? value as UnknownRecord : null;
 }
 
 function normalizeString(value: unknown): string | null {
-  if (typeof value !== 'string') return null;
-  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (typeof value !== 'string' && typeof value !== 'number') return null;
+  const normalized = String(value).replace(/\s+/g, ' ').trim();
   return normalized || null;
 }
 

--- a/src/content/player-monitor/index.ts
+++ b/src/content/player-monitor/index.ts
@@ -39,10 +39,7 @@ function scheduleInitialize(delay = 0): void {
 }
 
 async function initializeMonitor(): Promise<void> {
-  const context = collectCurrentVideoContext();
-  latestContext = context;
-  renderCurrentVideoAssistant(context);
-  sendCurrentVideoContext(context);
+  const context = await collectAndPublishCurrentVideoContext();
 
   if (!isVideoPage()) {
     cleanupMonitor();
@@ -144,8 +141,29 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     return true;
   }
 
+  if (message?.action === 'COLLECT_CURRENT_VIDEO_CONTEXT') {
+    collectAndPublishCurrentVideoContext().then(sendResponse).catch((error) => {
+      sendResponse({
+        kind: 'no_context',
+        url: location.href,
+        collectedAt: Date.now(),
+        reason: error instanceof Error ? 'video_context_unavailable' : 'unknown',
+        pageType: isVideoPage() ? 'video' : 'non_video',
+      } satisfies CurrentVideoContextResult);
+    });
+    return true;
+  }
+
   return false;
 });
+
+async function collectAndPublishCurrentVideoContext(): Promise<CurrentVideoContextResult> {
+  const context = await collectCurrentVideoContext();
+  latestContext = context;
+  renderCurrentVideoAssistant(context);
+  sendCurrentVideoContext(context);
+  return context;
+}
 
 async function handleVideoKnowledgeManualJump(payload: {
   node?: VideoKnowledgeNode;

--- a/src/shared/current-video-subtitle-state.ts
+++ b/src/shared/current-video-subtitle-state.ts
@@ -11,6 +11,7 @@ const BILIBILI_API_BASE = "https://api.bilibili.com";
 
 interface SubtitleProbeTarget {
   bvid: string | null;
+  aid?: number | null;
   cid: number | null;
   page: number | null;
 }
@@ -21,7 +22,7 @@ export interface PlayerInfoFetchOptions {
 }
 
 export type CurrentVideoSubtitlePlayerInfoFetcher = (
-  target: { bvid: string; cid: number; page: number | null },
+  target: { bvid: string; aid?: number | null; cid: number; page: number | null },
   options: PlayerInfoFetchOptions,
 ) => Promise<unknown>;
 
@@ -36,14 +37,14 @@ export async function probeCurrentVideoSubtitleSourceWithFetcher(
       target: { bvid: null, cid: null, page: null },
       now,
       reason: "no_current_video_context",
-      message:
-        "当前没有可探测的 B 站视频上下文；只能保留元数据和简介作为本地证据结果。",
+      message: "当前没有可检测的 B 站视频上下文；只能保留元数据和简介作为本地证据。",
       warnings: ["no_current_video_context"],
     });
   }
 
   const target = {
     bvid: context.bvid,
+    aid: context.aid ?? null,
     cid: context.cid,
     page: context.currentPart.page,
   };
@@ -54,14 +55,14 @@ export async function probeCurrentVideoSubtitleSourceWithFetcher(
       target,
       now,
       reason: "missing_cid",
-      message:
-        "当前视频缺少 CID，暂时无法探测 B 站字幕来源；只能保留元数据和简介作为本地证据结果。",
+      message: "当前视频 CID 未知，暂时无法检测 B 站字幕来源。请在 B 站播放器里手动开启中文 AI 字幕后，重新检测字幕。",
       warnings: ["cid_unknown"],
     });
   }
 
   let sawLoginRequired = false;
   let lastError: string | null = null;
+  let fallbackState: CurrentVideoSubtitleSourceState | null = null;
 
   for (const attempt of [
     {
@@ -74,17 +75,21 @@ export async function probeCurrentVideoSubtitleSourceWithFetcher(
       const data = await fetchPlayerInfo(
         {
           bvid: context.bvid,
+          aid: context.aid ?? null,
           cid: context.cid,
           page: context.currentPart.page,
         },
         attempt,
       );
-      return normalizeBilibiliSubtitleSourceState(data, {
+      const state = normalizeBilibiliSubtitleSourceState(data, {
         target,
         now,
         sourceType: attempt.sourceType,
         sourcePath: attempt.sourcePath,
       });
+      if (state.available) return state;
+      if (state.status === "login_required") sawLoginRequired = true;
+      fallbackState ??= state;
     } catch (error) {
       const message = errorMessage(error);
       lastError = message;
@@ -98,7 +103,7 @@ export async function probeCurrentVideoSubtitleSourceWithFetcher(
     }
   }
 
-  if (sawLoginRequired) {
+  if (sawLoginRequired && (!fallbackState || fallbackState.status === "unsupported")) {
     return buildCurrentVideoSubtitleSourceState({
       status: "login_required",
       target,
@@ -106,11 +111,12 @@ export async function probeCurrentVideoSubtitleSourceWithFetcher(
       sourceType: "bilibili_player_v2",
       sourcePath: "/x/player/v2",
       reason: "login_required",
-      message:
-        "B 站字幕接口要求当前浏览器会话具备访问权限；当前只能保留元数据和简介作为本地证据结果。",
+      message: "B 站字幕接口要求当前浏览器会话具备访问权限；当前只能保留元数据和简介作为本地证据。",
       warnings: ["subtitle_login_required"],
     });
   }
+
+  if (fallbackState) return fallbackState;
 
   return buildCurrentVideoSubtitleSourceState({
     status: "endpoint_failed",
@@ -119,7 +125,7 @@ export async function probeCurrentVideoSubtitleSourceWithFetcher(
     sourceType: "bilibili_player_v2",
     sourcePath: "/x/player/v2",
     reason: lastError ?? "endpoint_failed",
-    message: "B 站字幕接口请求失败；当前只能保留元数据和简介作为本地证据结果。",
+    message: "B 站字幕接口请求失败；当前只能保留元数据和简介作为本地证据。",
     warnings: ["subtitle_endpoint_failed"],
   });
 }
@@ -165,6 +171,7 @@ export function normalizeBilibiliSubtitleSourceState(
 ): CurrentVideoSubtitleSourceState {
   const root = asRecord(data);
   const subtitle = asRecord(root?.subtitle);
+  const needLoginSubtitle = normalizeBoolean(root?.need_login_subtitle ?? subtitle?.need_login_subtitle);
 
   if (!subtitle) {
     return buildCurrentVideoSubtitleSourceState({
@@ -173,9 +180,9 @@ export function normalizeBilibiliSubtitleSourceState(
       now: options.now,
       sourceType: options.sourceType,
       sourcePath: options.sourcePath,
+      needLoginSubtitle,
       reason: "subtitle_field_missing",
-      message:
-        "B 站播放器接口没有返回字幕字段；当前只能保留元数据和简介作为本地证据结果。",
+      message: "B 站播放器接口没有返回字幕字段；当前只能保留元数据和简介作为本地证据。",
       warnings: ["subtitle_field_missing"],
     });
   }
@@ -188,6 +195,7 @@ export function normalizeBilibiliSubtitleSourceState(
       now: options.now,
       sourceType: options.sourceType,
       sourcePath: options.sourcePath,
+      needLoginSubtitle,
       reason: "subtitle_tracks_not_array",
       message: "B 站字幕接口返回结构异常；当前不会把它当作可用字幕正文证据。",
       warnings: ["subtitle_malformed"],
@@ -196,15 +204,17 @@ export function normalizeBilibiliSubtitleSourceState(
 
   if (rawTracks.length === 0) {
     return buildCurrentVideoSubtitleSourceState({
-      status: "unavailable",
+      status: needLoginSubtitle ? "login_required" : "unavailable",
       target: options.target,
       now: options.now,
       sourceType: options.sourceType,
       sourcePath: options.sourcePath,
-      reason: "subtitle_tracks_empty",
-      message:
-        "当前视频没有可用字幕来源；只能基于元数据/简介，不能做完整视频总结。",
-      warnings: ["transcript_unavailable"],
+      needLoginSubtitle,
+      reason: needLoginSubtitle ? "need_login_subtitle" : "subtitle_tracks_empty",
+      message: needLoginSubtitle
+        ? "B 站提示字幕需要登录或访问权限；请确认浏览器已登录并已在播放器里手动开启中文 AI 字幕，然后重新检测字幕。"
+        : "当前接口没有返回可用字幕轨道；请先在 B 站播放器里手动开启中文 AI 字幕，开启后重新检测字幕。",
+      warnings: needLoginSubtitle ? ["subtitle_login_required"] : ["transcript_unavailable"],
     });
   }
 
@@ -221,9 +231,9 @@ export function normalizeBilibiliSubtitleSourceState(
       now: options.now,
       sourceType: options.sourceType,
       sourcePath: options.sourcePath,
+      needLoginSubtitle,
       reason: "subtitle_tracks_unusable",
-      message:
-        "B 站字幕接口返回了字幕列表，但没有可识别的语言或字幕轨道信息；当前不会把它当作可用字幕正文证据。",
+      message: "B 站字幕接口返回了字幕列表，但没有可识别的语言或轨道信息；当前不会把它当作可用字幕正文证据。",
       warnings: ["subtitle_malformed"],
     });
   }
@@ -251,8 +261,9 @@ export function normalizeBilibiliSubtitleSourceState(
     now: options.now,
     sourceType: options.sourceType,
     sourcePath: options.sourcePath,
+    needLoginSubtitle,
     reason: "subtitle_tracks_available",
-    message: `已探测到 ${tracks.length} 条字幕轨道；本版本只记录来源状态，不缓存字幕正文，也不会据此生成完整视频总结。`,
+    message: `已检测到 ${tracks.length} 条字幕轨道；本次只记录来源状态，不缓存字幕正文，也不会据此生成完整视频总结。`,
     warnings: ["transcript_source_available", "transcript_text_not_cached"],
     tracks,
     trackCount: tracks.length,
@@ -280,6 +291,7 @@ export function buildCurrentVideoSubtitleSourceState(input: {
   coverageStartSeconds?: number | null;
   coverageEndSeconds?: number | null;
   languages?: string[];
+  needLoginSubtitle?: boolean | null;
 }): CurrentVideoSubtitleSourceState {
   const sourcePath = input.sourcePath ?? null;
   return {
@@ -294,6 +306,7 @@ export function buildCurrentVideoSubtitleSourceState(input: {
       ? new URL(sourcePath, BILIBILI_API_BASE).hostname
       : null,
     sourcePath,
+    needLoginSubtitle: input.needLoginSubtitle ?? null,
     trackCount: input.trackCount ?? input.tracks?.length ?? 0,
     segmentCount: input.segmentCount ?? null,
     coverageStartSeconds: input.coverageStartSeconds ?? null,
@@ -318,9 +331,10 @@ function normalizeSubtitleTrack(
     track.lan_doc ?? track.language_label ?? track.label,
   );
   const id = normalizeString(track.id ?? track.ai_type ?? track.type);
-  const urlHost = subtitleUrlHost(
-    normalizeString(track.subtitle_url ?? track.url),
-  );
+  const subtitleUrl = normalizeString(track.subtitle_url ?? track.url);
+  const urlHost = subtitleUrlHost(subtitleUrl);
+  const aiStatus = normalizeNullableInteger(track.ai_status);
+  const aiType = normalizeNullableInteger(track.ai_type);
   const segments = Array.isArray(track.body)
     ? track.body.map(asRecord).filter(Boolean)
     : [];
@@ -341,6 +355,9 @@ function normalizeSubtitleTrack(
     id,
     language,
     languageLabel,
+    aiStatus,
+    aiType,
+    hasSubtitleUrl: Boolean(subtitleUrl),
     sourceType,
     urlHost,
     segmentCount: segments.length > 0 ? segments.length : null,
@@ -375,6 +392,20 @@ function normalizeNonNegativeNumber(value: unknown): number | null {
   const numeric = Number(value);
   if (!Number.isFinite(numeric) || numeric < 0) return null;
   return Math.round(numeric * 1000) / 1000;
+}
+
+function normalizeNullableInteger(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return null;
+  return Math.floor(numeric);
+}
+
+function normalizeBoolean(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (value === 1 || value === "1" || value === "true") return true;
+  if (value === 0 || value === "0" || value === "false") return false;
+  return null;
 }
 
 function subtitleUrlHost(value: string | null): string | null {

--- a/src/shared/types/current-video-context.ts
+++ b/src/shared/types/current-video-context.ts
@@ -40,6 +40,9 @@ export interface CurrentVideoSubtitleTrackDiagnostic {
   id: string | null;
   language: string | null;
   languageLabel: string | null;
+  aiStatus: number | null;
+  aiType: number | null;
+  hasSubtitleUrl: boolean;
   sourceType: CurrentVideoSubtitleSourceType;
   urlHost: string | null;
   segmentCount: number | null;
@@ -57,6 +60,7 @@ export interface CurrentVideoSubtitleSourceState {
   sourceType: CurrentVideoSubtitleSourceType;
   sourceDomain: string | null;
   sourcePath: string | null;
+  needLoginSubtitle: boolean | null;
   trackCount: number;
   segmentCount: number | null;
   coverageStartSeconds: number | null;
@@ -73,6 +77,7 @@ export interface CurrentVideoContext {
   url: string;
   collectedAt: number;
   bvid: string;
+  aid?: number | null;
   cid: number | null;
   title: string | null;
   authorName: string | null;

--- a/tests/current-video-context.test.ts
+++ b/tests/current-video-context.test.ts
@@ -2,9 +2,10 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { collectCurrentVideoContext } from '../src/content/player-monitor/current-video-context.ts';
 
-test('collects Bilibili video metadata and source availability from page runtime state', () => {
+test('collects Bilibili video metadata and source availability from page runtime state', async () => {
   setMockPage('https://www.bilibili.com/video/BV1CurrentCtx9?p=2', {
     videoData: {
+      aid: 8848,
       bvid: 'BV1CurrentCtx9',
       title: 'Mock current video',
       duration: 600,
@@ -17,26 +18,30 @@ test('collects Bilibili video metadata and source availability from page runtime
     },
   });
 
-  const context = collectCurrentVideoContext();
+  const context = await collectCurrentVideoContext({
+    fetchViewInfo: async () => null,
+  });
 
   assert.equal(context.kind, 'video');
   assert.equal(context.bvid, 'BV1CurrentCtx9');
-  assert.equal(context.cid, 1002);
-  assert.equal(context.title, 'Mock current video');
-  assert.equal(context.authorName, 'Mock UP');
-  assert.equal(context.authorMid, 42);
-  assert.equal(context.currentPart.page, 2);
-  assert.equal(context.parts.length, 2);
-  assert.equal(context.sources.metadata, 'available');
-  assert.equal(context.sources.description, 'available');
-  assert.equal(context.sources.pages, 'available');
-  assert.equal(context.sources.transcript, 'unknown');
-  assert.equal(context.sources.contentText, 'unavailable');
-  assert.equal(context.subtitleProbe, null);
-  assert.equal(context.description.text, 'Visible description text');
+  assert.equal(context.kind === 'video' ? context.aid : null, 8848);
+  assert.equal(context.kind === 'video' ? context.cid : null, 1002);
+  assert.equal(context.kind === 'video' ? context.title : null, 'Mock current video');
+  assert.equal(context.kind === 'video' ? context.authorName : null, 'Mock UP');
+  assert.equal(context.kind === 'video' ? context.authorMid : null, 42);
+  assert.equal(context.kind === 'video' ? context.currentPart.page : null, 2);
+  assert.equal(context.kind === 'video' ? context.parts.length : null, 2);
+  assert.equal(context.kind === 'video' ? context.sources.metadata : null, 'available');
+  assert.equal(context.kind === 'video' ? context.sources.description : null, 'available');
+  assert.equal(context.kind === 'video' ? context.sources.pages : null, 'available');
+  assert.equal(context.kind === 'video' ? context.sources.transcript : null, 'unknown');
+  assert.equal(context.kind === 'video' ? context.sources.contentText : null, 'unavailable');
+  assert.equal(context.kind === 'video' ? context.subtitleProbe : null, null);
+  assert.equal(context.kind === 'video' ? context.description.text : null, 'Visible description text');
+  assert.equal(context.kind === 'video' ? context.warnings.includes('cid_source_initial_state') : false, true);
 });
 
-test('marks missing description and transcript as unavailable without summary claims', () => {
+test('marks missing description and transcript as unavailable without summary claims', async () => {
   setMockPage('https://www.bilibili.com/video/BV1NoTextCtx9', {
     videoData: {
       bvid: 'BV1NoTextCtx9',
@@ -45,24 +50,113 @@ test('marks missing description and transcript as unavailable without summary cl
     },
   });
 
-  const context = collectCurrentVideoContext();
+  const context = await collectCurrentVideoContext({
+    fetchViewInfo: async () => null,
+  });
 
   assert.equal(context.kind, 'video');
-  assert.equal(context.sources.description, 'unavailable');
-  assert.equal(context.sources.contentText, 'unavailable');
-  assert.equal(context.sources.transcript, 'unknown');
-  assert.equal(context.description.text, null);
-  assert.deepEqual(context.warnings.includes('transcript_probe_pending'), true);
+  assert.equal(context.kind === 'video' ? context.sources.description : null, 'unavailable');
+  assert.equal(context.kind === 'video' ? context.sources.contentText : null, 'unavailable');
+  assert.equal(context.kind === 'video' ? context.sources.transcript : null, 'unknown');
+  assert.equal(context.kind === 'video' ? context.description.text : null, null);
+  assert.deepEqual(context.kind === 'video' ? context.warnings.includes('transcript_probe_pending') : false, true);
 });
 
-test('returns no-context fallback outside Bilibili video pages', () => {
+test('returns no-context fallback outside Bilibili video pages', async () => {
   setMockPage('https://www.bilibili.com/', {});
 
-  const context = collectCurrentVideoContext();
+  const context = await collectCurrentVideoContext();
 
   assert.equal(context.kind, 'no_context');
-  assert.equal(context.reason, 'non_video_page');
-  assert.equal(context.pageType, 'non_video');
+  assert.equal(context.kind === 'no_context' ? context.reason : null, 'non_video_page');
+  assert.equal(context.kind === 'no_context' ? context.pageType : null, 'non_video');
+});
+
+test('ignores stale initial-state CID when URL BVID differs and uses view API pages', async () => {
+  setMockPage('https://www.bilibili.com/video/BV1FreshCid9?p=2', {
+    videoData: {
+      bvid: 'BV1OldState99',
+      cid: 1111,
+      title: 'Old page state',
+      pages: [
+        { page: 1, cid: 1111, part: 'Old part' },
+      ],
+    },
+  });
+
+  const context = await collectCurrentVideoContext({
+    fetchViewInfo: async (bvid) => {
+      assert.equal(bvid, 'BV1FreshCid9');
+      return {
+        aid: 9002,
+        bvid,
+        title: 'Fresh video',
+        owner: { mid: 8, name: 'Fresh UP' },
+        pages: [
+          { page: 1, cid: 2001, part: 'Fresh intro' },
+          { page: 2, cid: 2002, part: 'Fresh current' },
+        ],
+      };
+    },
+  });
+
+  assert.equal(context.kind, 'video');
+  assert.equal(context.kind === 'video' ? context.bvid : null, 'BV1FreshCid9');
+  assert.equal(context.kind === 'video' ? context.cid : null, 2002);
+  assert.equal(context.kind === 'video' ? context.aid : null, 9002);
+  assert.equal(context.kind === 'video' ? context.title : null, 'Fresh video');
+  assert.equal(context.kind === 'video' ? context.currentPart.title : null, 'Fresh current');
+  assert.equal(context.kind === 'video' ? context.warnings.includes('state_bvid_mismatch') : false, true);
+  assert.equal(context.kind === 'video' ? context.warnings.includes('cid_source_view_api') : false, true);
+});
+
+test('uses player.getVideoInfo fallback when initial state has no CID', async () => {
+  setMockPage('https://www.bilibili.com/video/BV1PlayerCid9?p=2', {});
+
+  const context = await collectCurrentVideoContext({
+    readPageRuntime: async () => ({
+      initialState: {
+        videoData: {
+          bvid: 'BV1PlayerCid9',
+          title: 'Initial title',
+        },
+      },
+      playerInfo: {
+        aid: 3030,
+        bvid: 'BV1PlayerCid9',
+        cid: 3032,
+        page: 2,
+        pages: [
+          { page: 1, cid: 3031, part: 'Part 1' },
+          { page: 2, cid: 3032, part: 'Part 2' },
+        ],
+      },
+    }),
+  });
+
+  assert.equal(context.kind, 'video');
+  assert.equal(context.kind === 'video' ? context.cid : null, 3032);
+  assert.equal(context.kind === 'video' ? context.aid : null, 3030);
+  assert.equal(context.kind === 'video' ? context.currentPart.page : null, 2);
+  assert.equal(context.kind === 'video' ? context.warnings.includes('cid_source_player_info') : false, true);
+});
+
+test('does not reuse page-1 direct CID for URL p=2 when pages are missing', async () => {
+  setMockPage('https://www.bilibili.com/video/BV1MultiNoPages?p=2', {
+    videoData: {
+      bvid: 'BV1MultiNoPages',
+      cid: 4041,
+      title: 'Direct CID only',
+    },
+  });
+
+  const context = await collectCurrentVideoContext({
+    fetchViewInfo: async () => null,
+  });
+
+  assert.equal(context.kind, 'video');
+  assert.equal(context.kind === 'video' ? context.cid : null, null);
+  assert.equal(context.kind === 'video' ? context.warnings.includes('cid_unknown') : false, true);
 });
 
 function setMockPage(url: string, initialState: unknown): void {
@@ -71,6 +165,9 @@ function setMockPage(url: string, initialState: unknown): void {
     title: 'Mock title_bilibili',
     querySelector() {
       return null;
+    },
+    querySelectorAll() {
+      return [];
     },
   };
 

--- a/tests/current-video-subtitle-cid-detection.mock.html
+++ b/tests/current-video-subtitle-cid-detection.mock.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Bili-Bill 当前视频字幕检测 Mock</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #10131f;
+        color: #f2f4f8;
+      }
+
+      body {
+        margin: 0;
+        padding: 24px;
+      }
+
+      main {
+        max-width: 760px;
+        margin: 0 auto;
+      }
+
+      h1 {
+        font-size: 18px;
+        margin: 0 0 16px;
+      }
+
+      .panel {
+        border: 1px solid rgba(255, 255, 255, 0.16);
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.06);
+        padding: 14px 16px;
+        margin-top: 12px;
+      }
+
+      .row {
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        margin-top: 8px;
+        font-size: 14px;
+      }
+
+      .muted {
+        color: #a9b0c3;
+      }
+
+      .warn {
+        color: #ffcf8a;
+      }
+
+      .ok {
+        color: #9be7b0;
+      }
+
+      button {
+        margin-top: 14px;
+        border: 0;
+        border-radius: 6px;
+        background: #fb7299;
+        color: white;
+        padding: 8px 12px;
+        cursor: pointer;
+        font-weight: 700;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Bili-Bill 当前视频字幕检测 Mock</h1>
+      <section class="panel">
+        <strong>B 站播放器状态</strong>
+        <div class="row">
+          <span>当前视频</span>
+          <span>BV1MockSubtitle9 / 第 2 P</span>
+        </div>
+        <div class="row">
+          <span>播放器字幕</span>
+          <span class="ok" data-testid="player-subtitle">中文 AI 已开启</span>
+        </div>
+      </section>
+
+      <section class="panel">
+        <strong>重新检测前</strong>
+        <div class="row">
+          <span>Bili-Bill 上下文</span>
+          <span class="warn" data-testid="before-context">CID 未知 / 字幕不可用</span>
+        </div>
+        <div class="muted">
+          旧状态来自页面初次加载时的缺失 CID 快照，不能作为字幕探测目标。
+        </div>
+      </section>
+
+      <section class="panel">
+        <strong>重新检测后</strong>
+        <div class="muted">
+          如需使用 B 站 AI 字幕，请先在播放器里手动开启中文 AI 字幕，开启后重新检测。
+        </div>
+        <button type="button" data-testid="reprobe-button">重新检测字幕</button>
+        <div class="row">
+          <span>Bili-Bill 上下文</span>
+          <span data-testid="resolved-context">等待检测</span>
+        </div>
+        <div class="row">
+          <span>字幕轨道</span>
+          <span data-testid="resolved-subtitle">等待检测</span>
+        </div>
+        <div class="row">
+          <span>诊断</span>
+          <span data-testid="resolved-diagnostic">等待检测</span>
+        </div>
+      </section>
+    </main>
+    <script>
+      const button = document.querySelector('[data-testid="reprobe-button"]');
+      button.addEventListener('click', () => {
+        document.querySelector('[data-testid="resolved-context"]').textContent =
+          'BV1MockSubtitle9 / CID 2202 / 第 2 P';
+        document.querySelector('[data-testid="resolved-subtitle"]').textContent =
+          '中文 AI；AI 状态 1；AI 类型 0；字幕地址已返回但不展示原始链接';
+        document.querySelector('[data-testid="resolved-diagnostic"]').textContent =
+          '先用 /x/player/wbi/v2 探测，未返回轨道后回退 /x/player/v2，并检测到 1 条字幕轨道。';
+      });
+    </script>
+  </body>
+</html>

--- a/tests/current-video-subtitle-probe.test.ts
+++ b/tests/current-video-subtitle-probe.test.ts
@@ -24,7 +24,9 @@ test("normalizes available Bilibili subtitle metadata without storing raw track 
           {
             id: 101,
             lan: "zh-CN",
-            lan_doc: "中文（自动生成）",
+            lan_doc: "中文（AI）",
+            ai_status: 1,
+            ai_type: 2,
             subtitle_url:
               "//aisubtitle.hdslb.com/bfs/ai_subtitle/mock-track.json?token=redacted",
           },
@@ -52,7 +54,11 @@ test("normalizes available Bilibili subtitle metadata without storing raw track 
   assert.deepEqual(probe.languages, ["zh-CN", "en-US"]);
   assert.equal(probe.sourceDomain, "api.bilibili.com");
   assert.equal(probe.sourcePath, "/x/player/wbi/v2");
+  assert.equal(probe.needLoginSubtitle, null);
   assert.equal(probe.tracks[0].urlHost, "aisubtitle.hdslb.com");
+  assert.equal(probe.tracks[0].aiStatus, 1);
+  assert.equal(probe.tracks[0].aiType, 2);
+  assert.equal(probe.tracks[0].hasSubtitleUrl, true);
   assert.equal(probe.segmentCount, null);
   assert.equal(probe.coverageEndSeconds, null);
   assert.doesNotMatch(
@@ -98,7 +104,42 @@ test("reports unavailable when player subtitle track list is empty", async () =>
   assert.equal(probe.status, "unavailable");
   assert.equal(probe.available, false);
   assert.equal(probe.trackCount, 0);
-  assert.match(probe.message, /没有可用字幕来源/);
+  assert.match(probe.message, /手动开启中文 AI 字幕/);
+});
+
+test("falls back from WBI player endpoint to v2 when WBI returns no tracks", async () => {
+  const calls: string[] = [];
+  const probe = await probeCurrentVideoSubtitleSource(
+    videoContext(),
+    async (_target, options) => {
+      calls.push(options.sourcePath);
+      if (options.sourcePath === "/x/player/wbi/v2") {
+        return { subtitle: { subtitles: [] } };
+      }
+      return {
+        subtitle: {
+          subtitles: [
+            {
+              lan: "zh-CN",
+              lan_doc: "中文 AI",
+              ai_status: 1,
+              ai_type: 0,
+              subtitle_url: "//aisubtitle.hdslb.com/bfs/ai_subtitle/zh.json",
+            },
+          ],
+        },
+      };
+    },
+    3500,
+  );
+
+  assert.deepEqual(calls, ["/x/player/wbi/v2", "/x/player/v2"]);
+  assert.equal(probe.status, "available");
+  assert.equal(probe.sourceType, "bilibili_player_v2");
+  assert.equal(probe.tracks[0].languageLabel, "中文 AI");
+  assert.equal(probe.tracks[0].aiStatus, 1);
+  assert.equal(probe.tracks[0].aiType, 0);
+  assert.equal(probe.tracks[0].hasSubtitleUrl, true);
 });
 
 test("reports endpoint failure after player subtitle endpoints fail", async () => {
@@ -133,6 +174,19 @@ test("reports login required only when both player endpoints require session acc
   assert.ok(probe.warnings.includes("subtitle_login_required"));
 });
 
+test("reports need-login subtitle diagnostic from player response", async () => {
+  const probe = await probeCurrentVideoSubtitleSource(
+    videoContext(),
+    async () => ({ subtitle: { need_login_subtitle: true, subtitles: [] } }),
+    5500,
+  );
+
+  assert.equal(probe.status, "login_required");
+  assert.equal(probe.reason, "need_login_subtitle");
+  assert.equal(probe.needLoginSubtitle, true);
+  assert.ok(probe.warnings.includes("subtitle_login_required"));
+});
+
 test("reports malformed player subtitle response without treating it as transcript evidence", async () => {
   const probe = await probeCurrentVideoSubtitleSource(
     videoContext(),
@@ -143,7 +197,7 @@ test("reports malformed player subtitle response without treating it as transcri
   assert.equal(probe.status, "malformed");
   assert.equal(probe.available, false);
   assert.equal(probe.trackCount, 0);
-  assert.match(probe.message, /返回结构异常/);
+  assert.match(probe.message, /结构异常/);
 });
 
 test("reports unsupported when there is no current video context", async () => {
@@ -165,6 +219,23 @@ test("reports unsupported when there is no current video context", async () => {
   assert.equal(probe.status, "unsupported");
   assert.equal(probe.available, false);
   assert.equal(probe.reason, "no_current_video_context");
+});
+
+test("does not call player subtitle endpoints when CID is missing", async () => {
+  let called = false;
+  const probe = await probeCurrentVideoSubtitleSource(
+    { ...videoContext(), cid: null },
+    async () => {
+      called = true;
+      return { subtitle: { subtitles: [] } };
+    },
+    7500,
+  );
+
+  assert.equal(called, false);
+  assert.equal(probe.status, "unsupported");
+  assert.equal(probe.reason, "missing_cid");
+  assert.match(probe.message, /CID 未知/);
 });
 
 test("keeps subtitle source diagnostics out of current video AI payload", async () => {
@@ -208,6 +279,7 @@ function videoContext(): CurrentVideoContext {
     url: "https://www.bilibili.com/video/BV1Subtitle99?p=1",
     collectedAt: 1000,
     bvid: "BV1Subtitle99",
+    aid: 8800,
     cid: 9901,
     title: "Subtitle probe video",
     authorName: "Probe UP",

--- a/tests/current-video-summary.test.ts
+++ b/tests/current-video-summary.test.ts
@@ -62,6 +62,7 @@ test('keeps available subtitle source state separate from transcript summary', (
     sourceType: 'bilibili_player_wbi_v2',
     sourceDomain: 'api.bilibili.com',
     sourcePath: '/x/player/wbi/v2',
+    needLoginSubtitle: null,
     trackCount: 1,
     segmentCount: null,
     coverageStartSeconds: null,

--- a/tests/video-knowledge.test.ts
+++ b/tests/video-knowledge.test.ts
@@ -55,6 +55,7 @@ test('exposes available subtitle source state without generating transcript node
     sourceType: 'bilibili_player_wbi_v2',
     sourceDomain: 'api.bilibili.com',
     sourcePath: '/x/player/wbi/v2',
+    needLoginSubtitle: null,
     trackCount: 1,
     segmentCount: null,
     coverageStartSeconds: null,


### PR DESCRIPTION
﻿## Scope

- Fix current-video identity collection so Bili-Bill can resolve `bvid`, current `cid`, `aid`, and current part/page after Bilibili page/player state changes.
- Add a main-world page-runtime bridge for `__INITIAL_STATE__` and `window.player.getVideoInfo()` metadata only.
- Add `/x/web-interface/view?bvid=...` fallback for safe page/CID metadata when runtime state is incomplete or stale.
- Refresh subtitle detection on demand with a popup “重新检测字幕” entry point that bypasses the cached probe.
- Extend subtitle metadata diagnostics for endpoint fallback, language, AI subtitle flags, URL presence without raw URL exposure, and login/access hints.

## Root Cause / Product Judgment

The previous flow depended on the first content-script context snapshot and then reused a 5-minute subtitle-probe cache. If Bilibili filled CID/player state later, if `__INITIAL_STATE__` was incomplete or stale for another BVID, or if the user enabled “中文 AI” subtitles after the first probe, Bili-Bill stayed on `CID 未知` or an old unavailable subtitle result. This PR keeps the product slice at source detection only: it detects reliable identity and subtitle-track state, but does not fetch subtitle bodies, write transcript segments, change summary semantics, or add retrieval/jump/rerank behavior.

## Validation

- `node --test tests/current-video-context.test.ts tests/current-video-subtitle-probe.test.ts tests/current-video-context-resolver.test.ts`
- `npm run test:current-video-transcript`
- `npm run test:current-video-summary`
- `npm run test:video-knowledge`
- `npm run typecheck`
- `git diff --check` and `git diff --cached --check` (only Windows LF/CRLF notices before staging; staged check clean)
- `rg -n "未消费|猜你喜欢" dashboard popup public src README.md tests` (no matches)
- `npm run build` (passed; existing Vite chunk-size/dynamic-import warnings only)
- Browser/mock QA over `tests/current-video-subtitle-cid-detection.mock.html` served from localhost: before state showed `CID 未知 / 字幕不可用` while player displayed `中文 AI 已开启`; after clicking “重新检测字幕”, mock reported `BV1MockSubtitle9 / CID 2202 / 第 2 P` and one Chinese AI subtitle track without showing raw subtitle URL.

## Privacy Boundary

- Did not read Cookie files, browser profile files, Bilibili login-state files, local key files, or `C:\Users\LittleNub\Desktop\Key.txt`.
- Did not upload full history, favorites, following, feedback, or local DB content.
- Runtime requests use only active-page metadata and Bilibili subtitle metadata endpoints; no Bilibili write-back.
- Raw `subtitle_url` values stay internal and are not exposed in normal UI.

## Blockers / Must Fix / Follow-up

- Blockers: none.
- Must fix: none known.
- Follow-up: #114/#115 can consume the improved source state to continue transcript-body/cache or downstream current-video workflows, but this PR intentionally does not fetch subtitle正文 or alter summary/retrieval/jump/rerank behavior.

Closes #113
