### PR TITLE
[codex] Add current-video query rewrite

### DIFF
--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -997,6 +997,11 @@ function CurrentVideoSegmentRetrievalPanel({
           <div style={{ color: retrievalStatusColor(result), fontSize: '10px', lineHeight: 1.45 }}>
             {retrievalStatusMessage(result)}
           </div>
+          {result.queryRewrite.expanded && result.queryRewrite.visibleExpandedTerms.length > 0 && (
+            <div style={{ color: '#C8E6FF', fontSize: '10px', lineHeight: 1.45, marginTop: '4px' }}>
+              已扩展相关表达：{result.queryRewrite.visibleExpandedTerms.slice(0, 6).join('、')}
+            </div>
+          )}
           <div style={{ color: segmentAiRerankColor(result.aiRerank.status), fontSize: '10px', lineHeight: 1.45, marginTop: '4px' }}>
             AI 重排：{segmentAiRerankStatusLabel(result.aiRerank.status)}。{result.aiRerank.note}
           </div>

--- a/src/content/player-monitor/assistant-status.ts
+++ b/src/content/player-monitor/assistant-status.ts
@@ -824,7 +824,19 @@ function appendSegmentRetrievalResult(
     appendBadge(meta, `本地节点 ${result.evidenceState.timedKnowledgeNodeCount} 条`);
   }
   appendBadge(meta, result.evidenceState.contextFresh ? '当前视频上下文有效' : '上下文需刷新');
+  if (result.queryRewrite.expanded) {
+    appendBadge(meta, '已扩展相关表达');
+  }
   parent.appendChild(meta);
+
+  if (result.queryRewrite.expanded && result.queryRewrite.visibleExpandedTerms.length > 0) {
+    appendText(
+      parent,
+      'div',
+      'bdc-assistant-muted',
+      safeVisibleText(`已扩展相关表达：${result.queryRewrite.visibleExpandedTerms.slice(0, 6).join('、')}`),
+    );
+  }
 
   appendSegmentJumpStatus(parent);
 

--- a/src/shared/current-video-segment-retrieval.ts
+++ b/src/shared/current-video-segment-retrieval.ts
@@ -4,6 +4,7 @@ import type {
   CurrentVideoSegmentRetrievalCandidate,
   CurrentVideoSegmentRetrievalCandidateSource,
   CurrentVideoSegmentRetrievalConfidenceLabel,
+  CurrentVideoQueryRewriteState,
   CurrentVideoSegmentRetrievalResult,
   CurrentVideoSegmentRetrievalStatus,
 } from './types/current-video-segment-retrieval';
@@ -18,6 +19,54 @@ const LOW_CONFIDENCE_THRESHOLD = 0.45;
 const MEDIUM_CONFIDENCE_THRESHOLD = 0.62;
 const HIGH_CONFIDENCE_THRESHOLD = 0.78;
 const EVIDENCE_TEXT_LIMIT = 220;
+
+const QUERY_SYNONYM_GROUPS = [
+  {
+    terms: [
+      'subagent',
+      'sub-agent',
+      'sub agent',
+      '子代理',
+      '子智能体',
+      '子 agent',
+      '子agent',
+      '多代理',
+      '多智能体',
+      'multi-agent',
+      'multi agent',
+      'multiagent',
+    ],
+  },
+  {
+    terms: [
+      'context window',
+      'context-window',
+      '上下文窗口',
+      '长上下文',
+      '1M context',
+      '1Mcontext',
+      '1M 上下文',
+      '100万上下文',
+      '100 万上下文',
+      '一百万上下文',
+      '一兆上下文',
+      '百万上下文',
+    ],
+  },
+  {
+    terms: [
+      'tool use',
+      'tool-use',
+      'tool calling',
+      'tool-calling',
+      '工具调用',
+      '工具使用',
+      '函数调用',
+      'function calling',
+      'function-calling',
+    ],
+  },
+] as const;
 
 const QUERY_HELPER_WORDS = [
   '那段',
@@ -64,9 +113,19 @@ interface QueryProfile {
   normalized: string;
   compact: string;
   meaningfulCompact: string;
+  rewrite: CurrentVideoQueryRewriteState;
   terms: string[];
   cjkTerms: string[];
   latinTerms: string[];
+  originalTerms: string[];
+  expandedTerms: string[];
+  semanticGroups: QuerySemanticGroup[];
+  termLabels: Map<string, string>;
+}
+
+interface QuerySemanticGroup {
+  terms: string[];
+  labels: string[];
 }
 
 interface ScoreResult {
@@ -374,19 +433,38 @@ function scoreText(profile: QueryProfile, text: string | null | undefined): Scor
 
   const compact = compactText(normalized);
   const matchedTerms = uniqueTerms(profile.terms.filter(term => compact.includes(term)));
-  const totalWeight = profile.terms.reduce((sum, term) => sum + termWeight(term), 0);
-  const matchedWeight = matchedTerms.reduce((sum, term) => sum + termWeight(term), 0);
-  const coverage = totalWeight > 0 ? matchedWeight / totalWeight : 0;
+  const totalWeight = profile.originalTerms.reduce((sum, term) => sum + termWeight(term), 0);
+  const matchedWeight = matchedTerms
+    .filter(term => profile.originalTerms.includes(term))
+    .reduce((sum, term) => sum + termWeight(term), 0);
+  const baseCoverage = totalWeight > 0 ? matchedWeight / totalWeight : 0;
+  const matchedSemanticGroups = profile.semanticGroups
+    .map(group => ({
+      group,
+      matchedTerms: uniqueTerms(group.terms.filter(term => compact.includes(term))),
+    }))
+    .filter(item => item.matchedTerms.length > 0);
+  const semanticCoverage = profile.semanticGroups.length > 0
+    ? matchedSemanticGroups.length / profile.semanticGroups.length
+    : 0;
+  const coverage = Math.max(baseCoverage, semanticCoverage);
   const exact = Boolean(profile.meaningfulCompact && compact.includes(profile.meaningfulCompact));
   const latinExact = profile.latinTerms.length > 0 && profile.latinTerms.every(term => compact.includes(term));
   const cjkCoverage = profile.cjkTerms.length > 0
     ? matchedTerms.filter(term => profile.cjkTerms.includes(term)).length / profile.cjkTerms.length
     : 0;
+  const matchedExpandedTerms = uniqueTerms(
+    matchedTerms.filter(term =>
+      profile.expandedTerms.includes(term)
+      && !profile.originalTerms.includes(term),
+    ),
+  );
 
   let score = coverage * 0.58;
   if (exact) score += 0.28;
   if (latinExact) score += 0.18;
   if (cjkCoverage >= 0.5) score += 0.14;
+  if (semanticCoverage > 0) score += Math.min(0.2, semanticCoverage * 0.18);
   if (matchedTerms.length >= 2) score += 0.06;
   if (matchedTerms.length === 1 && matchedTerms[0].length <= 2) score -= 0.03;
 
@@ -397,8 +475,11 @@ function scoreText(profile: QueryProfile, text: string | null | undefined): Scor
   if (latinExact && !exact) {
     reasons.push(`证据文本命中 ${profile.latinTerms.slice(0, 3).join('、')}`);
   }
+  if (matchedExpandedTerms.length > 0) {
+    reasons.push(`已扩展相关表达命中：${formatMatchedTerms(matchedExpandedTerms, profile).slice(0, 5).join('、')}`);
+  }
   if (matchedTerms.length > 0) {
-    reasons.push(`和问题词有重叠：${matchedTerms.slice(0, 5).join('、')}`);
+    reasons.push(`和查询相关表达有重叠：${formatMatchedTerms(matchedTerms, profile).slice(0, 5).join('、')}`);
   }
   if (cjkCoverage >= 0.5 && profile.cjkTerms.length > 0) {
     reasons.push('中文短语有连续重叠');
@@ -571,6 +652,7 @@ function result(input: {
     })),
     summary: input.summary,
     limitations: input.limitations,
+    queryRewrite: input.profile.rewrite,
     evidenceState: {
       transcriptSegmentCount: evidenceState.transcriptSegmentCount,
       timedKnowledgeNodeCount: evidenceState.timedKnowledgeNodeCount,
@@ -590,21 +672,42 @@ function result(input: {
   };
 }
 
+export function rewriteCurrentVideoSegmentQuery(query: string): CurrentVideoQueryRewriteState {
+  const originalQuery = normalizeText(query);
+  const normalizedQuery = normalizeSearchText(originalQuery);
+  const expansion = buildQueryExpansion(normalizedQuery);
+  return {
+    originalQuery,
+    normalizedQuery,
+    expanded: expansion.expandedTerms.length > 0,
+    expandedTerms: expansion.visibleExpandedTerms,
+    visibleExpandedTerms: expansion.visibleExpandedTerms,
+    reasons: expansion.reasons,
+    aiRewriteEnabled: false,
+  };
+}
+
 function buildQueryProfile(query: string): QueryProfile {
   const original = normalizeText(query);
   const normalized = normalizeSearchText(original);
   const compact = compactText(normalized);
   const meaningfulCompact = stripQueryHelpers(compact);
+  const expansion = buildQueryExpansion(normalized);
+  const rewrite = rewriteCurrentVideoSegmentQuery(query);
   const latinTerms = uniqueTerms(
     (normalized.match(/[a-z0-9]+(?:\.[a-z0-9]+)*/g) ?? [])
       .map(compactText)
       .filter(term => term.length >= 2),
   );
   const cjkTerms = buildCjkTerms(normalized);
-  const terms = uniqueTerms([
+  const originalTerms = uniqueTerms([
     meaningfulCompact.length >= 2 ? meaningfulCompact : '',
     ...latinTerms,
     ...cjkTerms,
+  ].filter(Boolean));
+  const terms = uniqueTerms([
+    ...originalTerms,
+    ...expansion.expandedTerms,
   ].filter(Boolean));
 
   return {
@@ -612,9 +715,81 @@ function buildQueryProfile(query: string): QueryProfile {
     normalized,
     compact,
     meaningfulCompact,
+    rewrite,
     terms,
     cjkTerms,
     latinTerms,
+    originalTerms,
+    expandedTerms: expansion.expandedTerms,
+    semanticGroups: expansion.semanticGroups,
+    termLabels: expansion.termLabels,
+  };
+}
+
+function buildQueryExpansion(normalizedQuery: string): {
+  expandedTerms: string[];
+  visibleExpandedTerms: string[];
+  reasons: string[];
+  semanticGroups: QuerySemanticGroup[];
+  termLabels: Map<string, string>;
+} {
+  const queryCompact = compactText(normalizedQuery);
+  const expandedTerms: string[] = [];
+  const visibleExpandedTerms: string[] = [];
+  const reasons: string[] = [];
+  const semanticGroups: QuerySemanticGroup[] = [];
+  const termLabels = new Map<string, string>();
+
+  if (!queryCompact) {
+    return {
+      expandedTerms,
+      visibleExpandedTerms,
+      reasons,
+      semanticGroups,
+      termLabels,
+    };
+  }
+
+  for (const group of QUERY_SYNONYM_GROUPS) {
+    const variants = group.terms
+      .map(term => ({
+        label: normalizeText(term),
+        compact: compactText(term),
+      }))
+      .filter(term => term.label && term.compact.length >= 2);
+    const matchesQuery = variants.some(term => queryCompact.includes(term.compact));
+    if (!matchesQuery) continue;
+
+    const groupTerms = uniqueTerms(variants.map(term => term.compact));
+    const groupLabels = uniqueTerms(variants.map(term => term.label));
+    semanticGroups.push({
+      terms: groupTerms,
+      labels: groupLabels,
+    });
+    expandedTerms.push(...groupTerms);
+
+    for (const term of variants) {
+      if (!termLabels.has(term.compact)) {
+        termLabels.set(term.compact, term.label);
+      }
+      if (!queryCompact.includes(term.compact)) {
+        visibleExpandedTerms.push(term.label);
+      }
+    }
+  }
+
+  const uniqueExpandedTerms = uniqueTerms(expandedTerms);
+  const uniqueVisibleExpandedTerms = uniqueTerms(visibleExpandedTerms).slice(0, 10);
+  if (uniqueExpandedTerms.length > 0) {
+    reasons.push('已使用本地词表扩展相关表达');
+  }
+
+  return {
+    expandedTerms: uniqueExpandedTerms,
+    visibleExpandedTerms: uniqueVisibleExpandedTerms,
+    reasons,
+    semanticGroups,
+    termLabels,
   };
 }
 
@@ -738,6 +913,10 @@ function formatDuration(seconds: number): string {
 function termWeight(term: string): number {
   if (/^[a-z0-9.]+$/i.test(term)) return Math.min(4, Math.max(1.4, term.length / 2));
   return Math.min(4, Math.max(1, term.length - 1));
+}
+
+function formatMatchedTerms(terms: string[], profile: QueryProfile): string[] {
+  return uniqueTerms(terms.map(term => profile.termLabels.get(term) ?? term));
 }
 
 function uniqueTerms(values: string[]): string[] {

--- a/src/shared/types/current-video-segment-retrieval.ts
+++ b/src/shared/types/current-video-segment-retrieval.ts
@@ -72,6 +72,16 @@ export interface CurrentVideoSegmentRetrievalEvidenceState {
   contextFresh: boolean;
 }
 
+export interface CurrentVideoQueryRewriteState {
+  originalQuery: string;
+  normalizedQuery: string;
+  expanded: boolean;
+  expandedTerms: string[];
+  visibleExpandedTerms: string[];
+  reasons: string[];
+  aiRewriteEnabled: false;
+}
+
 export type CurrentVideoSegmentRerankAiStatus =
   | 'not_requested'
   | 'disabled'
@@ -108,6 +118,7 @@ export interface CurrentVideoSegmentRetrievalResult {
   candidates: CurrentVideoSegmentRetrievalCandidate[];
   summary: string;
   limitations: string[];
+  queryRewrite: CurrentVideoQueryRewriteState;
   evidenceState: CurrentVideoSegmentRetrievalEvidenceState;
   aiRerank: CurrentVideoSegmentRerankAiState;
 }

--- a/tests/current-video-segment-retrieval.mock.html
+++ b/tests/current-video-segment-retrieval.mock.html
@@ -192,6 +192,26 @@
       </article>
     </section>
 
+    <section data-testid="retrieval-query-rewrite">
+      <h1>查询改写同义召回</h1>
+      <div class="status" data-testid="rewrite-status">已扩展相关表达：子代理、子智能体、多代理、100万上下文、一兆上下文、工具调用、函数调用</div>
+      <article class="candidate" data-testid="rewrite-subagent">
+        <label class="meta">输入 <input value="subagent" readonly></label>
+        <div class="evidence">候选片段：这里讲子代理和子智能体如何协作，也提到多代理任务拆分。</div>
+        <div class="reason">匹配原因：已扩展相关表达命中：子代理、子智能体、多代理</div>
+      </article>
+      <article class="candidate" data-testid="rewrite-context">
+        <label class="meta">输入 <input value="1M context" readonly></label>
+        <div class="evidence">候选片段：这一段解释100万上下文和一兆上下文，也说明长上下文的限制。</div>
+        <div class="reason">匹配原因：已扩展相关表达命中：100万上下文、一兆上下文、长上下文</div>
+      </article>
+      <article class="candidate" data-testid="rewrite-tool-use">
+        <label class="meta">输入 <input value="tool use" readonly></label>
+        <div class="evidence">候选片段：这里重点讲工具调用和函数调用，说明模型怎样选择外部工具。</div>
+        <div class="reason">匹配原因：已扩展相关表达命中：工具调用、函数调用</div>
+      </article>
+    </section>
+
     <section data-testid="retrieval-ai-disabled">
       <h1>AI 未启用回退</h1>
       <div class="status">找到 2 个基于当前视频本地证据的候选片段。</div>

--- a/tests/current-video-segment-retrieval.test.ts
+++ b/tests/current-video-segment-retrieval.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { searchCurrentVideoSegments } from '../src/shared/current-video-segment-retrieval.ts';
+import {
+  rewriteCurrentVideoSegmentQuery,
+  searchCurrentVideoSegments,
+} from '../src/shared/current-video-segment-retrieval.ts';
 import { buildVideoKnowledgeResult } from '../src/shared/video-knowledge.ts';
 import type { CurrentVideoContext, CurrentVideoContextResult } from '../src/shared/types/current-video-context.ts';
 import type { CurrentVideoTranscriptSegment } from '../src/shared/types/current-video-transcript.ts';
@@ -46,6 +49,122 @@ test('matches a Chinese fuzzy phrase by token and n-gram overlap', () => {
   assert.equal(result.candidates[0].timeRangeLabel, '0:24-0:32');
   assert.ok(result.candidates[0].evidenceText.includes('模型'));
   assert.ok(result.candidates[0].matchReasons.some(reason => reason.includes('中文短语') || reason.includes('模型')));
+});
+
+test('rewrites required current-video synonym groups locally without AI', () => {
+  const cases = [
+    {
+      query: 'sub-agent',
+      expected: ['子代理', '子智能体', '多代理', 'multi-agent'],
+    },
+    {
+      query: 'multi-agent',
+      expected: ['subagent', '子代理', '子智能体', '多代理'],
+    },
+    {
+      query: '上下文窗口',
+      expected: ['长上下文', '1M context', '100万上下文', '一兆上下文'],
+    },
+    {
+      query: 'function calling',
+      expected: ['tool use', '工具调用', '函数调用'],
+    },
+  ];
+
+  for (const item of cases) {
+    const rewrite = rewriteCurrentVideoSegmentQuery(item.query);
+    assert.equal(rewrite.expanded, true);
+    assert.equal(rewrite.aiRewriteEnabled, false);
+    for (const term of item.expected) {
+      assert.ok(
+        rewrite.visibleExpandedTerms.includes(term),
+        `${item.query} should expand ${term}`,
+      );
+    }
+    assert.ok(rewrite.reasons.some(reason => reason.includes('本地词表')));
+  }
+});
+
+test('expands subagent queries to Chinese current-video transcript expressions', () => {
+  const context = withTranscriptEvidence(videoContext({ title: 'Agent 能力演示', descriptionText: null }));
+  const [base] = transcriptSegments();
+  const segments = [{
+    ...base,
+    segmentId: 'transcript:BV1Segment00:101:1:zh-cn:hash123:subagent',
+    startSeconds: 50,
+    endSeconds: 58,
+    text: '这里讲子代理和子智能体如何协作，也提到多代理任务拆分。',
+  }];
+
+  const result = searchCurrentVideoSegments(context, {
+    query: 'subagent',
+    transcriptSegments: segments,
+    videoKnowledge: null,
+    now: 3000,
+  });
+
+  assert.equal(result.status, 'ready');
+  assert.equal(result.queryRewrite.expanded, true);
+  assert.equal(result.queryRewrite.aiRewriteEnabled, false);
+  assert.ok(result.queryRewrite.visibleExpandedTerms.includes('子代理'));
+  assert.equal(result.candidates[0].binding.segmentId, segments[0].segmentId);
+  assert.ok(result.candidates[0].evidenceText.includes('子智能体'));
+  assert.ok(result.candidates[0].matchReasons.some(reason => reason.includes('已扩展相关表达')));
+  assert.equal(result.candidates[0].jumpPreview.canJump, true);
+});
+
+test('expands 1M context queries to Chinese long-context transcript expressions', () => {
+  const context = withTranscriptEvidence(videoContext({ title: '长上下文演示', descriptionText: null }));
+  const [base] = transcriptSegments();
+  const segments = [{
+    ...base,
+    segmentId: 'transcript:BV1Segment00:101:1:zh-cn:hash123:context',
+    startSeconds: 70,
+    endSeconds: 78,
+    text: '这一段解释100万上下文和一兆上下文，也说明长上下文的限制。',
+  }];
+
+  const result = searchCurrentVideoSegments(context, {
+    query: '1M context',
+    transcriptSegments: segments,
+    videoKnowledge: null,
+    now: 3000,
+  });
+
+  assert.equal(result.status, 'ready');
+  assert.equal(result.queryRewrite.expanded, true);
+  assert.ok(result.queryRewrite.visibleExpandedTerms.includes('100万上下文'));
+  assert.equal(result.candidates[0].binding.segmentId, segments[0].segmentId);
+  assert.ok(result.candidates[0].evidenceText.includes('一兆上下文'));
+  assert.ok(result.candidates[0].matchReasons.some(reason => reason.includes('已扩展相关表达')));
+  assert.equal(result.candidates[0].jumpPreview.canJump, true);
+});
+
+test('expands tool use queries to Chinese tool and function calling transcript expressions', () => {
+  const context = withTranscriptEvidence(videoContext({ title: '工具调用演示', descriptionText: null }));
+  const [base] = transcriptSegments();
+  const segments = [{
+    ...base,
+    segmentId: 'transcript:BV1Segment00:101:1:zh-cn:hash123:tool-use',
+    startSeconds: 90,
+    endSeconds: 98,
+    text: '这里重点讲工具调用和函数调用，说明模型怎样选择外部工具。',
+  }];
+
+  const result = searchCurrentVideoSegments(context, {
+    query: 'tool use',
+    transcriptSegments: segments,
+    videoKnowledge: null,
+    now: 3000,
+  });
+
+  assert.equal(result.status, 'ready');
+  assert.equal(result.queryRewrite.expanded, true);
+  assert.ok(result.queryRewrite.visibleExpandedTerms.includes('工具调用'));
+  assert.equal(result.candidates[0].binding.segmentId, segments[0].segmentId);
+  assert.ok(result.candidates[0].evidenceText.includes('函数调用'));
+  assert.ok(result.candidates[0].matchReasons.some(reason => reason.includes('已扩展相关表达')));
+  assert.equal(result.candidates[0].jumpPreview.canJump, true);
 });
 
 test('uses a weak metadata helper only when no timed evidence is available', () => {


### PR DESCRIPTION
﻿## Issue
Closes #131

## Scope
- Adds local current-video query rewrite / synonym expansion for segment retrieval.
- Covers bilingual and equivalent expressions such as subagent / 子代理, 1M context / 100万上下文, and tool use / 工具调用.
- Surfaces a user-facing "已扩展相关表达" hint in the in-page assistant and popup.
- Does not add AI answers, embeddings, jump/seek behavior, or non-current-video evidence.

## Validation
- Child thread reported focused segment retrieval / timestamp jump / rerank tests passed.
- Child thread reported current-video transcript, summary, video-knowledge, typecheck, build, diff check, and forbidden-copy scan passed.
- Main Agent rebased branch onto latest origin/main after #130 merge; focused validation will be rerun before merge.

## Privacy
- Current-video retrieval remains bounded to current-video transcript/key-node evidence.
- No local key files, Cookie files, browser profiles, Bilibili login-state files, full history, full favorites, full following, or feedback datasets were read.
