### PR TITLE
[codex] Add current video subtitle diagnostics UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit",
     "test:experiments": "node --test tests/experiment-blind-boxes.test.ts",
     "test:favorites": "node --test tests/favorite-sync-audit.test.ts tests/favorite-folder-gap-probe.test.ts tests/favorite-itemkey-persistence.test.ts tests/smart-favorite-index.test.ts tests/smart-favorites-qa.test.ts",
-    "test:current-video-transcript": "node --test tests/current-video-transcript-cache.test.ts",
+    "test:current-video-transcript": "node --test tests/current-video-transcript-cache.test.ts tests/current-video-subtitle-diagnostics.test.ts",
     "test:current-video-summary": "node --test tests/current-video-summary.test.ts",
     "test:video-knowledge": "node --test tests/video-knowledge.test.ts"
   },

--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -7,7 +7,6 @@ import type { HistoryTailProbeReport } from '../src/shared/types/history-tail-pr
 import type { HistorySyncProgress, HistorySyncStatus } from '../src/shared/types/history-sync';
 import type {
   CurrentVideoContextResult,
-  CurrentVideoSubtitleSourceState,
 } from '../src/shared/types/current-video-context';
 import type { CurrentVideoTranscriptEvidenceState } from '../src/shared/types/current-video-transcript';
 import type {
@@ -20,6 +19,10 @@ import type {
 import type { CurrentVideoSummaryResult } from '../src/shared/types/current-video-summary';
 import type { VideoKnowledgeJumpResponse, VideoKnowledgeNode, VideoKnowledgeResult } from '../src/shared/types/video-knowledge';
 import { cancelledCurrentVideoSummary, loadingCurrentVideoSummary } from '../src/shared/current-video-summary';
+import {
+  buildCurrentVideoSubtitleDiagnostics,
+  type CurrentVideoSubtitleDiagnostics,
+} from '../src/shared/current-video-subtitle-diagnostics';
 import { ProgressRing } from './components/ProgressRing';
 import { QuickStats as QuickStatsPanel } from './components/QuickStats';
 import { OpenDashboard } from './components/OpenDashboard';
@@ -126,19 +129,29 @@ export function App() {
     setSubtitleProbeLoading(true);
     setSubtitleProbeStatus(null);
     try {
-      const context = await requestSW<CurrentVideoContextResult>('GET_CURRENT_VIDEO_CONTEXT', {
+      const firstContext = await requestSW<CurrentVideoContextResult>('GET_CURRENT_VIDEO_CONTEXT', {
         forceContextRefresh: true,
         forceSubtitleProbe: true,
       });
-      setCurrentVideoContext(context);
-      setSubtitleProbeStatus(
-        context.kind === 'video' && context.subtitleProbe
-          ? context.subtitleProbe.message
-          : '已重新检测当前视频上下文。',
-      );
-      await fetchVideoKnowledge();
-    } catch (e) {
-      setSubtitleProbeStatus((e as Error).message);
+      setCurrentVideoContext(firstContext);
+
+      const transcriptEvidence = await requestSW<CurrentVideoTranscriptEvidenceState>('GET_CURRENT_VIDEO_TRANSCRIPT_EVIDENCE', {
+        forceContextRefresh: true,
+        forceSubtitleProbe: true,
+      });
+      const refreshedContext = await requestSW<CurrentVideoContextResult>('GET_CURRENT_VIDEO_CONTEXT');
+      const contextWithEvidence = refreshedContext.kind === 'video'
+        ? { ...refreshedContext, transcriptEvidence }
+        : refreshedContext;
+      setCurrentVideoContext(contextWithEvidence);
+      const diagnostics = buildCurrentVideoSubtitleDiagnostics(contextWithEvidence);
+      setSubtitleProbeStatus(`${diagnostics.title}：${diagnostics.message}`);
+      await Promise.all([
+        fetchCurrentVideoSummary(),
+        fetchVideoKnowledge(),
+      ]);
+    } catch {
+      setSubtitleProbeStatus('重新检测失败：请确认当前 B 站视频页仍然打开，并在播放器里开启中文 AI 字幕后重试。');
     } finally {
       setSubtitleProbeLoading(false);
     }
@@ -578,6 +591,9 @@ function CurrentVideoAssistantStatus({
   const [segmentPreviewCandidateId, setSegmentPreviewCandidateId] = useState<string | null>(null);
   const [segmentJumpStatus, setSegmentJumpStatus] = useState<string | null>(null);
   const [segmentReturnAvailable, setSegmentReturnAvailable] = useState(false);
+  const subtitleDiagnostics = buildCurrentVideoSubtitleDiagnostics(context, {
+    refreshing: subtitleProbeLoading,
+  });
 
   async function searchCurrentVideoSegments() {
     const query = segmentQuery.trim();
@@ -666,40 +682,58 @@ function CurrentVideoAssistantStatus({
             BVID {context.bvid} / CID {context.cid ?? '未知'}
             <br />
             简介 {availabilityLabel(context.sources.description)}；字幕 {availabilityLabel(context.sources.transcript)}；正文文本 {availabilityLabel(context.sources.contentText)}
-            {context.subtitleProbe && (
-              <>
-                <br />
-                {subtitleProbeDetail(context.subtitleProbe)}
-              </>
-            )}
-            {context.transcriptEvidence && context.transcriptEvidence.status !== 'missing' && (
-              <>
-                <br />
-                {transcriptEvidenceDetail(context.transcriptEvidence)}
-              </>
-            )}
+            <br />
+            字幕状态：{subtitleDiagnostics.title}
           </div>
           <div style={{
             marginTop: '6px',
             padding: '7px 8px',
-            border: '1px solid rgba(255,179,71,0.24)',
+            border: `1px solid ${subtitleDiagnosticsBorder(subtitleDiagnostics)}`,
             borderRadius: '6px',
-            background: 'rgba(255,179,71,0.08)',
+            background: subtitleDiagnosticsBackground(subtitleDiagnostics),
           }}>
-            <div style={{ color: '#FFCF8A', fontSize: '10px', lineHeight: 1.45 }}>
-              如需使用 B 站 AI 字幕，请先在播放器里手动开启中文 AI 字幕，开启后重新检测。
+            <div style={{ color: subtitleDiagnosticsColor(subtitleDiagnostics), fontSize: '10px', lineHeight: 1.45, fontWeight: 700 }}>
+              {subtitleDiagnostics.title}
+            </div>
+            <div style={{ color: '#E8E8F2', fontSize: '10px', lineHeight: 1.45, marginTop: '4px' }}>
+              {subtitleDiagnostics.message}
+            </div>
+            <div style={{ color: '#FFCF8A', fontSize: '10px', lineHeight: 1.45, marginTop: '4px' }}>
+              {subtitleDiagnostics.action}
+            </div>
+            {subtitleDiagnostics.detailLines.slice(0, 2).map(line => (
+              <div key={line} style={{ color: '#A0A0B0', fontSize: '9px', lineHeight: 1.45, marginTop: '3px' }}>
+                {line}
+              </div>
+            ))}
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4px', marginTop: '6px' }}>
+              {subtitleDiagnostics.featureGates.map(item => (
+                <div
+                  key={item.label}
+                  style={{
+                    border: `1px solid ${item.available ? 'rgba(160,231,160,0.25)' : 'rgba(255,179,71,0.22)'}`,
+                    borderRadius: '6px',
+                    padding: '4px 5px',
+                    color: item.available ? '#A0E7A0' : '#FFCF8A',
+                    fontSize: '9px',
+                    lineHeight: 1.35,
+                  }}
+                >
+                  <strong>{item.label}</strong> {item.message}
+                </div>
+              ))}
             </div>
             <button
               type="button"
               onClick={onReprobeSubtitle}
-              disabled={subtitleProbeLoading}
+              disabled={subtitleProbeLoading || !subtitleDiagnostics.canRetry}
               style={{
                 marginTop: '6px',
-                background: subtitleProbeLoading ? 'rgba(255,255,255,0.08)' : 'rgba(255,179,71,0.18)',
-                color: subtitleProbeLoading ? '#9090A0' : '#FFCF8A',
+                background: subtitleProbeLoading || !subtitleDiagnostics.canRetry ? 'rgba(255,255,255,0.08)' : 'rgba(255,179,71,0.18)',
+                color: subtitleProbeLoading || !subtitleDiagnostics.canRetry ? '#9090A0' : '#FFCF8A',
                 border: '1px solid rgba(255,179,71,0.32)',
                 borderRadius: '6px',
-                cursor: subtitleProbeLoading ? 'default' : 'pointer',
+                cursor: subtitleProbeLoading || !subtitleDiagnostics.canRetry ? 'default' : 'pointer',
                 fontSize: '10px',
                 padding: '4px 7px',
               }}
@@ -784,6 +818,7 @@ function CurrentVideoAssistantStatus({
             onConfirm={onConfirmJump}
           />
           <CurrentVideoSegmentRetrievalPanel
+            subtitleDiagnostics={subtitleDiagnostics}
             query={segmentQuery}
             result={segmentResult}
             loading={segmentLoading}
@@ -851,6 +886,7 @@ function CurrentVideoAssistantStatus({
 }
 
 function CurrentVideoSegmentRetrievalPanel({
+  subtitleDiagnostics,
   query,
   result,
   loading,
@@ -864,6 +900,7 @@ function CurrentVideoSegmentRetrievalPanel({
   onConfirmJump,
   onReturn,
 }: {
+  subtitleDiagnostics: CurrentVideoSubtitleDiagnostics;
   query: string;
   result: CurrentVideoSegmentRetrievalResult | null;
   loading: boolean;
@@ -881,6 +918,8 @@ function CurrentVideoSegmentRetrievalPanel({
   const aiExplanations = new Map(
     (result?.aiRerank.explanations ?? []).map(explanation => [explanation.candidateId, explanation]),
   );
+  const searchGate = subtitleDiagnostics.featureGates.find(item => item.label === '片段检索');
+  const jumpGate = subtitleDiagnostics.featureGates.find(item => item.label === '手动跳转');
   return (
     <div style={{
       marginTop: '8px',
@@ -933,7 +972,7 @@ function CurrentVideoSegmentRetrievalPanel({
         </button>
       </form>
       <div style={{ color: '#A0A0B0', fontSize: '9px', lineHeight: 1.45, marginTop: '5px' }}>
-        只查当前视频本地已有证据；候选必须预览并确认后才会跳转，不会自动改变播放位置。
+        {searchGate?.message} {jumpGate?.message}
       </div>
       {error && (
         <div style={{ color: '#FFB347', fontSize: '10px', lineHeight: 1.45, marginTop: '6px' }}>
@@ -1327,18 +1366,25 @@ function availabilityLabel(value: string): string {
   }
 }
 
-function subtitleProbeDetail(probe: CurrentVideoSubtitleSourceState): string {
-  if (!probe.available) return probe.message;
-  const languages = probe.languages.length > 0 ? `；语言 ${probe.languages.join(', ')}` : '';
-  const coverage = typeof probe.coverageEndSeconds === 'number'
-    ? `；覆盖至 ${formatSeconds(probe.coverageEndSeconds)}`
-    : '';
-  return `${probe.message}（字幕轨道 ${probe.trackCount}${languages}${coverage}）`;
+function subtitleDiagnosticsColor(state: CurrentVideoSubtitleDiagnostics): string {
+  if (state.tone === 'ready') return '#A0E7A0';
+  if (state.tone === 'info') return '#C8E6FF';
+  if (state.tone === 'blocked') return '#FF8A8A';
+  return '#FFCF8A';
 }
 
-function transcriptEvidenceDetail(evidence: CurrentVideoTranscriptEvidenceState): string {
-  if (!evidence.active) return evidence.message;
-  return `${evidence.message} 已缓存片段=${evidence.segmentCount}`;
+function subtitleDiagnosticsBorder(state: CurrentVideoSubtitleDiagnostics): string {
+  if (state.tone === 'ready') return 'rgba(160,231,160,0.28)';
+  if (state.tone === 'info') return 'rgba(127,219,255,0.28)';
+  if (state.tone === 'blocked') return 'rgba(255,138,138,0.28)';
+  return 'rgba(255,179,71,0.24)';
+}
+
+function subtitleDiagnosticsBackground(state: CurrentVideoSubtitleDiagnostics): string {
+  if (state.tone === 'ready') return 'rgba(160,231,160,0.08)';
+  if (state.tone === 'info') return 'rgba(127,219,255,0.08)';
+  if (state.tone === 'blocked') return 'rgba(255,138,138,0.08)';
+  return 'rgba(255,179,71,0.08)';
 }
 
 function videoKnowledgeNotice(knowledge: VideoKnowledgeResult | null, transcriptNodeCount: number): string {

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -649,7 +649,7 @@ async function probeSubtitleSourceForActiveTab(
 async function getTranscriptEvidenceForActiveTab(
   params: Record<string, unknown> | undefined,
 ): Promise<CurrentVideoTranscriptEvidenceState> {
-  const context = await getCurrentVideoContextForActiveTab();
+  const context = await getCurrentVideoContextForActiveTab(currentVideoLookupOptions(params));
   const requestedLanguage = typeof params?.language === 'string'
     ? params.language
     : null;

--- a/src/content/player-monitor/assistant-status.ts
+++ b/src/content/player-monitor/assistant-status.ts
@@ -1,8 +1,13 @@
 import type {
-  CurrentVideoContext,
   CurrentVideoContextResult,
 } from '../../shared/types/current-video-context';
+import type { BiliVizResponse, RequestAction } from '../../shared/types/messages';
+import type { CurrentVideoTranscriptEvidenceState } from '../../shared/types/current-video-transcript';
 import { buildLocalCurrentVideoSummary } from '../../shared/current-video-summary';
+import {
+  buildCurrentVideoSubtitleDiagnostics,
+  type CurrentVideoSubtitleDiagnostics,
+} from '../../shared/current-video-subtitle-diagnostics';
 
 const CARD_ID = 'bdc-current-video-assistant';
 const STYLE_ID = 'bdc-current-video-assistant-style';
@@ -67,6 +72,56 @@ const CSS = `
   font-size: 12px;
   line-height: 1.45;
 }
+#${CARD_ID} .bdc-assistant-subtitle-title {
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+#${CARD_ID} .bdc-assistant-subtitle-detail {
+  color: #a0a0b0;
+  font-size: 11px;
+  line-height: 1.45;
+  margin-top: 4px;
+}
+#${CARD_ID} .bdc-assistant-gates {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 5px;
+  margin-top: 8px;
+}
+#${CARD_ID} .bdc-assistant-gate {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  padding: 5px;
+  color: #c8c8d8;
+  font-size: 11px;
+  line-height: 1.35;
+}
+#${CARD_ID} .bdc-assistant-gate-ready {
+  border-color: rgba(160, 231, 160, 0.28);
+  color: #a0e7a0;
+}
+#${CARD_ID} .bdc-assistant-action {
+  margin-top: 8px;
+  border: 1px solid rgba(255, 179, 71, 0.32);
+  border-radius: 6px;
+  background: rgba(255, 179, 71, 0.18);
+  color: #ffcf8a;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 6px 8px;
+}
+#${CARD_ID} .bdc-assistant-action:disabled {
+  background: rgba(255, 255, 255, 0.08);
+  color: #9090a0;
+  cursor: default;
+}
+#${CARD_ID} .bdc-assistant-status {
+  color: #c8e6ff;
+  font-size: 11px;
+  line-height: 1.45;
+  margin-top: 6px;
+}
 #${CARD_ID} .bdc-assistant-tier {
   display: inline-block;
   margin: 4px 0 6px;
@@ -123,6 +178,7 @@ export function renderCurrentVideoAssistant(context: CurrentVideoContextResult):
       aiStatus: 'not_requested',
       aiNote: '页面悬浮卡只显示本地证据；启用后可在 Popup 查看 AI 摘要。',
     });
+    const subtitleDiagnostics = buildCurrentVideoSubtitleDiagnostics(context);
     appendText(card, 'div', 'bdc-assistant-video', context.title ?? context.bvid);
     appendText(card, 'div', 'bdc-assistant-tier', `${summary.sourceTierLabel} / 证据强度 ${summaryConfidenceLabel(summary.confidence)}`);
     appendText(card, 'div', 'bdc-assistant-summary', summary.summary);
@@ -151,12 +207,7 @@ export function renderCurrentVideoAssistant(context: CurrentVideoContextResult):
       'bdc-assistant-row bdc-assistant-muted',
       `字幕 ${availabilityLabel(context.sources.transcript)}；正文文本 ${availabilityLabel(context.sources.contentText)}`,
     );
-    appendText(
-      card,
-      'div',
-      'bdc-assistant-warning',
-      subtitleStatusMessage(context),
-    );
+    appendSubtitleDiagnostics(card, subtitleDiagnostics);
   } else {
     appendText(card, 'div', 'bdc-assistant-video', '没有当前视频上下文');
     appendText(
@@ -178,6 +229,90 @@ export function renderCurrentVideoAssistant(context: CurrentVideoContextResult):
   if (!existing) {
     document.body.appendChild(card);
   }
+}
+
+function appendSubtitleDiagnostics(parent: HTMLElement, diagnostics: CurrentVideoSubtitleDiagnostics): void {
+  const panel = document.createElement('div');
+  panel.className = 'bdc-assistant-warning';
+  panel.style.border = `1px solid ${subtitleDiagnosticsBorder(diagnostics)}`;
+  panel.style.background = subtitleDiagnosticsBackground(diagnostics);
+
+  const title = document.createElement('div');
+  title.className = 'bdc-assistant-subtitle-title';
+  title.style.color = subtitleDiagnosticsColor(diagnostics);
+  title.textContent = diagnostics.title;
+  panel.appendChild(title);
+
+  appendText(panel, 'div', 'bdc-assistant-row', diagnostics.message);
+  appendText(panel, 'div', 'bdc-assistant-row', diagnostics.action);
+
+  for (const line of diagnostics.detailLines.slice(0, 2)) {
+    appendText(panel, 'div', 'bdc-assistant-subtitle-detail', line);
+  }
+
+  const gates = document.createElement('div');
+  gates.className = 'bdc-assistant-gates';
+  for (const gate of diagnostics.featureGates) {
+    const item = document.createElement('div');
+    item.className = gate.available
+      ? 'bdc-assistant-gate bdc-assistant-gate-ready'
+      : 'bdc-assistant-gate';
+    item.textContent = `${gate.label}：${gate.message}`;
+    gates.appendChild(item);
+  }
+  panel.appendChild(gates);
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'bdc-assistant-action';
+  button.disabled = !diagnostics.canRetry;
+  button.textContent = '重新检测字幕';
+  const status = document.createElement('div');
+  status.className = 'bdc-assistant-status';
+  button.addEventListener('click', () => {
+    void refreshSubtitleEvidenceFromPage(button, status);
+  });
+  panel.append(button, status);
+  parent.appendChild(panel);
+}
+
+async function refreshSubtitleEvidenceFromPage(
+  button: HTMLButtonElement,
+  status: HTMLElement,
+): Promise<void> {
+  button.disabled = true;
+  button.textContent = '检测中...';
+  status.textContent = '正在刷新当前视频字幕状态，并尝试读取字幕正文。';
+
+  try {
+    const transcriptEvidence = await sendRuntimeRequest<CurrentVideoTranscriptEvidenceState>(
+      'GET_CURRENT_VIDEO_TRANSCRIPT_EVIDENCE',
+      {
+        forceContextRefresh: true,
+        forceSubtitleProbe: true,
+      },
+    );
+    const context = await sendRuntimeRequest<CurrentVideoContextResult>('GET_CURRENT_VIDEO_CONTEXT');
+    const nextContext = context.kind === 'video'
+      ? { ...context, transcriptEvidence }
+      : context;
+    renderCurrentVideoAssistant(nextContext);
+  } catch {
+    status.textContent = '重新检测失败：请确认当前 B 站视频页仍然打开，并在播放器里开启中文 AI 字幕后重试。';
+    button.disabled = false;
+    button.textContent = '重新检测字幕';
+  }
+}
+
+async function sendRuntimeRequest<T>(
+  action: RequestAction,
+  params?: Record<string, unknown>,
+): Promise<T> {
+  const response = await chrome.runtime.sendMessage({ action, params }) as BiliVizResponse<T>;
+  if (!response?.success || response.data === undefined) {
+    throw new Error('REQUEST_FAILED');
+  }
+  return response.data;
 }
 
 function appendText(parent: HTMLElement, tag: 'div' | 'p', className: string, text: string): void {
@@ -215,23 +350,29 @@ function availabilityLabel(value: string): string {
   }
 }
 
+function subtitleDiagnosticsColor(state: CurrentVideoSubtitleDiagnostics): string {
+  if (state.tone === 'ready') return '#a0e7a0';
+  if (state.tone === 'info') return '#c8e6ff';
+  if (state.tone === 'blocked') return '#ff8a8a';
+  return '#ffcf8a';
+}
+
+function subtitleDiagnosticsBorder(state: CurrentVideoSubtitleDiagnostics): string {
+  if (state.tone === 'ready') return 'rgba(160,231,160,0.28)';
+  if (state.tone === 'info') return 'rgba(127,219,255,0.28)';
+  if (state.tone === 'blocked') return 'rgba(255,138,138,0.28)';
+  return 'rgba(255,179,71,0.24)';
+}
+
+function subtitleDiagnosticsBackground(state: CurrentVideoSubtitleDiagnostics): string {
+  if (state.tone === 'ready') return 'rgba(160,231,160,0.08)';
+  if (state.tone === 'info') return 'rgba(127,219,255,0.08)';
+  if (state.tone === 'blocked') return 'rgba(255,138,138,0.08)';
+  return 'rgba(255,179,71,0.08)';
+}
+
 function summaryConfidenceLabel(value: 'low' | 'medium' | 'high'): string {
   if (value === 'high') return '高';
   if (value === 'medium') return '中';
   return '低';
-}
-
-function subtitleStatusMessage(context: CurrentVideoContext): string {
-  if (context.transcriptEvidence?.active) return context.transcriptEvidence.message;
-  if (context.transcriptEvidence && context.transcriptEvidence.status !== 'missing') {
-    return context.transcriptEvidence.message;
-  }
-  if (context.subtitleProbe) return context.subtitleProbe.message;
-  if (context.sources.transcript === 'unknown') {
-    return '字幕来源等待后台探测；当前只使用元数据和简介作为本地证据兜底，不能做完整视频总结。';
-  }
-  if (context.sources.description === 'available') {
-    return '简介可用，但字幕和完整正文文本不可用；这不是完整视频总结。';
-  }
-  return '当前没有可用字幕、简介或完整正文文本；这不是完整视频总结。';
 }

--- a/src/shared/current-video-subtitle-diagnostics.ts
+++ b/src/shared/current-video-subtitle-diagnostics.ts
@@ -1,0 +1,389 @@
+import type {
+  CurrentVideoContext,
+  CurrentVideoContextResult,
+  CurrentVideoSubtitleSourceState,
+} from './types/current-video-context';
+import type { CurrentVideoTranscriptEvidenceState } from './types/current-video-transcript';
+
+export type CurrentVideoSubtitleDiagnosticStatus =
+  | 'no_context'
+  | 'missing_cid'
+  | 'enable_ai_subtitle'
+  | 'track_found'
+  | 'reading_body'
+  | 'cached'
+  | 'login_required'
+  | 'no_track'
+  | 'fetch_failed'
+  | 'malformed'
+  | 'empty'
+  | 'language_mismatch'
+  | 'unsupported_host'
+  | 'stale'
+  | 'metadata_only';
+
+export type CurrentVideoSubtitleDiagnosticTone = 'ready' | 'info' | 'warning' | 'blocked';
+
+export interface CurrentVideoSubtitleFeatureGate {
+  label: '摘要' | '知识节点' | '片段检索' | '手动跳转';
+  available: boolean;
+  message: string;
+}
+
+export interface CurrentVideoSubtitleDiagnostics {
+  status: CurrentVideoSubtitleDiagnosticStatus;
+  tone: CurrentVideoSubtitleDiagnosticTone;
+  title: string;
+  message: string;
+  action: string;
+  detailLines: string[];
+  featureGates: CurrentVideoSubtitleFeatureGate[];
+  evidenceAvailable: boolean;
+  canRetry: boolean;
+}
+
+export interface CurrentVideoSubtitleDiagnosticsOptions {
+  refreshing?: boolean;
+}
+
+export function buildCurrentVideoSubtitleDiagnostics(
+  context: CurrentVideoContextResult | null,
+  options: CurrentVideoSubtitleDiagnosticsOptions = {},
+): CurrentVideoSubtitleDiagnostics {
+  if (options.refreshing) {
+    return diagnostics({
+      status: 'reading_body',
+      tone: 'info',
+      title: '正在读取字幕正文',
+      message: '正在刷新当前视频上下文、重新检测字幕来源，并尝试把 B 站字幕正文缓存为本地证据。',
+      action: '请保持当前 B 站视频页打开；如果刚开启中文 AI 字幕，等待检测完成即可。',
+      evidenceAvailable: false,
+      canRetry: false,
+      detailLines: [
+        '这个过程只使用当前页面和 B 站字幕接口，不会读取浏览器本地敏感文件或账号资料。',
+      ],
+    });
+  }
+
+  if (!context || context.kind !== 'video') {
+    return diagnostics({
+      status: 'no_context',
+      tone: 'blocked',
+      title: '没有当前视频上下文',
+      message: '请先打开一个 B 站视频页，再使用当前视频摘要、知识节点、片段检索或跳转。',
+      action: '打开视频页后再点击重新检测字幕。',
+      evidenceAvailable: false,
+      canRetry: true,
+      detailLines: ['没有当前视频时，不会从历史、收藏、关注或本地账号资料里寻找替代证据。'],
+    });
+  }
+
+  if (isMissingCid(context)) {
+    return diagnostics({
+      status: 'missing_cid',
+      tone: 'blocked',
+      title: '缺少 CID，暂时不能检测字幕',
+      message: 'Bili-Bill 还没有拿到当前分 P 的 CID，因此不能安全请求 B 站字幕来源或读取字幕正文。',
+      action: '请确认视频页加载完成；如果播放器里已经开启中文 AI 字幕，请点击重新检测字幕。',
+      evidenceAvailable: false,
+      canRetry: true,
+      detailLines: [
+        'CID 仍未知时，摘要只能使用标题、UP 主、简介、分 P 或章节等元数据兜底。',
+      ],
+    });
+  }
+
+  const evidence = context.transcriptEvidence ?? null;
+  if (evidence?.active) {
+    return diagnostics({
+      status: 'cached',
+      tone: 'ready',
+      title: '已缓存字幕正文',
+      message: `已缓存当前视频字幕正文证据${countText(evidence.segmentCount)}，摘要、知识节点、片段检索和手动跳转会使用这些本地字幕片段。`,
+      action: '如果刚切换分 P 或重新开启字幕，可以再次重新检测字幕以刷新证据。',
+      evidenceAvailable: true,
+      canRetry: true,
+      detailLines: [
+        coverageText(evidence),
+        '字幕正文只作为当前视频的本地证据；普通界面不会展示原始字幕地址、内部片段编号或校验信息。',
+      ].filter(Boolean),
+    });
+  }
+
+  if (evidence && evidence.status !== 'missing') {
+    return transcriptEvidenceDiagnostics(evidence);
+  }
+
+  const probe = context.subtitleProbe ?? null;
+  if (probe) {
+    return subtitleProbeDiagnostics(probe);
+  }
+
+  if (context.sources.transcript === 'unknown') {
+    return diagnostics({
+      status: 'enable_ai_subtitle',
+      tone: 'warning',
+      title: '请先开启中文 AI 字幕',
+      message: '当前还没有可用字幕正文。B 站视频通常需要先在播放器里手动开启“中文 AI”字幕，插件才有机会检测到字幕来源。',
+      action: '在播放器字幕菜单中开启中文 AI 字幕后，点击重新检测字幕。',
+      evidenceAvailable: false,
+      canRetry: true,
+      detailLines: [notModelFailureText()],
+    });
+  }
+
+  return diagnostics({
+    status: 'metadata_only',
+    tone: 'warning',
+    title: '仍使用元数据和简介兜底',
+    message: '当前没有可引用的字幕正文；摘要不能当作完整视频总结，片段检索和跳转也不能定位到具体字幕时间。',
+    action: '如果这个视频提供中文 AI 字幕，请先在播放器里开启，再点击重新检测字幕。',
+    evidenceAvailable: false,
+    canRetry: true,
+    detailLines: [notModelFailureText()],
+  });
+}
+
+function transcriptEvidenceDiagnostics(
+  evidence: CurrentVideoTranscriptEvidenceState,
+): CurrentVideoSubtitleDiagnostics {
+  switch (evidence.status) {
+    case 'stale':
+      return diagnostics({
+        status: 'stale',
+        tone: 'warning',
+        title: '本地字幕证据与当前视频不匹配',
+        message: '本地缓存的字幕正文不属于当前 BVID、CID、分 P 或语言，已经停止作为当前视频证据使用。',
+        action: '点击重新检测字幕，重新读取当前视频的字幕正文。',
+        evidenceAvailable: false,
+        canRetry: true,
+        detailLines: ['为了避免把旧视频片段当作当前视频证据，摘要、检索和跳转会继续使用元数据或简介兜底。'],
+      });
+    case 'empty':
+      return diagnostics({
+        status: 'empty',
+        tone: 'warning',
+        title: '字幕正文为空',
+        message: '已找到可读取的字幕来源，但 B 站没有返回有效正文片段。',
+        action: '请确认播放器里开启的是中文 AI 字幕；如果刚开启，请稍后重新检测字幕。',
+        evidenceAvailable: false,
+        canRetry: true,
+        detailLines: [notModelFailureText()],
+      });
+    case 'malformed':
+      return diagnostics({
+        status: 'malformed',
+        tone: 'warning',
+        title: '字幕正文结构异常',
+        message: 'B 站返回的字幕正文结构无法稳定解析，Bili-Bill 不会把它当作可引用字幕证据。',
+        action: '可以稍后重新检测字幕；在结构恢复前，摘要和定位功能只能使用元数据或简介兜底。',
+        evidenceAvailable: false,
+        canRetry: true,
+        detailLines: [notModelFailureText()],
+      });
+    case 'language_mismatch':
+      return diagnostics({
+        status: 'language_mismatch',
+        tone: 'warning',
+        title: '字幕语言不匹配',
+        message: '当前可读字幕不是本次需要的中文 AI 字幕，因此不会作为当前视频正文证据。',
+        action: '请在 B 站播放器里切换到中文 AI 字幕后，再点击重新检测字幕。',
+        evidenceAvailable: false,
+        canRetry: true,
+        detailLines: [notModelFailureText()],
+      });
+    case 'login_required':
+      return diagnostics({
+      status: 'login_required',
+      tone: 'blocked',
+      title: '字幕需要登录或访问权限',
+      message: 'B 站字幕正文接口要求当前浏览器会话具备访问权限。Bili-Bill 不会读取浏览器本地敏感文件。',
+      action: '请在浏览器里确认 B 站已登录且播放器字幕可见，然后重新检测字幕。',
+        evidenceAvailable: false,
+        canRetry: true,
+        detailLines: ['这不是模型失败；当前缺少的是 B 站允许读取的字幕正文。'],
+      });
+    case 'endpoint_failed':
+      return diagnostics({
+        status: 'fetch_failed',
+        tone: 'warning',
+        title: '字幕正文拉取失败',
+        message: '已尝试读取字幕正文，但请求失败；当前仍只能使用元数据或简介作为本地证据。',
+        action: '请稍后重试，或确认当前视频页仍然打开且字幕已在播放器里开启。',
+        evidenceAvailable: false,
+        canRetry: true,
+        detailLines: [notModelFailureText()],
+      });
+    case 'track_unavailable':
+      return diagnostics({
+        status: evidence.reason === 'subtitle_host_unsupported' ? 'unsupported_host' : 'no_track',
+        tone: 'warning',
+        title: evidence.reason === 'subtitle_host_unsupported' ? '字幕来源不受支持' : '字幕轨道没有正文地址',
+        message: evidence.reason === 'subtitle_host_unsupported'
+          ? '字幕正文地址不属于受限的 B 站或 hdslb 字幕域名，Bili-Bill 已拒绝读取。'
+          : '播放器返回了字幕信息，但没有可读取的正文地址。',
+        action: '请在播放器里重新选择中文 AI 字幕后，再点击重新检测字幕。',
+        evidenceAvailable: false,
+        canRetry: true,
+        detailLines: ['普通界面不会展示原始字幕地址，也不会向其他服务上传字幕。'],
+      });
+    case 'unsupported':
+      return diagnostics({
+        status: 'metadata_only',
+        tone: 'warning',
+        title: '当前页面暂时不能读取字幕正文',
+        message: '当前上下文不满足读取字幕正文的条件；Bili-Bill 仍使用元数据或简介兜底。',
+        action: '请确认当前标签页是 B 站视频页，再重新检测字幕。',
+        evidenceAvailable: false,
+        canRetry: true,
+        detailLines: [notModelFailureText()],
+      });
+    default:
+      return diagnostics({
+        status: 'metadata_only',
+        tone: 'warning',
+        title: '仍使用元数据和简介兜底',
+        message: '当前没有可引用的字幕正文；摘要不能当作完整视频总结，片段检索和跳转也不能定位到具体字幕时间。',
+        action: '如果这个视频提供中文 AI 字幕，请先在播放器里开启，再点击重新检测字幕。',
+        evidenceAvailable: false,
+        canRetry: true,
+        detailLines: [notModelFailureText()],
+      });
+  }
+}
+
+function subtitleProbeDiagnostics(
+  probe: CurrentVideoSubtitleSourceState,
+): CurrentVideoSubtitleDiagnostics {
+  switch (probe.status) {
+    case 'available':
+      return diagnostics({
+        status: 'track_found',
+        tone: 'info',
+        title: '已发现字幕轨道',
+        message: `已检测到当前视频字幕轨道${countText(probe.trackCount)}，但还没有可引用的字幕正文缓存。`,
+        action: '点击重新检测字幕，继续读取并缓存字幕正文。',
+        evidenceAvailable: false,
+        canRetry: true,
+        detailLines: [
+          probe.languages.length > 0 ? `检测到语言：${probe.languages.join('、')}` : '',
+          '只有字幕正文缓存成功后，摘要、片段检索和手动跳转才会解除限制。',
+        ].filter(Boolean),
+      });
+    case 'login_required':
+      return diagnostics({
+      status: 'login_required',
+      tone: 'blocked',
+      title: '字幕需要登录或访问权限',
+      message: 'B 站字幕来源检测提示需要当前浏览器会话具备访问权限。Bili-Bill 不会读取浏览器本地敏感文件。',
+      action: '请确认 B 站已登录，并在播放器里开启中文 AI 字幕后重新检测。',
+        evidenceAvailable: false,
+        canRetry: true,
+        detailLines: ['这不是 DeepSeek 或模型失败；当前缺少的是 B 站字幕访问权限。'],
+      });
+    case 'unavailable':
+      return diagnostics({
+        status: 'no_track',
+        tone: 'warning',
+        title: '没有返回字幕轨道',
+        message: 'B 站播放器接口没有返回可用字幕轨道。最常见原因是还没有在播放器里手动开启中文 AI 字幕。',
+        action: '请先在播放器字幕菜单中开启中文 AI 字幕，开启后点击重新检测字幕。',
+        evidenceAvailable: false,
+        canRetry: true,
+        detailLines: [notModelFailureText()],
+      });
+    case 'endpoint_failed':
+      return diagnostics({
+        status: 'fetch_failed',
+        tone: 'warning',
+        title: '字幕来源检测失败',
+        message: '字幕来源检测请求失败，因此还不能读取字幕正文。',
+        action: '请稍后重试，或确认当前 B 站视频页仍然打开。',
+        evidenceAvailable: false,
+        canRetry: true,
+        detailLines: ['当前仍使用元数据或简介兜底；不会把简介当作完整视频正文。'],
+      });
+    case 'malformed':
+      return diagnostics({
+        status: 'malformed',
+        tone: 'warning',
+        title: '字幕来源结构异常',
+        message: 'B 站播放器返回的字幕来源结构无法稳定识别，暂时不会继续读取字幕正文。',
+        action: '可以稍后重新检测字幕；在结构恢复前，摘要和定位功能只能使用元数据或简介兜底。',
+        evidenceAvailable: false,
+        canRetry: true,
+        detailLines: [notModelFailureText()],
+      });
+    default:
+      return diagnostics({
+        status: probe.reason === 'missing_cid' ? 'missing_cid' : 'metadata_only',
+        tone: 'warning',
+        title: probe.reason === 'missing_cid' ? '缺少 CID，暂时不能检测字幕' : '当前页面暂时不能检测字幕',
+        message: probe.reason === 'missing_cid'
+          ? 'Bili-Bill 还没有拿到当前分 P 的 CID，因此不能安全请求 B 站字幕来源。'
+          : '当前页面不满足字幕检测条件；仍使用元数据或简介兜底。',
+        action: '请确认视频页加载完成，并在播放器里开启中文 AI 字幕后重新检测字幕。',
+        evidenceAvailable: false,
+        canRetry: true,
+        detailLines: [notModelFailureText()],
+      });
+  }
+}
+
+function diagnostics(input: Omit<CurrentVideoSubtitleDiagnostics, 'featureGates'>): CurrentVideoSubtitleDiagnostics {
+  return {
+    ...input,
+    detailLines: input.detailLines.filter(Boolean),
+    featureGates: featureGates(input.evidenceAvailable),
+  };
+}
+
+function featureGates(evidenceAvailable: boolean): CurrentVideoSubtitleFeatureGate[] {
+  if (evidenceAvailable) {
+    return [
+      { label: '摘要', available: true, message: '可用：可基于本地字幕正文生成摘要。' },
+      { label: '知识节点', available: true, message: '可用：可生成带时间范围的字幕节点。' },
+      { label: '片段检索', available: true, message: '可用：可搜索当前视频字幕片段。' },
+      { label: '手动跳转', available: true, message: '可用：命中片段后可预览并手动确认跳转。' },
+    ];
+  }
+
+  return [
+    { label: '摘要', available: false, message: '不可用：没有字幕正文时只能展示元数据或简介说明，不能完整总结。' },
+    { label: '知识节点', available: false, message: '不可用：没有字幕正文时不会生成推测时间点。' },
+    { label: '片段检索', available: false, message: '不可用：没有字幕正文时不能定位具体片段。' },
+    { label: '手动跳转', available: false, message: '不可用：没有可定位片段时不会提供跳转目标。' },
+  ];
+}
+
+function isMissingCid(context: CurrentVideoContext): boolean {
+  return !context.cid
+    || context.subtitleProbe?.reason === 'missing_cid'
+    || context.transcriptEvidence?.reason === 'missing_cid';
+}
+
+function countText(count: number): string {
+  return count > 0 ? ` ${count} 条` : '';
+}
+
+function coverageText(evidence: CurrentVideoTranscriptEvidenceState): string {
+  if (typeof evidence.coverageStartSeconds !== 'number' || typeof evidence.coverageEndSeconds !== 'number') {
+    return '';
+  }
+  return `可引用时间范围：${formatDuration(evidence.coverageStartSeconds)}-${formatDuration(evidence.coverageEndSeconds)}。`;
+}
+
+function formatDuration(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+  const rest = safe % 60;
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(rest).padStart(2, '0')}`;
+  }
+  return `${minutes}:${String(rest).padStart(2, '0')}`;
+}
+
+function notModelFailureText(): string {
+  return '这不是 DeepSeek 或模型失败；当前缺少的是可引用的当前视频字幕正文。';
+}

--- a/tests/current-video-subtitle-diagnostics.mock.html
+++ b/tests/current-video-subtitle-diagnostics.mock.html
@@ -1,0 +1,303 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Bili-Bill 当前视频字幕诊断 Mock</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #10131f;
+        color: #f2f4f8;
+      }
+
+      body {
+        margin: 0;
+        padding: 24px;
+      }
+
+      main {
+        max-width: 780px;
+        margin: 0 auto;
+      }
+
+      h1 {
+        font-size: 18px;
+        margin: 0 0 14px;
+      }
+
+      .panel {
+        border: 1px solid rgba(255, 255, 255, 0.16);
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.06);
+        padding: 14px 16px;
+        margin-top: 12px;
+      }
+
+      .row {
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        margin-top: 8px;
+        font-size: 14px;
+      }
+
+      .muted {
+        color: #a9b0c3;
+      }
+
+      .ok {
+        color: #9be7b0;
+      }
+
+      .warn {
+        color: #ffcf8a;
+      }
+
+      .bad {
+        color: #ff9b9b;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px;
+        margin-top: 10px;
+      }
+
+      .gate {
+        border: 1px solid rgba(255, 179, 71, 0.24);
+        border-radius: 6px;
+        padding: 8px;
+        color: #ffcf8a;
+        font-size: 13px;
+        line-height: 1.45;
+      }
+
+      .gate.ok {
+        border-color: rgba(155, 231, 176, 0.28);
+      }
+
+      button {
+        margin-top: 10px;
+        margin-right: 8px;
+        border: 0;
+        border-radius: 6px;
+        background: #fb7299;
+        color: white;
+        padding: 8px 12px;
+        cursor: pointer;
+        font-weight: 700;
+      }
+
+      button.secondary {
+        background: rgba(255, 255, 255, 0.14);
+        color: #f2f4f8;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Bili-Bill 当前视频字幕诊断 Mock</h1>
+
+      <section class="panel">
+        <strong>当前视频</strong>
+        <div class="row">
+          <span>身份</span>
+          <span data-testid="identity">BV1MockSubtitle9 / CID 2202 / 第 2 P</span>
+        </div>
+        <div class="row">
+          <span>播放器字幕</span>
+          <span class="warn" data-testid="player-subtitle">尚未手动开启中文 AI 字幕</span>
+        </div>
+        <button type="button" data-testid="enable-subtitle">在播放器里开启中文 AI 字幕</button>
+        <button type="button" data-testid="redetect">重新检测字幕</button>
+      </section>
+
+      <section class="panel">
+        <strong data-testid="status-title">请先开启中文 AI 字幕</strong>
+        <p class="warn" data-testid="status-message">
+          当前还没有可用字幕正文。B 站视频通常需要先在播放器里手动开启“中文 AI”字幕，插件才有机会检测到字幕来源。
+        </p>
+        <p class="muted" data-testid="status-action">在播放器字幕菜单中开启中文 AI 字幕后，点击重新检测字幕。</p>
+        <p class="muted" data-testid="status-detail">这不是 DeepSeek 或模型失败；当前缺少的是可引用的当前视频字幕正文。</p>
+        <div class="grid" data-testid="feature-gates">
+          <div class="gate" data-testid="summary-gate">摘要：不可用：没有字幕正文时只能展示元数据或简介说明，不能完整总结。</div>
+          <div class="gate" data-testid="knowledge-gate">知识节点：不可用：没有字幕正文时不会生成推测时间点。</div>
+          <div class="gate" data-testid="search-gate">片段检索：不可用：没有字幕正文时不能定位具体片段。</div>
+          <div class="gate" data-testid="jump-gate">手动跳转：不可用：没有可定位片段时不会提供跳转目标。</div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <strong>错误态</strong>
+        <div>
+          <button class="secondary" type="button" data-error="missing-cid">缺少 CID</button>
+          <button class="secondary" type="button" data-error="no-track">没有返回字幕轨道</button>
+          <button class="secondary" type="button" data-error="login">需要登录或访问权限</button>
+          <button class="secondary" type="button" data-error="fetch">字幕正文拉取失败</button>
+          <button class="secondary" type="button" data-error="empty">字幕正文为空</button>
+          <button class="secondary" type="button" data-error="malformed">字幕正文结构异常</button>
+          <button class="secondary" type="button" data-error="language">字幕语言不匹配</button>
+          <button class="secondary" type="button" data-error="host">字幕来源不受支持</button>
+          <button class="secondary" type="button" data-error="stale">本地字幕证据不匹配</button>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      let enabled = false;
+
+      const states = {
+        found: {
+          title: "已发现字幕轨道",
+          message: "已检测到当前视频字幕轨道 1 条，但还没有可引用的字幕正文缓存。",
+          action: "点击重新检测字幕，继续读取并缓存字幕正文。",
+          detail: "只有字幕正文缓存成功后，摘要、片段检索和手动跳转才会解除限制。",
+          tone: "warn",
+          available: false,
+        },
+        reading: {
+          title: "正在读取字幕正文",
+          message: "正在刷新当前视频上下文、重新检测字幕来源，并尝试把 B 站字幕正文缓存为本地证据。",
+          action: "请保持当前 B 站视频页打开；如果刚开启中文 AI 字幕，等待检测完成即可。",
+          detail: "这个过程只使用当前页面和 B 站字幕接口，不会读取浏览器本地敏感文件或账号资料。",
+          tone: "warn",
+          available: false,
+        },
+        cached: {
+          title: "已缓存字幕正文",
+          message: "已缓存当前视频字幕正文证据 2 条，摘要、知识节点、片段检索和手动跳转会使用这些本地字幕片段。",
+          action: "如果刚切换分 P 或重新开启字幕，可以再次重新检测字幕以刷新证据。",
+          detail: "可引用时间范围：0:00-0:08。普通界面不会展示原始字幕地址、内部片段编号或校验信息。",
+          tone: "ok",
+          available: true,
+        },
+        "missing-cid": {
+          title: "缺少 CID，暂时不能检测字幕",
+          message: "Bili-Bill 还没有拿到当前分 P 的 CID，因此不能安全请求 B 站字幕来源或读取字幕正文。",
+          action: "请确认视频页加载完成；如果播放器里已经开启中文 AI 字幕，请点击重新检测字幕。",
+          detail: "CID 仍未知时，摘要只能使用标题、UP 主、简介、分 P 或章节等元数据兜底。",
+          tone: "bad",
+          available: false,
+        },
+        "no-track": {
+          title: "没有返回字幕轨道",
+          message: "B 站播放器接口没有返回可用字幕轨道。最常见原因是还没有在播放器里手动开启中文 AI 字幕。",
+          action: "请先在播放器字幕菜单中开启中文 AI 字幕，开启后点击重新检测字幕。",
+          detail: "这不是 DeepSeek 或模型失败；当前缺少的是可引用的当前视频字幕正文。",
+          tone: "warn",
+          available: false,
+        },
+        login: {
+          title: "字幕需要登录或访问权限",
+          message: "B 站字幕正文接口要求当前浏览器会话具备访问权限。Bili-Bill 不会读取浏览器本地敏感文件。",
+          action: "请在浏览器里确认 B 站已登录且播放器字幕可见，然后重新检测字幕。",
+          detail: "这不是模型失败；当前缺少的是 B 站允许读取的字幕正文。",
+          tone: "bad",
+          available: false,
+        },
+        fetch: {
+          title: "字幕正文拉取失败",
+          message: "已尝试读取字幕正文，但请求失败；当前仍只能使用元数据或简介作为本地证据。",
+          action: "请稍后重试，或确认当前视频页仍然打开且字幕已在播放器里开启。",
+          detail: "这不是 DeepSeek 或模型失败；当前缺少的是可引用的当前视频字幕正文。",
+          tone: "warn",
+          available: false,
+        },
+        empty: {
+          title: "字幕正文为空",
+          message: "已找到可读取的字幕来源，但 B 站没有返回有效正文片段。",
+          action: "请确认播放器里开启的是中文 AI 字幕；如果刚开启，请稍后重新检测字幕。",
+          detail: "这不是 DeepSeek 或模型失败；当前缺少的是可引用的当前视频字幕正文。",
+          tone: "warn",
+          available: false,
+        },
+        malformed: {
+          title: "字幕正文结构异常",
+          message: "B 站返回的字幕正文结构无法稳定解析，Bili-Bill 不会把它当作可引用字幕证据。",
+          action: "可以稍后重新检测字幕；在结构恢复前，摘要和定位功能只能使用元数据或简介兜底。",
+          detail: "这不是 DeepSeek 或模型失败；当前缺少的是可引用的当前视频字幕正文。",
+          tone: "warn",
+          available: false,
+        },
+        language: {
+          title: "字幕语言不匹配",
+          message: "当前可读字幕不是本次需要的中文 AI 字幕，因此不会作为当前视频正文证据。",
+          action: "请在 B 站播放器里切换到中文 AI 字幕后，再点击重新检测字幕。",
+          detail: "这不是 DeepSeek 或模型失败；当前缺少的是可引用的当前视频字幕正文。",
+          tone: "warn",
+          available: false,
+        },
+        host: {
+          title: "字幕来源不受支持",
+          message: "字幕正文地址不属于受限的 B 站或 hdslb 字幕域名，Bili-Bill 已拒绝读取。",
+          action: "请在播放器里重新选择中文 AI 字幕后，再点击重新检测字幕。",
+          detail: "普通界面不会展示原始字幕地址，也不会向其他服务上传字幕。",
+          tone: "warn",
+          available: false,
+        },
+        stale: {
+          title: "本地字幕证据与当前视频不匹配",
+          message: "本地缓存的字幕正文不属于当前 BVID、CID、分 P 或语言，已经停止作为当前视频证据使用。",
+          action: "点击重新检测字幕，重新读取当前视频的字幕正文。",
+          detail: "为了避免把旧视频片段当作当前视频证据，摘要、检索和跳转会继续使用元数据或简介兜底。",
+          tone: "warn",
+          available: false,
+        },
+      };
+
+      function setState(state) {
+        document.querySelector('[data-testid="status-title"]').textContent = state.title;
+        document.querySelector('[data-testid="status-message"]').textContent = state.message;
+        document.querySelector('[data-testid="status-message"]').className = state.tone;
+        document.querySelector('[data-testid="status-action"]').textContent = state.action;
+        document.querySelector('[data-testid="status-detail"]').textContent = state.detail;
+
+        const gateText = state.available
+          ? [
+              "摘要：可用：可基于本地字幕正文生成摘要。",
+              "知识节点：可用：可生成带时间范围的字幕节点。",
+              "片段检索：可用：可搜索当前视频字幕片段。",
+              "手动跳转：可用：命中片段后可预览并手动确认跳转。",
+            ]
+          : [
+              "摘要：不可用：没有字幕正文时只能展示元数据或简介说明，不能完整总结。",
+              "知识节点：不可用：没有字幕正文时不会生成推测时间点。",
+              "片段检索：不可用：没有字幕正文时不能定位具体片段。",
+              "手动跳转：不可用：没有可定位片段时不会提供跳转目标。",
+            ];
+
+        for (const [index, selector] of ["summary", "knowledge", "search", "jump"].entries()) {
+          const node = document.querySelector(`[data-testid="${selector}-gate"]`);
+          node.textContent = gateText[index];
+          node.className = state.available ? "gate ok" : "gate";
+        }
+      }
+
+      document.querySelector('[data-testid="enable-subtitle"]').addEventListener("click", () => {
+        enabled = true;
+        const label = document.querySelector('[data-testid="player-subtitle"]');
+        label.textContent = "播放器已开启中文 AI 字幕";
+        label.className = "ok";
+        setState(states.found);
+      });
+
+      document.querySelector('[data-testid="redetect"]').addEventListener("click", () => {
+        if (!enabled) {
+          setState(states["no-track"]);
+          return;
+        }
+        setState(states.reading);
+        window.setTimeout(() => setState(states.cached), 80);
+      });
+
+      for (const button of document.querySelectorAll("[data-error]")) {
+        button.addEventListener("click", () => {
+          setState(states[button.dataset.error]);
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/tests/current-video-subtitle-diagnostics.test.ts
+++ b/tests/current-video-subtitle-diagnostics.test.ts
@@ -1,0 +1,254 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildCurrentVideoSubtitleDiagnostics } from '../src/shared/current-video-subtitle-diagnostics.ts';
+import type {
+  CurrentVideoContext,
+  CurrentVideoSubtitleSourceState,
+  CurrentVideoSubtitleSourceStatus,
+} from '../src/shared/types/current-video-context.ts';
+import type {
+  CurrentVideoTranscriptEvidenceState,
+  CurrentVideoTranscriptEvidenceStatus,
+} from '../src/shared/types/current-video-transcript.ts';
+
+test('explains metadata-only state and asks user to enable Chinese AI subtitles', () => {
+  const state = buildCurrentVideoSubtitleDiagnostics(videoContext({
+    subtitleProbe: null,
+    transcriptEvidence: null,
+  }));
+
+  assert.equal(state.status, 'enable_ai_subtitle');
+  assert.equal(state.evidenceAvailable, false);
+  assert.match(visibleText(state), /手动开启.?中文 AI.?字幕/);
+  assert.match(visibleText(state), /不是 DeepSeek 或模型失败/);
+  assertFeatureGatesUnavailable(state);
+  assertNoRawUiLeak(state);
+});
+
+test('reports missing CID before subtitle detection or body caching', () => {
+  const state = buildCurrentVideoSubtitleDiagnostics(videoContext({ cid: null }));
+
+  assert.equal(state.status, 'missing_cid');
+  assert.match(visibleText(state), /缺少 CID/);
+  assert.match(visibleText(state), /重新检测字幕/);
+  assertFeatureGatesUnavailable(state);
+  assertNoRawUiLeak(state);
+});
+
+test('reports detected subtitle tracks before subtitle body is cached', () => {
+  const state = buildCurrentVideoSubtitleDiagnostics(videoContext({
+    subtitleProbe: subtitleProbe('available', {
+      trackCount: 1,
+      languages: ['zh-CN'],
+    }),
+    transcriptEvidence: evidence('missing'),
+  }));
+
+  assert.equal(state.status, 'track_found');
+  assert.match(visibleText(state), /已发现字幕轨道/);
+  assert.match(visibleText(state), /读取并缓存字幕正文/);
+  assertFeatureGatesUnavailable(state);
+  assertNoRawUiLeak(state);
+});
+
+test('reports active cached subtitle body as enabling downstream current-video tools', () => {
+  const state = buildCurrentVideoSubtitleDiagnostics(videoContext({
+    subtitleProbe: subtitleProbe('available'),
+    transcriptEvidence: evidence('cached', {
+      active: true,
+      segmentCount: 12,
+      coverageStartSeconds: 0,
+      coverageEndSeconds: 96,
+      sourceHash: 'hash-should-not-be-visible',
+    }),
+  }));
+
+  assert.equal(state.status, 'cached');
+  assert.equal(state.evidenceAvailable, true);
+  assert.match(visibleText(state), /已缓存字幕正文/);
+  assert.match(visibleText(state), /摘要、知识节点、片段检索和手动跳转/);
+  assert.ok(state.featureGates.every(item => item.available));
+  assertNoRawUiLeak(state);
+});
+
+test('maps subtitle body cache failures to user-actionable diagnostics', () => {
+  const cases: Array<{
+    evidence: CurrentVideoTranscriptEvidenceState;
+    expected: string;
+    text: RegExp;
+  }> = [
+    { evidence: evidence('endpoint_failed'), expected: 'fetch_failed', text: /字幕正文拉取失败/ },
+    { evidence: evidence('empty'), expected: 'empty', text: /字幕正文为空/ },
+    { evidence: evidence('malformed'), expected: 'malformed', text: /字幕正文结构异常/ },
+    { evidence: evidence('language_mismatch'), expected: 'language_mismatch', text: /字幕语言不匹配/ },
+    { evidence: evidence('login_required'), expected: 'login_required', text: /登录或访问权限/ },
+    { evidence: evidence('stale'), expected: 'stale', text: /不匹配/ },
+    {
+      evidence: evidence('track_unavailable', { reason: 'subtitle_host_unsupported' }),
+      expected: 'unsupported_host',
+      text: /不受支持/,
+    },
+  ];
+
+  for (const item of cases) {
+    const state = buildCurrentVideoSubtitleDiagnostics(videoContext({
+      subtitleProbe: subtitleProbe('available'),
+      transcriptEvidence: item.evidence,
+    }));
+    assert.equal(state.status, item.expected);
+    assert.match(visibleText(state), item.text);
+    assertFeatureGatesUnavailable(state);
+    assertNoRawUiLeak(state);
+  }
+});
+
+test('maps source-probe errors to Chinese user states without exposing internals', () => {
+  const cases: Array<{
+    probe: CurrentVideoSubtitleSourceState;
+    expected: string;
+    text: RegExp;
+  }> = [
+    { probe: subtitleProbe('unavailable'), expected: 'no_track', text: /没有返回字幕轨道/ },
+    { probe: subtitleProbe('login_required'), expected: 'login_required', text: /登录或访问权限/ },
+    { probe: subtitleProbe('endpoint_failed'), expected: 'fetch_failed', text: /字幕来源检测失败/ },
+    { probe: subtitleProbe('malformed'), expected: 'malformed', text: /字幕来源结构异常/ },
+  ];
+
+  for (const item of cases) {
+    const state = buildCurrentVideoSubtitleDiagnostics(videoContext({
+      subtitleProbe: item.probe,
+      transcriptEvidence: evidence('missing'),
+    }));
+    assert.equal(state.status, item.expected);
+    assert.match(visibleText(state), item.text);
+    assertFeatureGatesUnavailable(state);
+    assertNoRawUiLeak(state);
+  }
+});
+
+test('shows explicit reading state during re-detection', () => {
+  const state = buildCurrentVideoSubtitleDiagnostics(videoContext(), { refreshing: true });
+
+  assert.equal(state.status, 'reading_body');
+  assert.equal(state.canRetry, false);
+  assert.match(visibleText(state), /正在读取字幕正文/);
+  assert.match(visibleText(state), /重新检测字幕来源/);
+  assertNoRawUiLeak(state);
+});
+
+function assertFeatureGatesUnavailable(state: ReturnType<typeof buildCurrentVideoSubtitleDiagnostics>): void {
+  assert.ok(state.featureGates.every(item => !item.available));
+  assert.match(visibleText(state), /不能完整总结|不能定位具体片段|不会提供跳转目标/);
+}
+
+function assertNoRawUiLeak(state: ReturnType<typeof buildCurrentVideoSubtitleDiagnostics>): void {
+  assert.doesNotMatch(
+    visibleText(state),
+    /sourceHash|segmentId|subtitle_url|endpoint path|\/x\/player|token|Cookie|profile|登录态|Key\.txt|本地 key|Chrome\\User Data/i,
+  );
+}
+
+function visibleText(state: ReturnType<typeof buildCurrentVideoSubtitleDiagnostics>): string {
+  return [
+    state.title,
+    state.message,
+    state.action,
+    ...state.detailLines,
+    ...state.featureGates.map(item => `${item.label}:${item.message}`),
+  ].join('\n');
+}
+
+function videoContext(overrides: Partial<CurrentVideoContext> = {}): CurrentVideoContext {
+  return {
+    kind: 'video',
+    url: 'https://www.bilibili.com/video/BV1Diagnostic00?p=1',
+    collectedAt: 1000,
+    bvid: 'BV1Diagnostic00',
+    aid: 8800,
+    cid: 9901,
+    title: 'Subtitle diagnostic video',
+    authorName: 'Diagnostic UP',
+    authorMid: 42,
+    durationSeconds: 600,
+    currentPart: {
+      page: 1,
+      title: 'Main',
+      total: 1,
+    },
+    parts: [{ page: 1, cid: 9901, title: 'Main', durationSeconds: 600 }],
+    chapters: [],
+    description: {
+      availability: 'available',
+      text: 'Visible description used as bounded metadata evidence.',
+      length: 54,
+    },
+    sources: {
+      metadata: 'available',
+      description: 'available',
+      pages: 'available',
+      chapters: 'unknown',
+      transcript: 'unknown',
+      contentText: 'unavailable',
+    },
+    subtitleProbe: null,
+    transcriptEvidence: null,
+    warnings: ['transcript_probe_pending'],
+    ...overrides,
+  };
+}
+
+function subtitleProbe(
+  status: CurrentVideoSubtitleSourceStatus,
+  overrides: Partial<CurrentVideoSubtitleSourceState> = {},
+): CurrentVideoSubtitleSourceState {
+  return {
+    status,
+    available: status === 'available',
+    checkedAt: 2000,
+    bvid: 'BV1Diagnostic00',
+    cid: 9901,
+    page: 1,
+    sourceType: 'bilibili_player_wbi_v2',
+    sourceDomain: 'api.bilibili.com',
+    sourcePath: '/x/player/wbi/v2',
+    needLoginSubtitle: null,
+    trackCount: status === 'available' ? 1 : 0,
+    segmentCount: null,
+    coverageStartSeconds: null,
+    coverageEndSeconds: null,
+    languages: status === 'available' ? ['zh-CN'] : [],
+    tracks: [],
+    reason: status === 'available' ? 'subtitle_tracks_available' : `subtitle_${status}`,
+    message: 'raw probe message should not be required for user diagnostics',
+    warnings: [],
+    ...overrides,
+  };
+}
+
+function evidence(
+  status: CurrentVideoTranscriptEvidenceStatus,
+  overrides: Partial<CurrentVideoTranscriptEvidenceState> = {},
+): CurrentVideoTranscriptEvidenceState {
+  return {
+    status,
+    active: status === 'cached',
+    checkedAt: 3000,
+    bvid: 'BV1Diagnostic00',
+    cid: 9901,
+    page: 1,
+    language: 'zh-CN',
+    source: status === 'cached' ? 'bilibili_subtitle' : null,
+    sourceType: 'bilibili_player_wbi_v2',
+    sourceHash: status === 'cached' ? 'internal-hash' : null,
+    segmentCount: status === 'cached' ? 6 : 0,
+    staleSegmentCount: 0,
+    coverageStartSeconds: status === 'cached' ? 0 : null,
+    coverageEndSeconds: status === 'cached' ? 60 : null,
+    fetchedAt: status === 'cached' ? 3000 : null,
+    updatedAt: status === 'cached' ? 3000 : null,
+    reason: `transcript_${status}`,
+    message: 'raw evidence message should not be required for user diagnostics',
+    warnings: [],
+    ...overrides,
+  };
+}


### PR DESCRIPTION
﻿## Scope

- Adds a shared Chinese subtitle diagnostics model for current-video subtitle states: missing CID, enable Chinese AI subtitles, track found, reading body, cached body, login/access required, no tracks, fetch failed, malformed body, empty body, language mismatch, unsupported host, stale/mismatch, and metadata-only fallback.
- Uses the shared model in both Popup and the in-page Bili-Bill local assistant card, including feature gates for summary, video knowledge, segment search, and manual jump.
- Adds a `重新检测字幕` path that refreshes current-video context, subtitle source probing, and transcript evidence caching/status without reloading the page.
- Keeps #101 summary, #102 key-node/video knowledge, #103 retrieval, #104 jump, and #105 rerank semantics unchanged; this PR only changes user-visible state flow and the refresh entry.

## Root Cause / Product Judgment

Previously, users could see separate states like unknown CID, subtitle unavailable, or metadata/description fallback, but the UI did not explain whether they needed to enable Bilibili Chinese AI subtitles, retry source probing, wait for body caching, or accept that downstream tools were blocked. The state also did not clearly distinguish subtitle source discovery from transcript body evidence.

This PR turns the #113 source probe and #114 body cache outcomes into one actionable Chinese UX contract. When transcript evidence is absent, the UI explicitly says this is not a DeepSeek/model failure and that complete summary or precise segment location requires subtitle body evidence.

## Validation

- `npm run test:current-video-transcript` passed: 18/18, including the new subtitle diagnostics focused tests.
- `npm run test:current-video-summary` passed: 18/18.
- `npm run test:video-knowledge` passed: 12/12.
- `node --test tests/current-video-segment-retrieval.test.ts tests/current-video-timestamp-jump.test.ts tests/current-video-segment-rerank.test.ts` passed: 25/25.
- `node --test tests/current-video-context.test.ts tests/current-video-subtitle-probe.test.ts tests/current-video-context-resolver.test.ts` passed: 21/21.
- `npm run typecheck` passed.
- `npm run build` passed; existing Vite dynamic-import/chunk-size warnings remain.
- `git diff --cached --check` passed. `git diff --check` only emitted Windows LF/CRLF working-copy normalization warnings.
- `rg -n "未消费|猜你喜欢" dashboard popup public src README.md tests` returned no banned copy matches.
- Focused source scan for `sourceHash|segmentId|subtitle_url|/x/player|endpoint path|token|Cookie|profile|登录态|Key.txt|本地 key|Chrome\User Data` returned no matches in changed user-facing sources/mock.
- Mock HTML QA content check passed for 16 required states and 0 raw leaks.
- Browser mock attempt: both Codex in-app Browser and Chrome Browser client rejected localhost mock URLs with `net::ERR_BLOCKED_BY_CLIENT`; no browser profile, cookies, login-state files, or key files were read.

## Blockers / Must Fix / Follow-Up

- Blockers: none. #113 / PR #116 and #114 / PR #117 are merged into `main`.
- Must fix before review: none known.
- Follow-up: parent #82/#83 should do integrated real Bilibili-player acceptance: manually enable Chinese AI subtitles, click `重新检测字幕`, verify transcript evidence cache, then confirm summary/knowledge/search/jump gates unlock against the real page.

## Privacy Boundary

This PR does not add AI calls, does not upload subtitles or local history/favorites/following/feedback, does not write back to Bilibili, and does not read cookies, browser profiles, Bilibili login-state files, local key files, or `C:\Users\LittleNub\Desktop\Key.txt`.

Closes #115
