### PR TITLE
Add in-page current video timestamp jump

### DIFF
--- a/src/content/player-monitor/assistant-status.ts
+++ b/src/content/player-monitor/assistant-status.ts
@@ -8,6 +8,8 @@ import type { CurrentVideoTranscriptEvidenceState } from '../../shared/types/cur
 import type {
   CurrentVideoSegmentRetrievalCandidate,
   CurrentVideoSegmentRetrievalResult,
+  CurrentVideoTimestampJumpResponse,
+  CurrentVideoTimestampReturnResponse,
 } from '../../shared/types/current-video-segment-retrieval';
 import {
   buildCurrentVideoSubtitleDiagnostics,
@@ -337,6 +339,41 @@ const CSS = `
 #${CARD_ID} .bdc-assistant-candidate-reasons li {
   margin-top: 3px;
 }
+#${CARD_ID} .bdc-assistant-jump-status {
+  margin-top: 8px;
+  border: 1px solid rgba(127, 219, 255, 0.22);
+  border-radius: 8px;
+  background: rgba(127, 219, 255, 0.07);
+  color: #c8e6ff;
+  font-size: 11px;
+  line-height: 1.5;
+  padding: 8px;
+  overflow-wrap: anywhere;
+}
+#${CARD_ID} .bdc-assistant-jump-preview {
+  margin-top: 8px;
+  border: 1px solid rgba(255, 179, 71, 0.30);
+  border-radius: 8px;
+  background: rgba(255, 179, 71, 0.08);
+  padding: 8px;
+}
+#${CARD_ID} .bdc-assistant-jump-preview-title {
+  color: #ffcf8a;
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1.35;
+}
+#${CARD_ID} .bdc-assistant-jump-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+#${CARD_ID} .bdc-assistant-button-warn {
+  border-color: rgba(255, 179, 71, 0.42);
+  background: #ffb347;
+  color: #1f2433;
+}
 #${CARD_ID} .bdc-assistant-summary-meta {
   display: flex;
   flex-wrap: wrap;
@@ -410,6 +447,11 @@ interface AssistantState {
   segmentLoading: boolean;
   segmentError: string | null;
   segmentRequestId: number;
+  segmentPreviewCandidateId: string | null;
+  segmentJumpStatus: string | null;
+  segmentJumpLoading: boolean;
+  segmentReturnAvailable: boolean;
+  segmentReturnLoading: boolean;
   subtitleRefreshing: boolean;
   subtitleStatus: string | null;
   subtitleRequestId: number;
@@ -430,6 +472,11 @@ const assistantState: AssistantState = {
   segmentLoading: false,
   segmentError: null,
   segmentRequestId: 0,
+  segmentPreviewCandidateId: null,
+  segmentJumpStatus: null,
+  segmentJumpLoading: false,
+  segmentReturnAvailable: false,
+  segmentReturnLoading: false,
   subtitleRefreshing: false,
   subtitleStatus: null,
   subtitleRequestId: 0,
@@ -459,6 +506,11 @@ function updateAssistantContext(context: CurrentVideoContextResult): void {
     assistantState.segmentResult = null;
     assistantState.segmentContextKey = '';
     assistantState.segmentError = null;
+    assistantState.segmentPreviewCandidateId = null;
+    assistantState.segmentJumpStatus = null;
+    assistantState.segmentJumpLoading = false;
+    assistantState.segmentReturnAvailable = false;
+    assistantState.segmentReturnLoading = false;
     assistantState.subtitleStatus = null;
   }
   assistantState.context = context;
@@ -728,6 +780,8 @@ function appendSegmentRetrievalResult(
   appendBadge(meta, result.evidenceState.contextFresh ? '当前视频上下文有效' : '上下文需刷新');
   parent.appendChild(meta);
 
+  appendSegmentJumpStatus(parent);
+
   if (result.candidates.length === 0) {
     appendSegmentLimitations(parent, result);
     return;
@@ -784,7 +838,130 @@ function segmentCandidateCard(
     appendText(card, 'div', 'bdc-assistant-subtitle-detail', safeVisibleText(candidate.note));
   }
 
+  appendSegmentJumpControls(card, candidate, result);
+
   return card;
+}
+
+function appendSegmentJumpStatus(parent: HTMLElement): void {
+  if (!assistantState.segmentJumpStatus && !assistantState.segmentReturnAvailable) return;
+
+  const status = document.createElement('div');
+  status.className = 'bdc-assistant-jump-status';
+  appendText(
+    status,
+    'div',
+    '',
+    safeVisibleText(assistantState.segmentJumpStatus ?? '已记录跳转前位置，可返回原位置。'),
+  );
+
+  if (assistantState.segmentReturnAvailable) {
+    const actions = document.createElement('div');
+    actions.className = 'bdc-assistant-jump-actions';
+    actions.appendChild(button(
+      assistantState.segmentReturnLoading ? '返回中...' : '返回原位置',
+      'bdc-assistant-button bdc-assistant-button-warn',
+      () => {
+        void returnCurrentVideoSegmentJumpFromPage();
+      },
+      assistantState.segmentReturnLoading,
+    ));
+    status.appendChild(actions);
+  }
+
+  parent.appendChild(status);
+}
+
+function appendSegmentJumpControls(
+  parent: HTMLElement,
+  candidate: CurrentVideoSegmentRetrievalCandidate,
+  result: CurrentVideoSegmentRetrievalResult,
+): void {
+  const preview = candidate.jumpPreview;
+  const selected = assistantState.segmentPreviewCandidateId === candidate.id;
+  const controls = document.createElement('div');
+  controls.className = 'bdc-assistant-jump-actions';
+
+  controls.appendChild(button(
+    preview.canJump ? (selected ? '收起预览' : '预览跳转') : '不可跳转',
+    preview.canJump
+      ? 'bdc-assistant-button bdc-assistant-button-quiet'
+      : 'bdc-assistant-button bdc-assistant-button-quiet',
+    () => {
+      if (!preview.canJump) return;
+      assistantState.segmentPreviewCandidateId = selected ? null : candidate.id;
+      assistantState.segmentJumpStatus = selected ? assistantState.segmentJumpStatus : null;
+      renderAssistantShell();
+    },
+    !preview.canJump,
+  ));
+  parent.appendChild(controls);
+
+  if (!preview.canJump) {
+    appendText(parent, 'div', 'bdc-assistant-subtitle-detail', safeVisibleText(preview.message));
+    return;
+  }
+
+  appendText(
+    parent,
+    'div',
+    'bdc-assistant-subtitle-detail',
+    `可预览目标时间 ${safeVisibleText(preview.targetTimeLabel ?? candidate.timeRangeLabel)}；预览不会改变播放位置。`,
+  );
+
+  if (selected) {
+    parent.appendChild(segmentJumpPreviewPanel(candidate, result));
+  }
+}
+
+function segmentJumpPreviewPanel(
+  candidate: CurrentVideoSegmentRetrievalCandidate,
+  result: CurrentVideoSegmentRetrievalResult,
+): HTMLElement {
+  const preview = candidate.jumpPreview;
+  const panel = document.createElement('div');
+  panel.className = 'bdc-assistant-jump-preview';
+  appendText(panel, 'div', 'bdc-assistant-jump-preview-title', '确认跳转前预览');
+  appendText(
+    panel,
+    'div',
+    'bdc-assistant-candidate-evidence',
+    `目标时间：${safeVisibleText(preview.targetTimeLabel ?? candidate.timeRangeLabel)}`,
+  );
+  appendText(
+    panel,
+    'div',
+    'bdc-assistant-subtitle-detail',
+    `来源：${safeVisibleText(preview.sourceLabel)}；证据强度 ${preview.confidenceLabel} ${formatPercent(preview.confidence)}`,
+  );
+  appendText(
+    panel,
+    'div',
+    'bdc-assistant-candidate-evidence',
+    `证据预览：${safeVisibleText(preview.evidencePreview || candidate.evidenceText)}`,
+  );
+  appendText(panel, 'div', 'bdc-assistant-subtitle-detail', safeVisibleText(preview.message));
+
+  const actions = document.createElement('div');
+  actions.className = 'bdc-assistant-jump-actions';
+  actions.appendChild(button(
+    assistantState.segmentJumpLoading ? '确认中...' : '确认跳转',
+    'bdc-assistant-button bdc-assistant-button-warn',
+    () => {
+      void confirmCurrentVideoSegmentJumpFromPage(candidate, result);
+    },
+    assistantState.segmentJumpLoading || !preview.canJump,
+  ));
+  actions.appendChild(button(
+    '取消',
+    'bdc-assistant-button bdc-assistant-button-quiet',
+    () => {
+      assistantState.segmentPreviewCandidateId = null;
+      renderAssistantShell();
+    },
+  ));
+  panel.appendChild(actions);
+  return panel;
 }
 
 function appendSegmentLimitations(
@@ -886,11 +1063,18 @@ async function searchCurrentVideoSegmentsFromPage(): Promise<void> {
 
   const requestId = assistantState.segmentRequestId + 1;
   const contextKey = assistantState.contextKey;
+  const returnAvailable = assistantState.segmentReturnAvailable;
+  const returnStatus = returnAvailable ? assistantState.segmentJumpStatus : null;
   assistantState.segmentRequestId = requestId;
   assistantState.segmentLoading = true;
   assistantState.segmentError = null;
   assistantState.segmentResult = null;
   assistantState.segmentContextKey = contextKey;
+  assistantState.segmentPreviewCandidateId = null;
+  assistantState.segmentJumpStatus = returnStatus;
+  assistantState.segmentJumpLoading = false;
+  assistantState.segmentReturnAvailable = returnAvailable;
+  assistantState.segmentReturnLoading = false;
   renderAssistantShell();
 
   try {
@@ -908,6 +1092,71 @@ async function searchCurrentVideoSegmentsFromPage(): Promise<void> {
       assistantState.segmentLoading = false;
       renderAssistantShell();
     }
+  }
+}
+
+async function confirmCurrentVideoSegmentJumpFromPage(
+  candidate: CurrentVideoSegmentRetrievalCandidate,
+  result: CurrentVideoSegmentRetrievalResult,
+): Promise<void> {
+  if (assistantState.segmentJumpLoading) return;
+
+  const preview = candidate.jumpPreview;
+  if (!preview.canJump) {
+    assistantState.segmentJumpStatus = safeVisibleText(preview.message);
+    assistantState.segmentReturnAvailable = false;
+    renderAssistantShell();
+    return;
+  }
+
+  assistantState.segmentJumpLoading = true;
+  assistantState.segmentJumpStatus = '正在确认跳转...';
+  assistantState.segmentReturnAvailable = false;
+  renderAssistantShell();
+
+  try {
+    const response = await sendRuntimeRequest<CurrentVideoTimestampJumpResponse>(
+      'REQUEST_CURRENT_VIDEO_SEGMENT_JUMP',
+      {
+        query: result.query,
+        candidateId: candidate.id,
+        confirmed: true,
+      },
+    );
+    assistantState.segmentJumpStatus = safeVisibleText(response.message);
+    assistantState.segmentReturnAvailable = response.ok && response.returnPointSeconds !== null;
+    if (response.ok) {
+      assistantState.segmentPreviewCandidateId = null;
+    }
+  } catch {
+    assistantState.segmentJumpStatus = '跳转失败：请确认当前 B 站视频页仍然打开，并稍后重试。';
+    assistantState.segmentReturnAvailable = false;
+  } finally {
+    assistantState.segmentJumpLoading = false;
+    renderAssistantShell();
+  }
+}
+
+async function returnCurrentVideoSegmentJumpFromPage(): Promise<void> {
+  if (assistantState.segmentReturnLoading) return;
+
+  assistantState.segmentReturnLoading = true;
+  assistantState.segmentJumpStatus = '正在返回原位置...';
+  renderAssistantShell();
+
+  try {
+    const response = await sendRuntimeRequest<CurrentVideoTimestampReturnResponse>(
+      'RETURN_CURRENT_VIDEO_SEGMENT_JUMP',
+    );
+    assistantState.segmentJumpStatus = safeVisibleText(response.message);
+    if (response.ok) {
+      assistantState.segmentReturnAvailable = false;
+    }
+  } catch {
+    assistantState.segmentJumpStatus = '返回失败：请确认当前 B 站视频页仍然打开，并稍后重试。';
+  } finally {
+    assistantState.segmentReturnLoading = false;
+    renderAssistantShell();
   }
 }
 

--- a/tests/current-video-assistant-shell.mock.html
+++ b/tests/current-video-assistant-shell.mock.html
@@ -64,6 +64,9 @@
       let subtitleCached = false;
       let summaryReadCount = 0;
       let searchReadCount = 0;
+      let playbackPosition = 12;
+      let returnPointSeconds = null;
+      let lastSearchResult = null;
 
       window.__INITIAL_STATE__ = {
         videoData: {
@@ -84,6 +87,16 @@
         configurable: true,
         get() {
           return 600;
+        },
+      });
+      Object.defineProperty(HTMLMediaElement.prototype, "currentTime", {
+        configurable: true,
+        get() {
+          return playbackPosition;
+        },
+        set(value) {
+          const next = Number(value);
+          playbackPosition = Number.isFinite(next) ? Math.max(0, next) : playbackPosition;
         },
       });
 
@@ -256,14 +269,29 @@
         };
       }
 
+      function formatMockTime(seconds) {
+        const safe = Math.max(0, Math.floor(seconds));
+        const minutes = Math.floor(safe / 60);
+        const rest = safe % 60;
+        return `${minutes}:${String(rest).padStart(2, "0")}`;
+      }
+
+      function writeRuntimeLog(text) {
+        const log = document.querySelector("[data-testid='runtime-log']");
+        const video = document.querySelector("video");
+        if (video) video.setAttribute("data-current-time", String(playbackPosition));
+        if (log) log.textContent = `${text}；播放位置=${formatMockTime(playbackPosition)}`;
+      }
+
+      window.__assistantMockPlaybackPosition = () => playbackPosition;
+
       function searchCurrentVideoSegmentsResult(query) {
         searchReadCount += 1;
         const normalized = String(query || "").trim();
-        const log = document.querySelector("[data-testid='runtime-log']");
-        if (log) log.textContent = `检索 ${searchReadCount} 次；字幕缓存=${subtitleCached ? "是" : "否"}`;
+        writeRuntimeLog(`检索 ${searchReadCount} 次；字幕缓存=${subtitleCached ? "是" : "否"}`);
 
         if (!normalized) {
-          return {
+          lastSearchResult = {
             status: "empty_query",
             query: normalized,
             normalizedQuery: normalized,
@@ -280,10 +308,11 @@
             },
             aiRerank: segmentAiState(),
           };
+          return lastSearchResult;
         }
 
         if (!subtitleCached) {
-          return {
+          lastSearchResult = {
             status: "no_evidence",
             query: normalized,
             normalizedQuery: normalized,
@@ -303,13 +332,61 @@
             },
             aiRerank: segmentAiState(),
           };
+          return lastSearchResult;
+        }
+
+        const metadataOnly = normalized.includes("简介") || normalized.toLowerCase().includes("metadata");
+        if (metadataOnly) {
+          lastSearchResult = {
+            status: "metadata_only",
+            query: normalized,
+            normalizedQuery: normalized.toLowerCase(),
+            title: "页内助手 Shell Mock 视频",
+            generatedAt: Date.now(),
+            candidates: [
+              {
+                id: ["candidate", "metadata", mockBvid, "0"].join(":"),
+                binding: { kind: "metadata_hint" },
+                source: "metadata_hint",
+                sourceLabel: "视频信息弱提示",
+                startSeconds: null,
+                endSeconds: null,
+                timeRangeLabel: "无法定位具体时间",
+                evidenceText: "简介里提到页内助手，但没有字幕时间点。",
+                matchReasons: ["只命中视频简介"],
+                confidence: 0.32,
+                confidenceLabel: "低",
+                note: "仅能说明当前视频信息相关，无法定位到具体时间。",
+                jumpPreview: segmentJumpPreview({
+                  canJump: false,
+                  disabledReason: "metadata_only",
+                  targetSeconds: null,
+                  targetTimeLabel: null,
+                  sourceLabel: "视频信息弱提示",
+                  confidence: 0.32,
+                  confidenceLabel: "低",
+                  message: "该候选只来自视频信息或简介，无法定位到具体播放时间。",
+                }),
+              },
+            ],
+            summary: "只找到视频信息或简介里的弱提示，当前无法定位到具体时间。",
+            limitations: ["仅视频信息或简介弱提示不能定位时间，需要字幕正文或本地节点证据。"],
+            evidenceState: {
+              transcriptSegmentCount: 3,
+              timedKnowledgeNodeCount: 0,
+              metadataHintAvailable: true,
+              contextFresh: true,
+            },
+            aiRerank: segmentAiState(),
+          };
+          return lastSearchResult;
         }
 
         const lowConfidence = normalized.includes("低置信") || normalized.includes("不确定");
         const confidence = lowConfidence ? 0.32 : 0.86;
         const confidenceLabel = lowConfidence ? "低" : "高";
         const status = lowConfidence ? "low_confidence" : "ready";
-        return {
+        lastSearchResult = {
           status,
           query: normalized,
           normalizedQuery: normalized.toLowerCase(),
@@ -386,6 +463,85 @@
           },
           aiRerank: segmentAiState(),
         };
+        return lastSearchResult;
+      }
+
+      function requestCurrentVideoSegmentJump(params) {
+        const candidate = lastSearchResult?.candidates?.find(item => item.id === params?.candidateId);
+        if (params?.confirmed !== true) {
+          return {
+            ok: false,
+            message: "需要先确认跳转。",
+            candidateId: String(params?.candidateId ?? ""),
+            targetSeconds: null,
+            targetTimeLabel: null,
+            returnPointSeconds: null,
+            sourceLabel: null,
+            confidence: null,
+          };
+        }
+        if (!candidate) {
+          return {
+            ok: false,
+            message: "候选已变化，请重新检索后再跳转。",
+            candidateId: String(params?.candidateId ?? ""),
+            targetSeconds: null,
+            targetTimeLabel: null,
+            returnPointSeconds: null,
+            sourceLabel: null,
+            confidence: null,
+          };
+        }
+        if (!candidate.jumpPreview.canJump || candidate.jumpPreview.targetSeconds === null) {
+          return {
+            ok: false,
+            message: candidate.jumpPreview.message,
+            candidateId: candidate.id,
+            targetSeconds: null,
+            targetTimeLabel: null,
+            returnPointSeconds: null,
+            sourceLabel: candidate.jumpPreview.sourceLabel,
+            confidence: candidate.jumpPreview.confidence,
+          };
+        }
+
+        returnPointSeconds = playbackPosition;
+        playbackPosition = candidate.jumpPreview.targetSeconds;
+        writeRuntimeLog(`确认跳转到 ${candidate.jumpPreview.targetTimeLabel}`);
+        return {
+          ok: true,
+          message: `已跳到 ${candidate.jumpPreview.targetTimeLabel}，可返回 ${formatMockTime(returnPointSeconds)}。`,
+          candidateId: candidate.id,
+          targetSeconds: candidate.jumpPreview.targetSeconds,
+          targetTimeLabel: candidate.jumpPreview.targetTimeLabel,
+          returnPointSeconds,
+          sourceLabel: candidate.jumpPreview.sourceLabel,
+          confidence: candidate.jumpPreview.confidence,
+        };
+      }
+
+      function returnCurrentVideoSegmentJump() {
+        if (returnPointSeconds === null) {
+          return {
+            ok: false,
+            message: "没有可返回的播放位置。",
+            candidateId: null,
+            returnPointSeconds: null,
+            targetSeconds: null,
+          };
+        }
+        const previous = returnPointSeconds;
+        const targetSeconds = playbackPosition;
+        playbackPosition = previous;
+        returnPointSeconds = null;
+        writeRuntimeLog(`返回原位置 ${formatMockTime(previous)}`);
+        return {
+          ok: true,
+          message: `已返回 ${formatMockTime(previous)}。`,
+          candidateId: null,
+          returnPointSeconds: previous,
+          targetSeconds,
+        };
       }
 
       window.chrome = {
@@ -411,6 +567,18 @@
               return Promise.resolve({
                 success: true,
                 data: searchCurrentVideoSegmentsResult(message.params?.query),
+              });
+            }
+            if (message.action === "REQUEST_CURRENT_VIDEO_SEGMENT_JUMP") {
+              return Promise.resolve({
+                success: true,
+                data: requestCurrentVideoSegmentJump(message.params),
+              });
+            }
+            if (message.action === "RETURN_CURRENT_VIDEO_SEGMENT_JUMP") {
+              return Promise.resolve({
+                success: true,
+                data: returnCurrentVideoSegmentJump(),
               });
             }
             return Promise.resolve({ success: true, data: null });


### PR DESCRIPTION
## Scope
- Add in-page preview and manual confirm controls to current-video segment candidates in the Bilibili page assistant.
- Reuse the existing `REQUEST_CURRENT_VIDEO_SEGMENT_JUMP` and `RETURN_CURRENT_VIDEO_SEGMENT_JUMP` actions; no Dashboard handoff, no new tab, no new AI call.
- Show disabled jump reasons in ordinary Chinese for low confidence, metadata-only, missing/non-timed, stale or invalid candidates through the existing jump preview contract.
- Extend the localhost current-video assistant mock to cover confirm-only seek, return-to-origin, low-confidence disabled state, metadata-only disabled state, and visible raw-field leak checks.

## Root Cause / Product Judgment
#119 moved the single-video assistant into the current Bilibili page, and #120 added current-video segment candidates. The remaining gap was that candidates were still informational only. A timestamp jump must stay in the active player page because the return point and seek target are bound to the current BVID/CID/player context. This PR keeps the flow manual: preview only explains the target, seek only happens after explicit confirm, and the return action is shown after a successful jump.

## Validation
- `node --test tests/current-video-segment-retrieval.test.ts tests/current-video-timestamp-jump.test.ts`
- `npm run test:current-video-transcript`
- `npm run test:current-video-summary`
- `npm run test:video-knowledge`
- `npm run typecheck`
- `npm run build`
- `git diff --check` (passes; PowerShell reports LF-to-CRLF normalization warnings only)
- `rg -n "???|????" dashboard popup public src README.md tests` (no matches)
- Browser/mock QA on localhost `/video/BV1ShellMock9?p=1`: expanded the assistant, re-detected subtitles, searched a current-video query, verified preview did not change playback position, confirmed jump changed mock playback position from 0:12 to 0:42, verified return restored 0:12, verified return remains available after a post-jump search, verified low-confidence and metadata-only candidates show disabled `????`, verified no visible raw-field hits (`subtitle_url`, `sourceHash`, `segmentId`, `candidateId`, token, endpoint, Cookie/profile/key), and verified no Dashboard/new-tab path or console warnings/errors.

## Blockers / Must Fix / Follow-up
- Blockers: none.
- Must fix: none known.
- Follow-up: #122 can add the knowledge-node area next to the existing summary/search/jump sections, using the same current-video bounded evidence and without changing this manual jump contract.

## Privacy Boundary
No Cookie files, browser profile files, Bilibili login-state files, local key files, or `C:\Users\LittleNub\Desktop\Key.txt` were read. This PR does not write back to Bilibili and does not add tables or AI calls.

Closes #121
