### PR TITLE
feat: add global AI settings MVP

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -10,6 +10,7 @@ import { CreatorPage } from './modules/creator/CreatorPage';
 import { BehaviorPage } from './modules/behavior/BehaviorPage';
 import { ExperimentsPage } from './modules/experiments/ExperimentsPage';
 import { SmartFavoritesPage } from './modules/favorites/SmartFavoritesPage';
+import { SettingsPage } from './modules/settings/SettingsPage';
 import type { WatchHistoryRecord } from '../src/shared/types/watch-event';
 import type { HistorySyncStatus } from '../src/shared/types/history-sync';
 
@@ -21,6 +22,7 @@ const NAV_ITEMS = [
   { id: 'behavior', label: '行为', caption: '节奏与时段', shortLabel: '行' },
   { id: 'experiments', label: '盲盒', caption: '视频盲盒', shortLabel: '盒' },
   { id: 'smart-favorites', label: '智能收藏', caption: '收藏夹整理', shortLabel: '藏' },
+  { id: 'settings', label: '设置', caption: 'AI 与隐私', shortLabel: '设' },
 ];
 
 const PAGES = [
@@ -31,6 +33,7 @@ const PAGES = [
   BehaviorPage,
   ExperimentsPage,
   SmartFavoritesPage,
+  SettingsPage,
 ];
 
 const EXPORT_PAGE_SIZE = 500;

--- a/dashboard/modules/dynamic-bill/DynamicBillPage.tsx
+++ b/dashboard/modules/dynamic-bill/DynamicBillPage.tsx
@@ -263,25 +263,6 @@ export function DynamicBillPage() {
     }
   }
 
-  async function handleToggleAiExplanations() {
-    const current = userConfig ?? await requestSW<UserConfig>("GET_CONFIG");
-    const nextEnabled = !current.dynamicBill.aiExplanationsEnabled;
-    setNotice("");
-    try {
-      await requestSW("UPDATE_CONFIG", {
-        dynamicBill: {
-          aiExplanationsEnabled: nextEnabled,
-        },
-      });
-      await refreshConfig();
-      setNotice(nextEnabled
-        ? "已启用动态账单 AI 解释；生成时只会发送已入选账单项的必要视频元数据和紧凑证据事实。"
-        : "已关闭动态账单 AI 解释；页面继续显示本地证据结果。");
-    } catch (error) {
-      setNotice(`更新 AI 解释开关失败：${describeError(error)}`);
-    }
-  }
-
   async function handleBuildExplanations() {
     setExplaining(true);
     setNotice("");
@@ -364,6 +345,10 @@ export function DynamicBillPage() {
     }
   }
 
+  function openSettings() {
+    window.location.hash = "settings";
+  }
+
   return (
     <div className="dynamic-bill-page">
       <header className="dynamic-bill-hero">
@@ -377,7 +362,10 @@ export function DynamicBillPage() {
         <div className="dynamic-bill-scope">
           <strong>解释数据范围</strong>
           <span>
-            AI 只接收已入选账单项的新视频标题/简介、UP 名、分区/标签、发布时间、时长和紧凑证据事实；不发送完整历史、完整关注列表、Cookie、用户 mid、个人资料或反馈记录。
+            AI 只接收已入选账单项的新视频标题/简介、UP 名、分区/标签、发布时间、时长和紧凑证据事实；不发送完整历史、完整关注列表、Cookie、用户账号标识、个人资料或反馈记录。
+          </span>
+          <span>
+            {dynamicBillAiSettingsCopy(isAiEnabled, isAiConfigured)}
           </span>
           <div className="dynamic-bill-scope-actions">
             <button
@@ -408,9 +396,9 @@ export function DynamicBillPage() {
               type="button"
               className="dynamic-bill-sync-button is-ghost"
               disabled={isSyncing || generating || explaining}
-              onClick={handleToggleAiExplanations}
+              onClick={openSettings}
             >
-              {isAiEnabled ? "关闭 AI 解释" : "启用 AI 解释"}
+              前往设置
             </button>
           </div>
         </div>
@@ -886,7 +874,7 @@ function describeExplanationResult(result: DynamicBillExplanationResult): string
     return `AI 解释未启用，已为 ${result.fallback} 个账单项展示本地证据结果。`;
   }
   if (result.status === "not_configured") {
-    return `AI 未配置 API Key，已为 ${result.fallback} 个账单项展示本地证据结果。`;
+    return `AI 尚未在设置中配置 API Key，已为 ${result.fallback} 个账单项展示本地证据结果。`;
   }
   const pending = result.pending > 0 ? `，剩余 ${result.pending} 个待处理` : "";
   return `AI 解释处理 ${result.processed} 项：成功 ${result.generated} 项，失败 ${result.failed} 项，跳过 ${result.skipped} 项${pending}；失败项仍展示本地证据结果。`;
@@ -999,12 +987,18 @@ function explanationStateCopy(
     return `AI 生成失败：${explanation.error ?? "未知错误"}；以下使用本地规则事实解释。`;
   }
   if (explanation?.status === "not_configured" || (aiAvailability.enabled && !aiAvailability.configured)) {
-    return "AI 未配置 API Key；以下使用本地规则事实解释。";
+    return "AI 尚未在设置中配置 API Key；以下使用本地规则事实解释。";
   }
   if (explanation?.status === "disabled" || !aiAvailability.enabled) {
-    return "AI 解释未启用；以下使用本地规则事实解释。";
+    return "AI 解释未在设置中启用；以下使用本地规则事实解释。";
   }
   return "尚未生成 AI 解释；以下使用本地规则事实解释。";
+}
+
+function dynamicBillAiSettingsCopy(enabled: boolean, configured: boolean): string {
+  if (!enabled) return "AI 解释未在设置中启用；生成解释时会直接写入本地证据说明。";
+  if (!configured) return "AI 解释已启用但尚未在设置中配置 API Key；生成解释时会回退到本地证据说明。";
+  return "AI 解释已在设置中启用；生成时只整理已入选账单项的必要证据。";
 }
 
 function localFallbackSummary(item: DynamicBillItem): string {

--- a/dashboard/modules/favorites/SmartFavoritesPage.tsx
+++ b/dashboard/modules/favorites/SmartFavoritesPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'preact/hooks';
 import { requestSW } from '../../utils/messaging';
 import { BILI_BLUE, BILI_PINK } from '../../../src/shared/constants';
-import type { AiConfig, AssistantConfig, UserConfig } from '../../../src/shared/types/config';
+import type { AssistantConfig, UserConfig } from '../../../src/shared/types/config';
 import type {
   FavoriteFolderGapProbeResult,
   FavoriteFolderSyncDiagnostic,
@@ -26,12 +26,12 @@ const CARD = {
 
 export function SmartFavoritesPage() {
   const [overview, setOverview] = useState<SmartFavoriteOverview | null>(null);
-  const [config, setConfig] = useState<AiConfig>({ baseURL: 'https://api.deepseek.com', apiKey: '', chatModel: 'deepseek-v4-flash' });
   const [assistantConfig, setAssistantConfig] = useState<AssistantConfig>({
     aiSummariesEnabled: false,
     smartFavoritesQaAiEnabled: false,
     currentVideoSegmentRerankAiEnabled: false,
   });
+  const [aiStatus, setAiStatus] = useState({ hasApiKey: false, model: '' });
   const [query, setQuery] = useState('');
   const [question, setQuestion] = useState('');
   const [search, setSearch] = useState<SmartFavoriteSearchResponse | null>(null);
@@ -58,8 +58,11 @@ export function SmartFavoritesPage() {
         requestSW<UserConfig>('GET_CONFIG'),
         requestSW<SmartFavoriteOverview>('GET_SMART_FAVORITES'),
       ]);
-      setConfig(cfg.ai);
       setAssistantConfig(cfg.assistant);
+      setAiStatus({
+        hasApiKey: Boolean(cfg.ai.apiKey.trim()),
+        model: cfg.ai.chatModel,
+      });
       setOverview(data);
       if (selectedPath.length > 0) {
         setPathResults(await requestSW<SmartFavoriteResult[]>('GET_SMART_FAVORITES_BY_PATH', { path: selectedPath, limit: 200 }));
@@ -68,20 +71,6 @@ export function SmartFavoritesPage() {
       setError((e as Error).message);
     } finally {
       setLoading(false);
-    }
-  }
-
-  async function saveAiConfig() {
-    setBusy('save');
-    setError(null);
-    try {
-      await ensureAiHostPermission(config.baseURL);
-      await requestSW('UPDATE_CONFIG', { ai: config, assistant: assistantConfig });
-      setNotice('AI 配置已保存');
-    } catch (e) {
-      setError((e as Error).message);
-    } finally {
-      setBusy('');
     }
   }
 
@@ -256,6 +245,10 @@ export function SmartFavoritesPage() {
     setExpandedTree(new Set());
   }
 
+  function openSettings() {
+    window.location.hash = 'settings';
+  }
+
   if (loading) return <div style={{ padding: '16px' }}><LoadingSkeleton height={420} /></div>;
 
   return (
@@ -309,65 +302,20 @@ export function SmartFavoritesPage() {
       </section>
 
       <section style={CARD}>
-        <div style={{ color: '#FFFFFF', fontSize: '13px', fontWeight: 600, marginBottom: '8px' }}>AI 配置</div>
-        <div style={{ display: 'grid', gridTemplateColumns: '1.2fr 1fr', gap: '8px', marginBottom: '8px' }}>
-          <TextInput value={config.baseURL} onInput={value => setConfig({ ...config, baseURL: value })} placeholder="Base URL" />
-          <TextInput value={config.chatModel} onInput={value => setConfig({ ...config, chatModel: value })} placeholder="模型" />
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: '10px', alignItems: 'center' }}>
+          <div>
+            <div style={{ color: '#FFFFFF', fontSize: '13px', fontWeight: 600, marginBottom: '6px' }}>AI 状态</div>
+            <div style={{ color: '#9090A0', fontSize: '12px', lineHeight: 1.55 }}>
+              AI 服务地址、模型名、API Key 和功能开关已迁移到全局设置。智能收藏页只显示当前状态，并在 AI 未启用或未配置时继续返回本地引用结果。
+            </div>
+          </div>
+          <ActionButton label="前往设置" onClick={openSettings} disabled={!!busy} />
         </div>
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr auto auto auto auto', gap: '8px', alignItems: 'center' }}>
-          <TextInput value={config.apiKey} onInput={value => setConfig({ ...config, apiKey: value })} placeholder="API Key" password />
-          <label style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '6px',
-            color: '#C8C8D8',
-            fontSize: '11px',
-          }}>
-            <input
-              type="checkbox"
-              checked={assistantConfig.aiSummariesEnabled}
-              onChange={(event) => setAssistantConfig({
-                ...assistantConfig,
-                aiSummariesEnabled: (event.currentTarget as HTMLInputElement).checked,
-              })}
-            />
-            当前视频摘要
-          </label>
-          <label style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '6px',
-            color: '#C8C8D8',
-            fontSize: '11px',
-          }}>
-            <input
-              type="checkbox"
-              checked={assistantConfig.smartFavoritesQaAiEnabled}
-              onChange={(event) => setAssistantConfig({
-                ...assistantConfig,
-                smartFavoritesQaAiEnabled: (event.currentTarget as HTMLInputElement).checked,
-              })}
-            />
-            收藏问答 AI
-          </label>
-          <label style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '6px',
-            color: '#C8C8D8',
-            fontSize: '11px',
-          }}>
-            <input
-              type="checkbox"
-              checked={assistantConfig.currentVideoSegmentRerankAiEnabled}
-              onChange={(event) => setAssistantConfig({
-                ...assistantConfig,
-                currentVideoSegmentRerankAiEnabled: (event.currentTarget as HTMLInputElement).checked,
-              })}
-            />
-            片段重排 AI
-          </label>
-          <ActionButton label={busy === 'save' ? '保存中...' : '保存'} onClick={saveAiConfig} disabled={!!busy} />
+        <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap', marginTop: '10px' }}>
+          <Badge text={aiStatus.hasApiKey ? 'AI 服务：已配置' : 'AI 服务：未配置'} color={aiStatus.hasApiKey ? '#00D4AA' : '#FFB347'} />
+          <Badge text={`模型：${aiStatus.model || '未设置'}`} color="#9090A0" />
+          <Badge text={assistantConfig.smartFavoritesQaAiEnabled ? '收藏问答：已启用' : '收藏问答：未启用'} color={assistantConfig.smartFavoritesQaAiEnabled ? '#00D4AA' : '#9090A0'} />
+          <Badge text={assistantConfig.currentVideoSegmentRerankAiEnabled ? '当前视频片段排序：已启用' : '当前视频片段排序：未启用'} color={assistantConfig.currentVideoSegmentRerankAiEnabled ? '#00D4AA' : '#9090A0'} />
         </div>
       </section>
 
@@ -700,10 +648,10 @@ function qaSynthesisStatusLabel(status: NonNullable<SmartFavoriteQaResponse['syn
 function qaSynthesisMessage(synthesis: NonNullable<SmartFavoriteQaResponse['synthesis']>): string {
   const reason = synthesis.reason ?? '';
   if (synthesis.status === 'disabled') {
-    return 'AI 综合未启用，当前显示本地引用结果。';
+    return 'AI 综合未在设置中启用，当前显示本地引用结果。';
   }
   if (synthesis.status === 'not_configured') {
-    return 'AI 综合尚未配置 API Key，当前显示本地引用结果。';
+    return 'AI 综合尚未在设置中配置 API Key，当前显示本地引用结果。';
   }
   if (synthesis.status === 'local_fallback') {
     return '没有可引用视频时不会请求 AI，当前显示本地检索结果。';
@@ -712,7 +660,7 @@ function qaSynthesisMessage(synthesis: NonNullable<SmartFavoriteQaResponse['synt
     return `AI 综合结果未通过引用边界检查，已显示本地引用结果。${qaGuardReasonLabel(reason)}`;
   }
   if (synthesis.status === 'failed') {
-    return `AI 综合失败，已显示本地引用结果。${reason ? `诊断：${reason}` : ''}`;
+    return 'AI 综合暂时不可用，已显示本地引用结果。';
   }
   return '当前显示本地引用结果。';
 }
@@ -724,7 +672,7 @@ function qaGuardReasonLabel(reason: string): string {
   if (reason.startsWith('AI_OUTSIDE_TITLE_REFERENCE')) return '原因：AI 提到了引用列表外的视频标题。';
   if (reason === 'AI_EMPTY_ANSWER') return '原因：AI 没有返回可用回答。';
   if (reason === 'AI_MISSING_CITED_VIDEO_REFS') return '原因：AI 没有标注引用视频。';
-  return `诊断：${reason}`;
+  return '原因：AI 返回内容不符合引用边界。';
 }
 
 function formatQaSourceFields(fields: string[]): string {
@@ -1333,42 +1281,4 @@ function collectExpandablePathKeys(nodes: SmartFavoriteTreeNode[]): string[] {
 
 function pathKey(path: string[]): string {
   return path.join('\u0001');
-}
-
-async function ensureAiHostPermission(baseURL: string): Promise<void> {
-  const pattern = getOriginPattern(baseURL);
-  const granted = await new Promise<boolean>(resolve => {
-    chrome.permissions.contains({ origins: [pattern] }, resolve);
-  });
-  if (granted) return;
-
-  const approved = await new Promise<boolean>(resolve => {
-    chrome.permissions.request({ origins: [pattern] }, resolve);
-  });
-  if (!approved) {
-    throw new Error(`缺少 AI 服务访问权限：${pattern}`);
-  }
-}
-
-function getOriginPattern(baseURL: string): string {
-  let url: URL;
-  try {
-    url = new URL(baseURL);
-  } catch {
-    throw new Error('AI Base URL 格式不正确');
-  }
-  if (!['https:', 'http:'].includes(url.protocol)) {
-    throw new Error('AI Base URL 只支持 http 或 https');
-  }
-
-  const hostname = url.hostname.toLowerCase();
-  if (url.protocol === 'http:' && !isLocalHttpHost(hostname)) {
-    throw new Error('HTTP AI Base URL 只支持 localhost 或 127.0.0.1');
-  }
-
-  return `${url.protocol}//${hostname}/*`;
-}
-
-function isLocalHttpHost(hostname: string): boolean {
-  return hostname === 'localhost' || hostname === '127.0.0.1';
 }

--- a/dashboard/modules/settings/SettingsPage.tsx
+++ b/dashboard/modules/settings/SettingsPage.tsx
@@ -1,0 +1,372 @@
+import { useEffect, useMemo, useState } from 'preact/hooks';
+import { requestSW } from '../../utils/messaging';
+import type {
+  AiConfig,
+  AiConnectionTestResult,
+  AssistantConfig,
+  DynamicBillConfig,
+  UserConfig,
+} from '../../../src/shared/types/config';
+
+type BusyState = '' | 'save' | 'test';
+
+interface AiFormState {
+  baseURL: string;
+  chatModel: string;
+  apiKeyInput: string;
+}
+
+const DEFAULT_AI_FORM: AiFormState = {
+  baseURL: 'https://api.deepseek.com',
+  chatModel: 'deepseek-v4-flash',
+  apiKeyInput: '',
+};
+
+const DEFAULT_ASSISTANT: AssistantConfig = {
+  aiSummariesEnabled: false,
+  smartFavoritesQaAiEnabled: false,
+  currentVideoSegmentRerankAiEnabled: false,
+};
+
+const DEFAULT_DYNAMIC_BILL: DynamicBillConfig = {
+  aiExplanationsEnabled: false,
+};
+
+export function SettingsPage() {
+  const [form, setForm] = useState<AiFormState>(DEFAULT_AI_FORM);
+  const [savedApiKey, setSavedApiKey] = useState('');
+  const [assistant, setAssistant] = useState<AssistantConfig>(DEFAULT_ASSISTANT);
+  const [dynamicBill, setDynamicBill] = useState<DynamicBillConfig>(DEFAULT_DYNAMIC_BILL);
+  const [loadedConfig, setLoadedConfig] = useState<UserConfig | null>(null);
+  const [busy, setBusy] = useState<BusyState>('');
+  const [loading, setLoading] = useState(true);
+  const [notice, setNotice] = useState('');
+  const [error, setError] = useState('');
+  const [lastTest, setLastTest] = useState<AiConnectionTestResult | null>(null);
+
+  useEffect(() => {
+    void refreshConfig();
+  }, []);
+
+  const effectiveAiConfig = useMemo<AiConfig>(() => ({
+    baseURL: form.baseURL.trim(),
+    chatModel: form.chatModel.trim(),
+    apiKey: form.apiKeyInput.trim() || savedApiKey,
+  }), [form, savedApiKey]);
+
+  const hasSavedApiKey = savedApiKey.trim().length > 0;
+  const hasPendingChanges = useMemo(() => {
+    if (!loadedConfig) return false;
+    return form.baseURL.trim() !== loadedConfig.ai.baseURL
+      || form.chatModel.trim() !== loadedConfig.ai.chatModel
+      || form.apiKeyInput.trim().length > 0
+      || assistant.aiSummariesEnabled !== loadedConfig.assistant.aiSummariesEnabled
+      || assistant.smartFavoritesQaAiEnabled !== loadedConfig.assistant.smartFavoritesQaAiEnabled
+      || assistant.currentVideoSegmentRerankAiEnabled !== loadedConfig.assistant.currentVideoSegmentRerankAiEnabled
+      || dynamicBill.aiExplanationsEnabled !== loadedConfig.dynamicBill.aiExplanationsEnabled;
+  }, [assistant, dynamicBill, form, loadedConfig]);
+
+  async function refreshConfig() {
+    setLoading(true);
+    setError('');
+    try {
+      const config = await requestSW<UserConfig>('GET_CONFIG');
+      applyConfig(config);
+      setNotice('');
+      setLastTest(null);
+    } catch (err) {
+      setError(formatSettingsError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function saveSettings() {
+    setBusy('save');
+    setError('');
+    setNotice('');
+    try {
+      await ensureAiHostPermission(effectiveAiConfig.baseURL);
+      const nextConfig: UserConfig = {
+        ...(loadedConfig ?? await requestSW<UserConfig>('GET_CONFIG')),
+        ai: effectiveAiConfig,
+        assistant,
+        dynamicBill,
+      };
+      await requestSW('UPDATE_CONFIG', {
+        ai: nextConfig.ai,
+        assistant: nextConfig.assistant,
+        dynamicBill: nextConfig.dynamicBill,
+      });
+      applyConfig(nextConfig);
+      setNotice('设置已保存。后续 AI 功能会从这里读取同一套服务配置和开关。');
+    } catch (err) {
+      setError(formatSettingsError(err));
+    } finally {
+      setBusy('');
+    }
+  }
+
+  async function testConnection() {
+    setBusy('test');
+    setError('');
+    setNotice('');
+    setLastTest(null);
+    try {
+      await ensureAiHostPermission(effectiveAiConfig.baseURL);
+      const result = await requestSW<AiConnectionTestResult>('TEST_AI_CONNECTION', {
+        ai: effectiveAiConfig,
+      });
+      setLastTest(result);
+      setNotice(`连接测试通过：模型 ${result.model} 已响应，用时 ${result.latencyMs} 毫秒。`);
+    } catch (err) {
+      setError(formatConnectionError(err));
+    } finally {
+      setBusy('');
+    }
+  }
+
+  function applyConfig(config: UserConfig) {
+    setLoadedConfig(config);
+    setForm({
+      baseURL: config.ai.baseURL,
+      chatModel: config.ai.chatModel,
+      apiKeyInput: '',
+    });
+    setSavedApiKey(config.ai.apiKey);
+    setAssistant(config.assistant);
+    setDynamicBill(config.dynamicBill);
+  }
+
+  if (loading) {
+    return (
+      <div className="settings-page">
+        <section className="settings-panel settings-panel-muted">正在读取设置...</section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-page">
+      <header className="settings-hero">
+        <div>
+          <span className="settings-kicker">全局配置</span>
+          <h2>设置</h2>
+          <p>
+            在这里统一管理 AI 服务、功能开关和隐私边界。当前视频、智能收藏和动态账单会共用这套配置；未启用或未配置时继续展示本地证据结果。
+          </p>
+        </div>
+        <div className="settings-save-state">
+          <strong>{hasPendingChanges ? '有未保存更改' : '设置已同步'}</strong>
+          <span>{hasSavedApiKey ? 'API Key 已保存在本地，不会在输入框中回显完整值。' : '尚未保存 API Key。'}</span>
+        </div>
+      </header>
+
+      {error && <div className="settings-alert settings-alert-error">{error}</div>}
+      {notice && <div className="settings-alert settings-alert-success">{notice}</div>}
+
+      <section className="settings-panel">
+        <div className="settings-section-head">
+          <div>
+            <h3>AI 服务</h3>
+            <p>支持 OpenAI 兼容服务。测试连接只发送一条最小健康检查消息，不包含本地历史、收藏、关注或反馈记录。</p>
+          </div>
+          <span className={hasSavedApiKey ? 'settings-pill settings-pill-ok' : 'settings-pill'}>
+            {hasSavedApiKey ? 'Key 已保存' : 'Key 未保存'}
+          </span>
+        </div>
+
+        <div className="settings-form-grid">
+          <label className="settings-field">
+            <span>服务地址</span>
+            <input
+              value={form.baseURL}
+              onInput={(event) => setForm({ ...form, baseURL: event.currentTarget.value })}
+              placeholder="https://api.deepseek.com"
+              autoComplete="off"
+            />
+          </label>
+          <label className="settings-field">
+            <span>模型名</span>
+            <input
+              value={form.chatModel}
+              onInput={(event) => setForm({ ...form, chatModel: event.currentTarget.value })}
+              placeholder="deepseek-v4-flash"
+              autoComplete="off"
+            />
+          </label>
+          <label className="settings-field settings-field-wide">
+            <span>API Key</span>
+            <input
+              value={form.apiKeyInput}
+              onInput={(event) => setForm({ ...form, apiKeyInput: event.currentTarget.value })}
+              placeholder={hasSavedApiKey ? '留空则沿用已保存在本地的 Key' : '输入服务提供方的 API Key'}
+              type="password"
+              autoComplete="new-password"
+            />
+            <small>
+              {form.apiKeyInput.trim()
+                ? '保存后会替换本地已保存的 Key。'
+                : hasSavedApiKey
+                  ? '完整 Key 不会重复展示；需要更换时直接输入新 Key 后保存。'
+                  : 'Key 只写入本地浏览器扩展存储。'}
+            </small>
+          </label>
+        </div>
+
+        <div className="settings-actions">
+          <button type="button" className="settings-action" onClick={testConnection} disabled={!!busy}>
+            {busy === 'test' ? '测试中...' : '测试连接'}
+          </button>
+          <button type="button" className="settings-action settings-action-primary" onClick={saveSettings} disabled={!!busy}>
+            {busy === 'save' ? '保存中...' : '保存设置'}
+          </button>
+          {lastTest && (
+            <span className="settings-action-note">
+              最近测试：{new Date(lastTest.checkedAt).toLocaleString('zh-CN')}，{lastTest.latencyMs} 毫秒
+            </span>
+          )}
+        </div>
+      </section>
+
+      <section className="settings-panel">
+        <div className="settings-section-head">
+          <div>
+            <h3>AI 功能开关</h3>
+            <p>关闭某个功能后，对应页面继续使用本地证据结果，不会把关闭状态当作错误。</p>
+          </div>
+        </div>
+
+        <div className="settings-toggle-grid">
+          <FeatureToggle
+            title="当前视频摘要"
+            detail="允许当前视频助手在有边界的元数据、简介或字幕证据上整理摘要。"
+            checked={assistant.aiSummariesEnabled}
+            onChange={(checked) => setAssistant({ ...assistant, aiSummariesEnabled: checked })}
+          />
+          <FeatureToggle
+            title="当前视频片段排序辅助"
+            detail="允许 AI 只在已检索出的本地候选片段中调整展示顺序和解释。"
+            checked={assistant.currentVideoSegmentRerankAiEnabled}
+            onChange={(checked) => setAssistant({ ...assistant, currentVideoSegmentRerankAiEnabled: checked })}
+          />
+          <FeatureToggle
+            title="智能收藏问答"
+            detail="允许 AI 基于已同步收藏的前置引用视频整理综合回答。"
+            checked={assistant.smartFavoritesQaAiEnabled}
+            onChange={(checked) => setAssistant({ ...assistant, smartFavoritesQaAiEnabled: checked })}
+          />
+          <FeatureToggle
+            title="动态账单解释"
+            detail="允许 AI 为已入选的账单项生成解释；入选、排序和状态推进仍由本地规则决定。"
+            checked={dynamicBill.aiExplanationsEnabled}
+            onChange={(checked) => setDynamicBill({ ...dynamicBill, aiExplanationsEnabled: checked })}
+          />
+        </div>
+      </section>
+
+      <section className="settings-panel">
+        <div className="settings-section-head">
+          <div>
+            <h3>隐私边界</h3>
+            <p>这里记录 Bili-Bill 的本地数据和 AI 请求边界，后续本地数据管理会在单独切片接入。</p>
+          </div>
+        </div>
+        <ul className="settings-privacy-list">
+          <li>API Key 只保存在本地浏览器扩展存储中，不会提交到 Bili-Bill 服务端。</li>
+          <li>AI 请求只发送当前功能需要的最小证据片段，不上传完整观看历史、完整收藏、完整关注或反馈记录。</li>
+          <li>Bili-Bill 不读取 Cookie 文件、浏览器用户资料目录、Bilibili 登录态文件或本地密钥文件。</li>
+          <li>动态账单、收藏和当前视频功能不会写回 B 站关注关系、收藏夹或视频数据。</li>
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+function FeatureToggle({
+  title,
+  detail,
+  checked,
+  onChange,
+}: {
+  title: string;
+  detail: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className="settings-toggle">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.currentTarget.checked)}
+      />
+      <span className="settings-toggle-control" aria-hidden="true" />
+      <span className="settings-toggle-copy">
+        <strong>{title}</strong>
+        <small>{detail}</small>
+      </span>
+    </label>
+  );
+}
+
+async function ensureAiHostPermission(baseURL: string): Promise<void> {
+  const pattern = getOriginPattern(baseURL);
+  const granted = await new Promise<boolean>(resolve => {
+    chrome.permissions.contains({ origins: [pattern] }, resolve);
+  });
+  if (granted) return;
+
+  const approved = await new Promise<boolean>(resolve => {
+    chrome.permissions.request({ origins: [pattern] }, resolve);
+  });
+  if (!approved) {
+    throw new Error('AI_PERMISSION_DENIED');
+  }
+}
+
+function getOriginPattern(baseURL: string): string {
+  let url: URL;
+  try {
+    url = new URL(baseURL.trim());
+  } catch {
+    throw new Error('AI_BASE_URL_INVALID');
+  }
+  if (!['https:', 'http:'].includes(url.protocol)) {
+    throw new Error('AI_BASE_URL_UNSUPPORTED');
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  if (url.protocol === 'http:' && !isLocalHttpHost(hostname)) {
+    throw new Error('AI_HTTP_HOST_UNSUPPORTED');
+  }
+
+  return `${url.protocol}//${hostname}/*`;
+}
+
+function isLocalHttpHost(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1';
+}
+
+function formatSettingsError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message === 'AI_BASE_URL_INVALID') return 'AI 服务地址格式不正确。';
+  if (message === 'AI_BASE_URL_UNSUPPORTED') return 'AI 服务地址只支持 http 或 https。';
+  if (message === 'AI_HTTP_HOST_UNSUPPORTED') return 'HTTP 服务地址仅限本机调试地址。';
+  if (message === 'AI_PERMISSION_DENIED') return '没有获得该 AI 服务地址的访问权限，设置尚未保存。';
+  return '设置保存失败，请检查服务地址、模型名和浏览器授权后重试。';
+}
+
+function formatConnectionError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message === 'AI_BASE_URL_INVALID' || message === 'AI_BASE_URL_MISSING') return '请填写有效的 AI 服务地址。';
+  if (message === 'AI_MODEL_MISSING') return '请填写模型名后再测试连接。';
+  if (message === 'AI_API_KEY_MISSING') return '请先输入 API Key，或保存并沿用本地已有 Key。';
+  if (message === 'AI_BASE_URL_UNSUPPORTED') return 'AI 服务地址只支持 http 或 https。';
+  if (message === 'AI_HTTP_HOST_UNSUPPORTED') return 'HTTP 服务地址仅限本机调试地址。';
+  if (message === 'AI_PERMISSION_DENIED') return '没有获得该 AI 服务地址的访问权限，无法测试连接。';
+  if (message === 'AI_REQUEST_TIMEOUT') return '连接测试超时，请稍后重试或检查服务地址。';
+  if (message.startsWith('AI_REQUEST_FAILED_')) return 'AI 服务拒绝了本次测试，请检查服务地址、模型名和 API Key。';
+  if (message === 'AI_RESPONSE_INVALID_JSON') return '服务已有响应，但返回格式无法确认，请检查模型是否支持兼容接口。';
+  return '连接测试失败，请检查服务地址、模型名和 API Key。';
+}

--- a/dashboard/styles/dashboard.css
+++ b/dashboard/styles/dashboard.css
@@ -257,6 +257,276 @@ button {
   box-shadow: 0 18px 38px rgba(25, 34, 50, 0.12);
 }
 
+.settings-page {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+}
+
+.settings-hero,
+.settings-panel {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-card);
+}
+
+.settings-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 320px);
+  gap: 18px;
+  align-items: start;
+  padding: 18px;
+}
+
+.settings-kicker {
+  display: block;
+  margin-bottom: 6px;
+  color: #7FD1FF;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.settings-hero h2 {
+  margin: 0;
+  color: #FFFFFF;
+  font-size: 28px;
+  line-height: 1.15;
+}
+
+.settings-hero p,
+.settings-section-head p,
+.settings-save-state span,
+.settings-field small,
+.settings-action-note,
+.settings-toggle-copy small,
+.settings-privacy-list {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.settings-hero p {
+  max-width: 760px;
+  margin: 8px 0 0;
+}
+
+.settings-save-state {
+  display: grid;
+  gap: 6px;
+  padding: 12px;
+  border: 1px solid rgba(127, 209, 255, 0.22);
+  border-radius: 8px;
+  background: rgba(0, 161, 214, 0.08);
+}
+
+.settings-save-state strong {
+  color: #FFFFFF;
+  font-size: 14px;
+}
+
+.settings-alert {
+  padding: 11px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.settings-alert-error {
+  border: 1px solid rgba(255, 107, 107, 0.34);
+  color: #FFD0D0;
+  background: rgba(255, 107, 107, 0.12);
+}
+
+.settings-alert-success {
+  border: 1px solid rgba(20, 184, 166, 0.34);
+  color: #C7FFF5;
+  background: rgba(20, 184, 166, 0.12);
+}
+
+.settings-panel {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+}
+
+.settings-panel-muted {
+  color: var(--text-secondary);
+}
+
+.settings-section-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.settings-section-head h3 {
+  margin: 0;
+  color: #FFFFFF;
+  font-size: 17px;
+}
+
+.settings-section-head p {
+  max-width: 780px;
+  margin: 5px 0 0;
+}
+
+.settings-pill {
+  flex: 0 0 auto;
+  padding: 5px 9px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  color: #C8C8D8;
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.settings-pill-ok {
+  border-color: rgba(20, 184, 166, 0.32);
+  color: #A8FFF0;
+  background: rgba(20, 184, 166, 0.12);
+}
+
+.settings-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.settings-field {
+  display: grid;
+  gap: 6px;
+}
+
+.settings-field-wide {
+  grid-column: 1 / -1;
+}
+
+.settings-field span {
+  color: #FFFFFF;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.settings-field input {
+  width: 100%;
+  min-height: 38px;
+  padding: 8px 10px;
+  border: 1px solid #3B3B62;
+  border-radius: 7px;
+  color: #FFFFFF;
+  background: #18182B;
+  outline: none;
+}
+
+.settings-field input:focus {
+  border-color: rgba(0, 161, 214, 0.8);
+  box-shadow: 0 0 0 3px rgba(0, 161, 214, 0.16);
+}
+
+.settings-actions {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex-wrap: wrap;
+}
+
+.settings-action {
+  min-height: 36px;
+  padding: 0 12px;
+  border: 1px solid #3B3B62;
+  border-radius: 7px;
+  color: #D8D8E8;
+  background: #1A1A2E;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 750;
+}
+
+.settings-action-primary {
+  border-color: rgba(251, 114, 153, 0.5);
+  color: #FFFFFF;
+  background: var(--bili-pink);
+}
+
+.settings-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
+.settings-toggle-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.settings-toggle {
+  position: relative;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  min-height: 74px;
+  padding: 12px;
+  border: 1px solid #333355;
+  border-radius: 8px;
+  background: #1A1A2E;
+  cursor: pointer;
+}
+
+.settings-toggle input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.settings-toggle-control {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  border-radius: 999px;
+  background: #3A3A56;
+  transition: background 160ms ease;
+}
+
+.settings-toggle-control::after {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #FFFFFF;
+  content: "";
+  transition: transform 160ms ease;
+}
+
+.settings-toggle input:checked + .settings-toggle-control {
+  background: var(--bb-mint);
+}
+
+.settings-toggle input:checked + .settings-toggle-control::after {
+  transform: translateX(18px);
+}
+
+.settings-toggle-copy {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.settings-toggle-copy strong {
+  color: #FFFFFF;
+  font-size: 13px;
+}
+
+.settings-privacy-list {
+  display: grid;
+  gap: 8px;
+  padding-left: 18px;
+}
+
 .dynamic-bill-page {
   display: grid;
   gap: 14px;
@@ -1234,7 +1504,8 @@ button {
 
   .dynamic-bill-status-grid,
   .dynamic-bill-board,
-  .creator-follow-board {
+  .creator-follow-board,
+  .settings-toggle-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -1313,6 +1584,16 @@ button {
     display: grid;
   }
 
+  .settings-hero,
+  .settings-form-grid,
+  .settings-toggle-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-section-head {
+    display: grid;
+  }
+
   .dynamic-bill-scope {
     min-width: 0;
   }
@@ -1326,7 +1607,8 @@ button {
   .dynamic-bill-status-grid,
   .dynamic-bill-board,
   .creator-follow-board,
-  .creator-secondary-grid {
+  .creator-secondary-grid,
+  .settings-toggle-grid {
     grid-template-columns: 1fr;
   }
 

--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -177,6 +177,10 @@ export function App() {
     setCurrentVideoSummary(cancelledCurrentVideoSummary(currentVideoContext));
   }
 
+  function openSettings() {
+    chrome.tabs.create({ url: chrome.runtime.getURL('dashboard/index.html#settings') });
+  }
+
   async function fetchStats(forceSync = true) {
     loading.value = quickStats.value === null;
     error.value = null;
@@ -382,6 +386,7 @@ export function App() {
         onRefreshKnowledge={fetchVideoKnowledge}
         onPreviewNode={setJumpPreviewNodeId}
         onConfirmJump={confirmVideoKnowledgeJump}
+        onOpenSettings={openSettings}
       />
 
       {loading.value && (
@@ -566,6 +571,7 @@ function CurrentVideoAssistantStatus({
   onRefreshKnowledge,
   onPreviewNode,
   onConfirmJump,
+  onOpenSettings,
 }: {
   context: CurrentVideoContextResult | null;
   summary: CurrentVideoSummaryResult | null;
@@ -581,6 +587,7 @@ function CurrentVideoAssistantStatus({
   onRefreshKnowledge: () => void;
   onPreviewNode: (nodeId: string | null) => void;
   onConfirmJump: (node: VideoKnowledgeNode) => void;
+  onOpenSettings: () => void;
 }) {
   const isVideo = context?.kind === 'video';
   const previewNode = knowledge?.nodes.find(node => node.id === previewNodeId) ?? null;
@@ -797,6 +804,9 @@ function CurrentVideoAssistantStatus({
               <div style={{ color: '#9090A0', fontSize: '10px', lineHeight: 1.45, marginTop: '4px' }}>
                 AI 状态：{aiStatusLabel(summary.ai.status)}。{summary.ai.note}
               </div>
+              {needsAiSettingsLink(summary.ai.status) && (
+                <SettingsInlineButton onClick={onOpenSettings} />
+              )}
             </div>
           )}
           <div style={{
@@ -831,6 +841,7 @@ function CurrentVideoAssistantStatus({
             onPreviewCandidate={setSegmentPreviewCandidateId}
             onConfirmJump={confirmSegmentJump}
             onReturn={returnSegmentJump}
+            onOpenSettings={onOpenSettings}
           />
           <div style={{ display: 'flex', gap: '6px', marginTop: '8px' }}>
             <button
@@ -899,6 +910,7 @@ function CurrentVideoSegmentRetrievalPanel({
   onPreviewCandidate,
   onConfirmJump,
   onReturn,
+  onOpenSettings,
 }: {
   subtitleDiagnostics: CurrentVideoSubtitleDiagnostics;
   query: string;
@@ -913,6 +925,7 @@ function CurrentVideoSegmentRetrievalPanel({
   onPreviewCandidate: (candidateId: string | null) => void;
   onConfirmJump: (candidate: CurrentVideoSegmentRetrievalCandidate) => void;
   onReturn: () => void;
+  onOpenSettings: () => void;
 }) {
   const previewCandidate = result?.candidates.find(candidate => candidate.id === previewCandidateId) ?? null;
   const aiExplanations = new Map(
@@ -987,6 +1000,9 @@ function CurrentVideoSegmentRetrievalPanel({
           <div style={{ color: segmentAiRerankColor(result.aiRerank.status), fontSize: '10px', lineHeight: 1.45, marginTop: '4px' }}>
             AI 重排：{segmentAiRerankStatusLabel(result.aiRerank.status)}。{result.aiRerank.note}
           </div>
+          {needsAiSettingsLink(result.aiRerank.status) && (
+            <SettingsInlineButton onClick={onOpenSettings} />
+          )}
           {result.candidates.length === 0 ? (
             <div style={{ color: '#A0A0B0', fontSize: '10px', lineHeight: 1.45, marginTop: '5px' }}>
               {result.limitations[0]}
@@ -1483,6 +1499,31 @@ function segmentAiRerankColor(status: CurrentVideoSegmentRetrievalResult['aiRera
   if (status === 'generated') return '#A0E7A0';
   if (status === 'disabled' || status === 'not_requested') return '#A0A0B0';
   return '#FFCF8A';
+}
+
+function SettingsInlineButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        marginTop: '6px',
+        background: 'rgba(0, 161, 214, 0.18)',
+        color: '#C8E6FF',
+        border: '1px solid rgba(127, 219, 255, 0.32)',
+        borderRadius: '6px',
+        cursor: 'pointer',
+        fontSize: '10px',
+        padding: '4px 7px',
+      }}
+    >
+      前往设置
+    </button>
+  );
+}
+
+function needsAiSettingsLink(status: string): boolean {
+  return status === 'disabled' || status === 'not_configured';
 }
 
 function formatNodeTimeRange(node: VideoKnowledgeNode): string {

--- a/src/background/ai/openai-compatible.ts
+++ b/src/background/ai/openai-compatible.ts
@@ -1,4 +1,4 @@
-import type { AiConfig } from '../../shared/types/config.ts';
+import type { AiConfig, AiConnectionTestResult } from '../../shared/types/config.ts';
 
 interface ChatMessage {
   role: 'system' | 'user';
@@ -23,7 +23,7 @@ export async function chatJson<T>(
     throw new Error('AI_API_KEY_MISSING');
   }
 
-  const endpoint = `${config.baseURL.replace(/\/+$/, '')}/chat/completions`;
+  const endpoint = `${config.baseURL.trim().replace(/\/+$/, '')}/chat/completions`;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), AI_REQUEST_TIMEOUT_MS);
   let response: Response;
@@ -59,6 +59,34 @@ export async function chatJson<T>(
   const json: ChatResponse = await response.json();
   const content = json.choices?.[0]?.message?.content ?? '';
   return parseJsonContent<T>(content);
+}
+
+export async function testAiConnection(config: AiConfig): Promise<AiConnectionTestResult> {
+  const baseURL = config.baseURL.trim();
+  const chatModel = config.chatModel.trim();
+  const apiKey = config.apiKey.trim();
+  if (!baseURL) throw new Error('AI_BASE_URL_MISSING');
+  if (!chatModel) throw new Error('AI_MODEL_MISSING');
+  if (!apiKey) throw new Error('AI_API_KEY_MISSING');
+
+  const startedAt = Date.now();
+  await chatJson<{ ok?: unknown }>({ baseURL, chatModel, apiKey }, [
+    {
+      role: 'system',
+      content: 'Return JSON only. The response schema is {"ok": true}.',
+    },
+    {
+      role: 'user',
+      content: '请返回 {"ok": true}，不要包含其他字段。',
+    },
+  ]);
+
+  return {
+    ok: true,
+    model: chatModel,
+    checkedAt: Date.now(),
+    latencyMs: Date.now() - startedAt,
+  };
 }
 
 function parseJsonContent<T>(content: string): T {

--- a/src/background/current-video-summary.ts
+++ b/src/background/current-video-summary.ts
@@ -34,7 +34,7 @@ export async function generateCurrentVideoSummary(
   const local = buildLocalCurrentVideoSummary(context, {
     aiStatus: 'disabled',
     aiModel: config.ai.chatModel,
-    aiNote: 'AI 摘要未启用，当前显示本地证据结果。',
+    aiNote: 'AI 摘要未在设置中启用，当前显示本地证据结果。',
     transcriptSegments: options.transcriptSegments,
     now,
   });
@@ -57,7 +57,7 @@ export async function generateCurrentVideoSummary(
     return buildLocalCurrentVideoSummary(context, {
       aiStatus: 'not_configured',
       aiModel: config.ai.chatModel,
-      aiNote: 'AI 摘要已启用但没有配置 API Key，当前显示本地证据结果。',
+      aiNote: 'AI 摘要已启用但尚未在设置中配置 API Key，当前显示本地证据结果。',
       transcriptSegments: options.transcriptSegments,
       now,
     });

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -84,6 +84,7 @@ import {
   getCurrentVideoTranscriptEvidenceState,
   getCurrentVideoTranscriptSegments,
 } from '../storage/current-video-transcript-repo';
+import { testAiConnection } from '../ai/openai-compatible';
 
 const EXPORT_PAGE_LIMIT_MAX = 1000;
 const SUBTITLE_PROBE_CACHE_MS = 5 * 60 * 1000;
@@ -312,6 +313,8 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
         }) as T,
       };
     }
+    case 'TEST_AI_CONNECTION':
+      return { success: true, data: await testAiConnection(normalizeAiConfigParam(request.params?.ai)) as T };
     case 'GET_CURRENT_VIDEO_CONTEXT':
       return { success: true, data: await getCurrentVideoContextForActiveTab(currentVideoLookupOptions(request.params)) as T };
     case 'PROBE_CURRENT_VIDEO_SUBTITLE_SOURCE':
@@ -834,6 +837,18 @@ function normalizeDynamicBillFeedbackScope(value: unknown): DynamicBillFeedbackS
 function requireStringParam(value: unknown, name: string): string {
   if (typeof value === 'string' && value.trim()) return value;
   throw new Error(`MISSING_${name.toUpperCase()}`);
+}
+
+function normalizeAiConfigParam(value: unknown): UserConfig['ai'] {
+  if (!value || typeof value !== 'object') {
+    throw new Error('MISSING_AI_CONFIG');
+  }
+  const raw = value as Record<string, unknown>;
+  return {
+    baseURL: typeof raw.baseURL === 'string' ? raw.baseURL.trim() : '',
+    apiKey: typeof raw.apiKey === 'string' ? raw.apiKey : '',
+    chatModel: typeof raw.chatModel === 'string' ? raw.chatModel.trim() : '',
+  };
 }
 
 function videoUrl(bvid: string): string {

--- a/src/content/player-monitor/assistant-status.ts
+++ b/src/content/player-monitor/assistant-status.ts
@@ -805,6 +805,16 @@ function appendSegmentRetrievalResult(
   );
   status.style.color = segmentRetrievalStatusColor(result);
 
+  if (needsAiSettingsLink(result.aiRerank.status)) {
+    appendText(
+      parent,
+      'div',
+      'bdc-assistant-subtitle-detail',
+      safeVisibleText(`AI 排序：${result.aiRerank.note}`),
+    );
+    parent.appendChild(dashboardLink('前往设置', '#settings'));
+  }
+
   const meta = document.createElement('div');
   meta.className = 'bdc-assistant-candidate-meta';
   appendBadge(meta, result.evidenceState.transcriptSegmentCount > 0
@@ -1075,6 +1085,11 @@ function appendSummary(parent: HTMLElement): void {
       'bdc-assistant-subtitle-detail',
       summary.limitations.slice(0, 2).map(safeVisibleText).join(' '),
     );
+  }
+
+  if (needsAiSettingsLink(summary.ai.status)) {
+    appendText(block, 'div', 'bdc-assistant-subtitle-detail', safeVisibleText(summary.ai.note));
+    block.appendChild(dashboardLink('前往设置', '#settings'));
   }
 
   parent.appendChild(block);
@@ -1468,14 +1483,18 @@ function button(
   return element;
 }
 
-function dashboardLink(text: string): HTMLAnchorElement {
+function dashboardLink(text: string, hash = ''): HTMLAnchorElement {
   const link = document.createElement('a');
   link.className = 'bdc-assistant-link';
-  link.href = chrome.runtime.getURL('dashboard/index.html');
+  link.href = chrome.runtime.getURL(`dashboard/index.html${hash}`);
   link.target = '_blank';
   link.rel = 'noopener noreferrer';
   link.textContent = text;
   return link;
+}
+
+function needsAiSettingsLink(status: string): boolean {
+  return status === 'disabled' || status === 'not_configured';
 }
 
 function appendRow(parent: HTMLElement, label: string, value: string): void {

--- a/src/shared/current-video-segment-rerank.ts
+++ b/src/shared/current-video-segment-rerank.ts
@@ -142,7 +142,7 @@ export async function rerankCurrentVideoSegmentCandidates(
     return withAiRerank(local, aiState({
       status: 'disabled',
       model,
-      note: 'AI 重排未启用，当前显示本地候选顺序。',
+      note: 'AI 重排未在设置中启用，当前显示本地候选顺序。',
       now,
     }));
   }
@@ -151,7 +151,7 @@ export async function rerankCurrentVideoSegmentCandidates(
     return withAiRerank(local, aiState({
       status: 'not_configured',
       model,
-      note: 'AI 重排已启用但没有配置 API Key，当前显示本地候选顺序。',
+      note: 'AI 重排已启用但尚未在设置中配置 API Key，当前显示本地候选顺序。',
       now,
     }));
   }

--- a/src/shared/current-video-summary.ts
+++ b/src/shared/current-video-summary.ts
@@ -849,9 +849,9 @@ function languageKey(value: string | null | undefined): string {
 function localAiNote(status?: CurrentVideoSummaryAiStatus): string {
   switch (status) {
     case 'disabled':
-      return 'AI 摘要未启用，因此当前显示本地证据结果。';
+      return 'AI 摘要未在设置中启用，因此当前显示本地证据结果。';
     case 'not_configured':
-      return 'AI 摘要已启用但没有配置 API Key，因此当前显示本地证据结果。';
+      return 'AI 摘要已启用但尚未在设置中配置 API Key，因此当前显示本地证据结果。';
     case 'failed':
       return 'AI 生成失败，当前显示本地证据结果。';
     case 'low_confidence':

--- a/src/shared/types/config.ts
+++ b/src/shared/types/config.ts
@@ -17,6 +17,13 @@ export interface AiConfig {
   chatModel: string;
 }
 
+export interface AiConnectionTestResult {
+  ok: true;
+  model: string;
+  checkedAt: number;
+  latencyMs: number;
+}
+
 export interface AssistantConfig {
   aiSummariesEnabled: boolean;
   smartFavoritesQaAiEnabled: boolean;

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -38,6 +38,7 @@ import type { CurrentVideoSummaryResult } from './current-video-summary';
 import type { VideoKnowledgeJumpResponse, VideoKnowledgeResult } from './video-knowledge';
 import type { HistoryTailProbeReport } from './history-tail-probe';
 import type { HistorySyncCursorSnapshot, HistorySyncMode } from './history-sync';
+import type { AiConnectionTestResult } from './config';
 
 // 弹窗 / 面板 → Service Worker
 export type RequestAction =
@@ -52,6 +53,7 @@ export type RequestAction =
   | 'CANCEL_SYNC'
   | 'GET_CONFIG'
   | 'UPDATE_CONFIG'
+  | 'TEST_AI_CONNECTION'
   | 'EXPORT_DATA'
   | 'EXPORT_DATA_PAGE'
   | 'GET_SYNC_STATUS'
@@ -198,3 +200,4 @@ export type DynamicBillItemResponse = BiliVizResponse<DynamicBillItem | null>;
 export type DynamicBillFilterResponse = BiliVizResponse<DynamicBillFilterPreference>;
 export type DynamicBillFeedbackResponse = BiliVizResponse<DynamicBillFeedbackResult>;
 export type HistoryTailProbeResponse = BiliVizResponse<HistoryTailProbeReport>;
+export type AiConnectionTestResponse = BiliVizResponse<AiConnectionTestResult>;

--- a/tests/ai-connection.test.ts
+++ b/tests/ai-connection.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { testAiConnection } from '../src/background/ai/openai-compatible.ts';
+
+test('AI connection test sends only a minimal health-check payload', async (t) => {
+  const originalFetch = globalThis.fetch;
+  let requestBody = '';
+  globalThis.fetch = (async (input, init) => {
+    assert.equal(String(input), 'https://api.test/chat/completions');
+    assert.equal((init?.headers as Record<string, string>).Authorization, 'Bearer test-key');
+    requestBody = String(init?.body ?? '');
+    return new Response(JSON.stringify({
+      choices: [{ message: { content: '{"ok":true}' } }],
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const result = await testAiConnection({
+    baseURL: 'https://api.test/',
+    apiKey: 'test-key',
+    chatModel: 'test-model',
+  });
+
+  const payload = JSON.parse(requestBody);
+  const rawPayload = JSON.stringify(payload);
+  assert.equal(result.ok, true);
+  assert.equal(result.model, 'test-model');
+  assert.equal(payload.model, 'test-model');
+  assert.equal(payload.messages.length, 2);
+  assert.doesNotMatch(rawPayload, /watchHistory|favorites|following|feedback|Cookie|Key\.txt|Chrome\\User Data/i);
+});
+
+test('AI connection test requires an API key before network access', async (t) => {
+  const originalFetch = globalThis.fetch;
+  let called = false;
+  globalThis.fetch = (async () => {
+    called = true;
+    throw new Error('fetch should not run');
+  }) as typeof fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  await assert.rejects(
+    () => testAiConnection({
+      baseURL: 'https://api.test',
+      apiKey: '',
+      chatModel: 'test-model',
+    }),
+    /AI_API_KEY_MISSING/,
+  );
+  assert.equal(called, false);
+});

--- a/tests/settings-mvp.mock.html
+++ b/tests/settings-mvp.mock.html
@@ -1,0 +1,230 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Bili-Bill 设置页 MVP Mock</title>
+  <style>
+    :root {
+      --pink: #fb7299;
+      --blue: #00a1d6;
+      --mint: #14b8a6;
+      --bg: #f5f7fb;
+      --panel: #222244;
+      --border: #333355;
+      --muted: #a0a0b0;
+      --ink: #202633;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", Arial, sans-serif;
+    }
+    .app {
+      display: grid;
+      grid-template-columns: 220px minmax(0, 1fr);
+      min-height: 100vh;
+    }
+    .nav {
+      padding: 18px;
+      border-right: 1px solid #dde4ee;
+      background: #fff;
+    }
+    .nav button {
+      display: block;
+      width: 100%;
+      margin-bottom: 8px;
+      padding: 10px;
+      border: 1px solid #dde4ee;
+      border-radius: 8px;
+      background: #fff;
+      color: #344054;
+      cursor: pointer;
+      font-weight: 700;
+      text-align: left;
+    }
+    .nav button.active {
+      border-color: var(--pink);
+      background: #fde7ef;
+      color: #111827;
+    }
+    .page {
+      padding: 22px;
+    }
+    .hidden {
+      display: none;
+    }
+    .panel {
+      margin-bottom: 12px;
+      padding: 16px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--panel);
+      color: #fff;
+    }
+    .panel h1,
+    .panel h2 {
+      margin: 0 0 8px;
+      line-height: 1.2;
+    }
+    .muted {
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.6;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px;
+    }
+    .field {
+      display: grid;
+      gap: 6px;
+      color: #fff;
+      font-size: 12px;
+      font-weight: 700;
+    }
+    .field input {
+      min-height: 38px;
+      padding: 9px 10px;
+      border: 1px solid #3b3b62;
+      border-radius: 7px;
+      background: #18182b;
+      color: #fff;
+    }
+    .wide {
+      grid-column: 1 / -1;
+    }
+    .actions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      margin-top: 12px;
+    }
+    .actions button,
+    .link-button {
+      min-height: 34px;
+      padding: 0 12px;
+      border: 1px solid rgba(0, 161, 214, 0.45);
+      border-radius: 7px;
+      background: var(--blue);
+      color: #fff;
+      cursor: pointer;
+      font-weight: 750;
+    }
+    .toggle {
+      display: flex;
+      gap: 8px;
+      align-items: flex-start;
+      margin-top: 8px;
+      padding: 10px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: #1a1a2e;
+      cursor: pointer;
+    }
+    .ok { color: #a8fff0; }
+    .warn { color: #ffcf8a; }
+    @media (max-width: 720px) {
+      .app { display: block; }
+      .grid { grid-template-columns: 1fr; }
+      .page { padding: 12px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <aside class="nav" aria-label="Bili-Bill 面板导航">
+      <button id="nav-overview" type="button">总览</button>
+      <button id="nav-smart" type="button">智能收藏</button>
+      <button id="nav-settings" class="active" type="button">设置</button>
+    </aside>
+    <main class="page">
+      <section id="settings-page">
+        <div class="panel">
+          <span class="muted">全局配置</span>
+          <h1>设置</h1>
+          <p class="muted">在这里统一管理 AI 服务、功能开关和隐私边界。当前视频、智能收藏和动态账单会共用这套配置；未启用或未配置时继续展示本地证据结果。</p>
+          <strong id="save-state">有未保存更改</strong>
+        </div>
+        <div class="panel">
+          <h2>AI 服务</h2>
+          <div class="grid">
+            <label class="field">服务地址<input id="base" value="https://api.deepseek.com" /></label>
+            <label class="field">模型名<input id="model" value="deepseek-v4-flash" /></label>
+            <label class="field wide">API Key<input id="key" type="password" placeholder="留空则沿用已保存在本地的 Key" /></label>
+          </div>
+          <div class="actions">
+            <button id="test" type="button">测试连接</button>
+            <button id="save" type="button">保存设置</button>
+            <span id="status" class="warn">Key 未保存</span>
+          </div>
+        </div>
+        <div class="panel">
+          <h2>AI 功能开关</h2>
+          <label class="toggle"><input id="current" type="checkbox" /> <span>当前视频摘要<br /><small class="muted">关闭后显示本地证据结果。</small></span></label>
+          <label class="toggle"><input id="smart" type="checkbox" /> <span>智能收藏问答<br /><small class="muted">关闭后显示本地引用结果。</small></span></label>
+          <label class="toggle"><input id="dynamic" type="checkbox" /> <span>动态账单解释<br /><small class="muted">关闭后写入本地证据说明。</small></span></label>
+        </div>
+        <div class="panel">
+          <h2>隐私边界</h2>
+          <p class="muted">API Key 只保存在本地浏览器扩展存储中，不上传完整观看历史、完整收藏、完整关注或反馈记录，不读取 Cookie 文件、浏览器用户资料目录、Bilibili 登录态文件或本地密钥文件。</p>
+        </div>
+      </section>
+      <section id="smart-page" class="hidden">
+        <div class="panel">
+          <h1>智能收藏</h1>
+          <p class="muted">AI 服务地址、模型名、API Key 和功能开关已迁移到全局设置。当前显示本地引用结果。</p>
+          <button id="smart-settings" class="link-button" type="button">前往设置</button>
+        </div>
+      </section>
+      <section id="prompts-page" class="hidden">
+        <div class="panel">
+          <h1>未配置提示</h1>
+          <p id="current-prompt" class="warn">当前视频 AI 摘要已启用但尚未在设置中配置 API Key，当前显示本地证据结果。</p>
+          <button id="current-settings" class="link-button" type="button">前往设置</button>
+          <p id="dynamic-prompt" class="warn">动态账单 AI 解释已启用但尚未在设置中配置 API Key，生成解释时会回退到本地证据说明。</p>
+          <button id="dynamic-settings" class="link-button" type="button">前往设置</button>
+        </div>
+      </section>
+    </main>
+  </div>
+  <script>
+    const pages = {
+      settings: document.getElementById('settings-page'),
+      smart: document.getElementById('smart-page'),
+      prompts: document.getElementById('prompts-page'),
+    };
+    function show(name) {
+      for (const [key, page] of Object.entries(pages)) {
+        page.classList.toggle('hidden', key !== name);
+      }
+      document.querySelectorAll('.nav button').forEach(button => button.classList.remove('active'));
+      if (name === 'settings') document.getElementById('nav-settings').classList.add('active');
+      if (name === 'smart') document.getElementById('nav-smart').classList.add('active');
+      if (name === 'prompts') document.getElementById('nav-overview').classList.add('active');
+      location.hash = name;
+    }
+    document.getElementById('nav-settings').addEventListener('click', () => show('settings'));
+    document.getElementById('nav-smart').addEventListener('click', () => show('smart'));
+    document.getElementById('nav-overview').addEventListener('click', () => show('prompts'));
+    document.getElementById('smart-settings').addEventListener('click', () => show('settings'));
+    document.getElementById('current-settings').addEventListener('click', () => show('settings'));
+    document.getElementById('dynamic-settings').addEventListener('click', () => show('settings'));
+    document.getElementById('test').addEventListener('click', () => {
+      const status = document.getElementById('status');
+      status.textContent = `连接测试通过：模型 ${document.getElementById('model').value} 已响应`;
+      status.className = 'ok';
+    });
+    document.getElementById('save').addEventListener('click', () => {
+      document.getElementById('save-state').textContent = '设置已保存';
+      document.getElementById('status').textContent = 'API Key 已保存在本地，不会在输入框中回显完整值。';
+      document.getElementById('status').className = 'ok';
+      document.getElementById('key').value = '';
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Scope
- Adds a Dashboard top-level Settings entry for AI service address, model name, API Key, saved-key state, connection test, and feature switches.
- Moves the full Smart Favorites AI config form into global settings; Smart Favorites now shows AI status and a Settings entry.
- Points Current Video, Smart Favorites, and Dynamic Bill AI unavailable states to Settings while preserving local-evidence fallback.
- Adds a minimal AI connection-test action plus focused unit and static mock QA coverage.

## Root Cause / Product Judgment
AI service config previously lived inside Smart Favorites, but the same AI boundary is now shared by Current Video and Dynamic Bill. Keeping configuration in a single feature makes the service look feature-specific and leaves privacy copy and feature switches without a global home. This PR centralizes only the MVP AI config and switches without changing AI request payload boundaries or adding local data management.

## Validation
- `node --test tests/ai-connection.test.ts tests/current-video-summary.test.ts tests/current-video-segment-rerank.test.ts tests/smart-favorites-qa.test.ts`
- `npm.cmd run typecheck`
- `npm.cmd run build` passes; Vite reports existing dynamic-import/chunk-size warnings.
- `git diff --check` passes; only Windows line-ending normalization warnings.
- `rg -n 未消费|猜你喜欢 dashboard popup public src README.md tests` returned no matches.
- User-visible raw/internal scan found only internal request constants/variable names and expected privacy/config copy, not ordinary UI raw fields.
- Browser/mock QA used `http://127.0.0.1:5173/tests/settings-mvp.mock.html`: Settings entry, save, connection test, toggles, Smart Favorites Settings entry, and AI unavailable prompts all passed.

## Blockers
none

## Must Fix
none

## Follow-up
#133 should add local data and privacy management as a separate settings slice, including explicit confirmations and scoped validation for local data actions. This PR intentionally does not add data deletion, index rebuild, cloud sync, provider profiles, OAuth, or remote storage.

## Privacy Boundary
No Cookie files, browser profile directories, Bilibili login-state files, local key files, or unrelated local database data were read. No writeback to Bilibili was added. API Key is not repeatedly shown in full after saving, and AI payload boundaries remain unchanged.

Closes #130