### PR TITLE
[codex] Cache current-video subtitle body evidence

### DIFF
--- a/src/background/current-video-transcript-cache.ts
+++ b/src/background/current-video-transcript-cache.ts
@@ -110,6 +110,7 @@ async function cacheCurrentVideoTranscriptEvidenceInner(
       const data = await fetchPlayerInfo(
         {
           bvid: context.bvid,
+          aid: context.aid ?? null,
           cid: context.cid as number,
           page: context.currentPart.page,
         },
@@ -149,9 +150,9 @@ async function cacheCurrentVideoTranscriptEvidenceInner(
           target,
           now: options.now,
           sourceType: attempt.sourceType,
-          reason: 'subtitle_url_host_unsupported',
+          reason: 'subtitle_host_unsupported',
           message: '字幕轨道地址不可用或不属于受限的 B 站字幕域名；未读取正文。',
-          warnings: ['subtitle_track_url_unavailable'],
+          warnings: ['subtitle_track_host_unsupported'],
         });
       }
 
@@ -387,7 +388,11 @@ function normalizeLanguage(value: unknown): string | null {
 }
 
 function isLoginRequiredError(message: string): boolean {
-  return message === 'NOT_LOGGED_IN' || /-101/.test(message);
+  return message === 'NOT_LOGGED_IN'
+    || /-101/.test(message)
+    || /-403/.test(message)
+    || /SUBTITLE_HTTP_40[13]/.test(message)
+    || /\b40[13]\b/.test(message);
 }
 
 function errorMessage(error: unknown): string {

--- a/tests/current-video-subtitle-body-cache.mock.html
+++ b/tests/current-video-subtitle-body-cache.mock.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Bili-Bill 当前视频字幕正文缓存 Mock</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #10131f;
+        color: #f2f4f8;
+      }
+
+      body {
+        margin: 0;
+        padding: 24px;
+      }
+
+      main {
+        max-width: 760px;
+        margin: 0 auto;
+      }
+
+      h1 {
+        font-size: 18px;
+        margin: 0 0 16px;
+      }
+
+      .panel {
+        border: 1px solid rgba(255, 255, 255, 0.16);
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.06);
+        padding: 14px 16px;
+        margin-top: 12px;
+      }
+
+      .row {
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        margin-top: 8px;
+        font-size: 14px;
+      }
+
+      .muted {
+        color: #a9b0c3;
+      }
+
+      .ok {
+        color: #9be7b0;
+      }
+
+      .warn {
+        color: #ffcf8a;
+      }
+
+      button {
+        margin-top: 14px;
+        border: 0;
+        border-radius: 6px;
+        background: #fb7299;
+        color: white;
+        padding: 8px 12px;
+        cursor: pointer;
+        font-weight: 700;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Bili-Bill 当前视频字幕正文缓存 Mock</h1>
+      <section class="panel">
+        <strong>当前视频</strong>
+        <div class="row">
+          <span>身份</span>
+          <span data-testid="identity">BV1MockSubtitle9 / CID 2202 / 第 2 P</span>
+        </div>
+        <div class="row">
+          <span>字幕来源</span>
+          <span class="ok" data-testid="source-state">已检测到 B 站 AI 中文字幕轨道</span>
+        </div>
+        <div class="muted">字幕轨道地址仅在后台内部使用，普通界面不展示原始链接。</div>
+      </section>
+
+      <section class="panel">
+        <strong>正文缓存</strong>
+        <button type="button" data-testid="cache-button">拉取并缓存字幕正文</button>
+        <div class="row">
+          <span>拉取结果</span>
+          <span data-testid="fetch-state">等待拉取</span>
+        </div>
+        <div class="row">
+          <span>缓存状态</span>
+          <span data-testid="cache-state">尚未缓存</span>
+        </div>
+      </section>
+
+      <section class="panel">
+        <strong>下游读取</strong>
+        <div class="row">
+          <span>摘要</span>
+          <span data-testid="summary-state" class="warn">当前仍是简介/元数据兜底</span>
+        </div>
+        <div class="row">
+          <span>Video Knowledge</span>
+          <span data-testid="knowledge-state" class="warn">当前没有字幕节点</span>
+        </div>
+        <div class="row">
+          <span>检索</span>
+          <span data-testid="search-state" class="warn">当前没有可定位字幕证据</span>
+        </div>
+      </section>
+    </main>
+    <script>
+      const subtitleUrl = "https://aisubtitle.hdslb.com/bfs/ai_subtitle/private-track.json?token=secret";
+      const subtitleJson = {
+        body: [
+          { from: 0, to: 4, content: "模型架构从这里开始，介绍专家路由。" },
+          { from: 4, to: 8, content: "这一段说明缓存后的字幕正文会作为本地证据。" },
+        ],
+      };
+
+      function allowedSubtitleHost(url) {
+        const parsed = new URL(url);
+        return parsed.protocol === "https:" && (
+          parsed.hostname === "bilibili.com" ||
+          parsed.hostname.endsWith(".bilibili.com") ||
+          parsed.hostname === "hdslb.com" ||
+          parsed.hostname.endsWith(".hdslb.com")
+        );
+      }
+
+      function cacheSubtitleBody() {
+        if (!allowedSubtitleHost(subtitleUrl)) {
+          document.querySelector('[data-testid="fetch-state"]').textContent = "字幕域名不受支持，未读取正文";
+          return;
+        }
+
+        const segments = subtitleJson.body
+          .map((row) => ({
+            startSeconds: Number(row.from),
+            endSeconds: Number(row.to),
+            text: String(row.content || "").trim(),
+          }))
+          .filter((row) => Number.isFinite(row.startSeconds) && row.endSeconds > row.startSeconds && row.text);
+
+        document.querySelector('[data-testid="fetch-state"]').textContent = `已从受限 B 站字幕域名读取 body[]，有效片段 ${segments.length} 段`;
+        document.querySelector('[data-testid="cache-state"]').textContent = `已缓存 ${segments.length} 段当前视频字幕正文证据`;
+        document.querySelector('[data-testid="summary-state"]').textContent = "字幕正文摘要：0:00-0:08 围绕模型架构与本地证据缓存";
+        document.querySelector('[data-testid="summary-state"]').className = "ok";
+        document.querySelector('[data-testid="knowledge-state"]').textContent = "已生成字幕节点：0:00-0:04 模型架构";
+        document.querySelector('[data-testid="knowledge-state"]').className = "ok";
+        document.querySelector('[data-testid="search-state"]').textContent = "检索“专家路由”命中 0:00-0:04 的可定位字幕证据";
+        document.querySelector('[data-testid="search-state"]').className = "ok";
+      }
+
+      document.querySelector('[data-testid="cache-button"]').addEventListener("click", cacheSubtitleBody);
+    </script>
+  </body>
+</html>

--- a/tests/current-video-transcript-cache.test.ts
+++ b/tests/current-video-transcript-cache.test.ts
@@ -12,7 +12,12 @@ import {
   auditAssistantPayload,
   currentVideoSummaryPayloadContract,
 } from '../src/shared/assistant-payload-audit.ts';
-import { buildCurrentVideoSummaryAiPayload } from '../src/shared/current-video-summary.ts';
+import {
+  buildCurrentVideoSummaryAiPayload,
+  buildLocalCurrentVideoSummary,
+} from '../src/shared/current-video-summary.ts';
+import { searchCurrentVideoSegments } from '../src/shared/current-video-segment-retrieval.ts';
+import { buildVideoKnowledgeResult } from '../src/shared/video-knowledge.ts';
 import type { CurrentVideoContext } from '../src/shared/types/current-video-context.ts';
 import type {
   CurrentVideoTranscriptEvidenceState,
@@ -159,20 +164,24 @@ test('records empty and malformed transcript states without active segments', ()
 test('background cache fetch keeps raw subtitle URL internal and reports language/track diagnostics', async () => {
   const store = memoryStore();
   let fetchedUrl = '';
+  const fetchTargets: Array<{ bvid: string; aid?: number | null; cid: number; page: number | null }> = [];
   const state = await cacheCurrentVideoTranscriptEvidence(videoContext(), {
     now: 5000,
-    fetchPlayerInfo: async () => ({
-      subtitle: {
-        subtitles: [
-          {
-            id: 7,
-            lan: 'zh-CN',
-            lan_doc: 'Chinese',
-            subtitle_url: '//aisubtitle.hdslb.com/bfs/ai_subtitle/private-track.json?token=secret',
-          },
-        ],
-      },
-    }),
+    fetchPlayerInfo: async (target) => {
+      fetchTargets.push(target);
+      return {
+        subtitle: {
+          subtitles: [
+            {
+              id: 7,
+              lan: 'zh-CN',
+              lan_doc: 'Chinese',
+              subtitle_url: '//aisubtitle.hdslb.com/bfs/ai_subtitle/private-track.json?token=secret',
+            },
+          ],
+        },
+      };
+    },
     fetchSubtitleJson: async (url) => {
       fetchedUrl = url;
       return { body: [{ from: 0, to: 2, content: 'background fetched text' }] };
@@ -183,8 +192,78 @@ test('background cache fetch keeps raw subtitle URL internal and reports languag
   assert.equal(state.status, 'cached');
   assert.equal(state.language, 'zh-CN');
   assert.equal(state.segmentCount, 1);
+  assert.deepEqual(fetchTargets[0], { bvid: 'BV1Transcript00', aid: 8800, cid: 101, page: 1 });
   assert.match(fetchedUrl, /^https:\/\/aisubtitle\.hdslb\.com\//);
   assert.doesNotMatch(JSON.stringify(state), /private-track|subtitle_url|token=secret|SESSDATA|Key\.txt/i);
+});
+
+test('background cache blocks unsupported subtitle hosts before fetching body', async () => {
+  let fetched = false;
+  const state = await cacheCurrentVideoTranscriptEvidence(videoContext(), {
+    now: 5100,
+    fetchPlayerInfo: async () => ({
+      subtitle: {
+        subtitles: [
+          {
+            id: 7,
+            lan: 'zh-CN',
+            subtitle_url: 'https://evil.example.invalid/private-track.json?token=secret',
+          },
+        ],
+      },
+    }),
+    fetchSubtitleJson: async () => {
+      fetched = true;
+      return { body: [{ from: 0, to: 2, content: 'should not fetch' }] };
+    },
+  });
+
+  assert.equal(state.status, 'track_unavailable');
+  assert.equal(state.reason, 'subtitle_host_unsupported');
+  assert.equal(fetched, false);
+  assert.doesNotMatch(JSON.stringify(state), /evil\.example|private-track|token=secret|subtitle_url/i);
+});
+
+test('background cache distinguishes fetch failure from subtitle access failure', async () => {
+  const endpointFailed = await cacheCurrentVideoTranscriptEvidence(videoContext(), {
+    now: 5200,
+    fetchPlayerInfo: async () => ({
+      subtitle: {
+        subtitles: [
+          {
+            lan: 'zh-CN',
+            subtitle_url: '//aisubtitle.hdslb.com/bfs/ai_subtitle/zh.json',
+          },
+        ],
+      },
+    }),
+    fetchSubtitleJson: async () => {
+      throw new Error('NETWORK_DOWN');
+    },
+  });
+  assert.equal(endpointFailed.status, 'endpoint_failed');
+  assert.equal(endpointFailed.active, false);
+  assert.ok(endpointFailed.warnings.includes('transcript_endpoint_failed'));
+
+  const accessFailure = await cacheCurrentVideoTranscriptEvidence(videoContext(), {
+    now: 5300,
+    fetchPlayerInfo: async () => ({
+      subtitle: {
+        subtitles: [
+          {
+            lan: 'zh-CN',
+            subtitle_url: '//aisubtitle.hdslb.com/bfs/ai_subtitle/private.json',
+          },
+        ],
+      },
+    }),
+    fetchSubtitleJson: async () => {
+      throw new Error('SUBTITLE_HTTP_403');
+    },
+  });
+  assert.equal(accessFailure.status, 'login_required');
+  assert.equal(accessFailure.active, false);
+  assert.ok(accessFailure.warnings.includes('transcript_login_required'));
 });
 
 test('background cache reports language mismatch and unavailable track states', async () => {
@@ -239,6 +318,44 @@ test('privacy audit keeps cached transcript text out of current video AI payload
     rawPayload,
     /SECRET TRANSCRIPT BODY|segmentId|sourceHash|watchHistory|favorites|following|feedback|Cookie|Key\.txt|Chrome\\User Data/i,
   );
+});
+
+test('cached subtitle body becomes active evidence for summary, video knowledge, and segment search', () => {
+  const store = memoryStore();
+  const state = store.upsert(normalizeBilibiliTranscriptEvidence(
+    {
+      body: [
+        { from: 0, to: 4, content: '模型架构从这里开始，介绍专家路由。' },
+        { from: 4, to: 8, content: '这一段说明缓存后的字幕正文会作为本地证据。' },
+      ],
+    },
+    baseNormalizeOptions(),
+  ));
+  const context = withTranscriptEvidenceState(videoContext(), state);
+  context.sources.transcript = 'available';
+  const summary = buildLocalCurrentVideoSummary(context, {
+    transcriptSegments: store.segments,
+    now: 8000,
+  });
+  const knowledge = buildVideoKnowledgeResult(context, {
+    transcriptSegments: store.segments,
+    now: 8000,
+  });
+  const search = searchCurrentVideoSegments(context, {
+    query: '专家路由',
+    transcriptSegments: store.segments,
+    videoKnowledge: knowledge,
+    now: 8000,
+  });
+  const raw = JSON.stringify({ summary, knowledge, search });
+
+  assert.equal(context.transcriptEvidence?.active, true);
+  assert.equal(summary.sourceTier, 'transcript_summary');
+  assert.equal(knowledge.sourceState.transcriptEvidence, true);
+  assert.ok(knowledge.nodes.some(node => node.source === 'transcript'));
+  assert.equal(search.status, 'ready');
+  assert.equal(search.candidates[0].binding.kind, 'transcript_segment');
+  assert.doesNotMatch(raw, /subtitle_url|raw subtitle|watchHistory|favorites|following|feedback|Cookie|Key\.txt|Chrome\\User Data/i);
 });
 
 function baseNormalizeOptions(overrides: Partial<Parameters<typeof normalizeBilibiliTranscriptEvidence>[1]> = {}) {
@@ -304,6 +421,7 @@ function videoContext(): CurrentVideoContext {
     url: 'https://www.bilibili.com/video/BV1Transcript00?p=1',
     collectedAt: 1000,
     bvid: 'BV1Transcript00',
+    aid: 8800,
     cid: 101,
     title: 'Transcript cache video',
     authorName: 'Cache UP',


### PR DESCRIPTION
## Scope

- Pass the #113 current-video `aid` through the subtitle metadata fetch used by `cacheCurrentVideoTranscriptEvidence`, so body caching uses the same reliable current `bvid/cid/page/aid` target as source probing.
- Keep subtitle body fetch constrained to Bilibili/hdslb HTTPS subtitle hosts and keep raw `subtitle_url` values internal.
- Treat subtitle-body 401/403-style failures as login/access diagnostics instead of generic endpoint failures.
- Expand focused transcript-cache coverage for unsupported host, fetch failure, access failure, same-current-video active evidence, and downstream summary / Video Knowledge / segment-search visibility through existing APIs.
- Add a localhost mock QA harness for the `subtitle_url -> body[] -> transcript evidence cached -> summary/knowledge/search visible` flow.

## Root Cause / Product Judgment

#113 made current-video identity and subtitle source detection reliable, but source detection alone still leaves the assistant on metadata/description fallback because downstream features require cached transcript body segments. This PR keeps the slice at the evidence-cache boundary: it consumes the detected Bilibili subtitle track internally, normalizes `body[]` rows into the existing current-video transcript cache, and lets existing summary, Video Knowledge, and retrieval paths read active evidence without changing their algorithms.

## Validation

- `npm run test:current-video-transcript`
- `npm run test:current-video-summary`
- `npm run test:video-knowledge`
- `node --test tests/current-video-segment-retrieval.test.ts`
- `npm run typecheck`
- `npm run build` (passed; existing Vite chunk-size/dynamic-import warnings only)
- `git diff --check` and `git diff --cached --check` (clean exit; Windows LF/CRLF notices only)
- `rg -n 未消费|猜你喜欢 dashboard popup public src README.md tests` (no matches)
- Browser/mock QA: served `tests/current-video-subtitle-body-cache.mock.html` on localhost and drove it with Playwright/Chromium. Before caching it showed metadata/description fallback; after clicking cache it showed body[] read from a restricted Bilibili subtitle host, 2 cached subtitle evidence segments, a transcript summary, a Video Knowledge subtitle node, and segment search hit. Visible DOM did not expose raw subtitle URL, token, `sourceHash`, or `segmentId`.

## Privacy Boundary

- Did not read Cookie files, browser profile files, Bilibili login-state files, local key files, or `C:\Users\LittleNub\Desktop\Key.txt`.
- Did not upload full history, favorites, following, feedback, or local DB content.
- Runtime subtitle requests use the active extension fetch context only; raw `subtitle_url` is used internally for fetch and is not exposed in popup/dashboard/content UI or AI payload.
- No Bilibili write-back.

## Blockers / Must Fix / Follow-up

- Blockers: none; #113 / PR #116 is merged in `origin/main` at `8843d3d07ede7f893a17be46d96d25af1b8db238`.
- Must fix: none known.
- Follow-up: #115 should surface user-facing cache/fetch states such as cached success, fetch failed, empty body, malformed body, language mismatch, unsupported subtitle host, and login/access failure without exposing raw subtitle URLs, hashes, or segment IDs.

Closes #114