### PR TITLE
[codex] Settings local data privacy controls

### DIFF
--- a/dashboard/modules/settings/SettingsPage.tsx
+++ b/dashboard/modules/settings/SettingsPage.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useMemo, useState } from 'preact/hooks';
 import { requestSW } from '../../utils/messaging';
+import {
+  buildLocalDataOperationMessage,
+  buildLocalDataSummaryCards,
+  buildSmartFavoriteRebuildMessage,
+  dangerousLocalDataClearScope,
+  formatLocalDataError,
+  LOCAL_DATA_CLEAR_CONFIRMATION,
+} from '../../../src/shared/local-data-privacy';
 import type {
   AiConfig,
   AiConnectionTestResult,
@@ -7,8 +15,13 @@ import type {
   DynamicBillConfig,
   UserConfig,
 } from '../../../src/shared/types/config';
+import type {
+  LocalDataOperationResult,
+  LocalDataPrivacySummary,
+  SmartFavoriteIndexRebuildResult,
+} from '../../../src/shared/types/local-data-privacy';
 
-type BusyState = '' | 'save' | 'test';
+type BusyState = '' | 'save' | 'test' | 'local-refresh' | 'subtitle-clear' | 'index-rebuild' | 'clear-all';
 
 interface AiFormState {
   baseURL: string;
@@ -43,9 +56,14 @@ export function SettingsPage() {
   const [notice, setNotice] = useState('');
   const [error, setError] = useState('');
   const [lastTest, setLastTest] = useState<AiConnectionTestResult | null>(null);
+  const [localData, setLocalData] = useState<LocalDataPrivacySummary | null>(null);
+  const [localDataError, setLocalDataError] = useState('');
+  const [clearConfirmVisible, setClearConfirmVisible] = useState(false);
+  const [clearConfirmText, setClearConfirmText] = useState('');
 
   useEffect(() => {
     void refreshConfig();
+    void refreshLocalData();
   }, []);
 
   const effectiveAiConfig = useMemo<AiConfig>(() => ({
@@ -65,6 +83,8 @@ export function SettingsPage() {
       || assistant.currentVideoSegmentRerankAiEnabled !== loadedConfig.assistant.currentVideoSegmentRerankAiEnabled
       || dynamicBill.aiExplanationsEnabled !== loadedConfig.dynamicBill.aiExplanationsEnabled;
   }, [assistant, dynamicBill, form, loadedConfig]);
+  const localDataCards = localData ? buildLocalDataSummaryCards(localData) : [];
+  const canConfirmClear = clearConfirmText.trim() === LOCAL_DATA_CLEAR_CONFIRMATION;
 
   async function refreshConfig() {
     setLoading(true);
@@ -78,6 +98,16 @@ export function SettingsPage() {
       setError(formatSettingsError(err));
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function refreshLocalData() {
+    setLocalDataError('');
+    try {
+      const summary = await requestSW<LocalDataPrivacySummary>('GET_LOCAL_DATA_PRIVACY_SUMMARY');
+      setLocalData(summary);
+    } catch (err) {
+      setLocalDataError(formatLocalDataError(err));
     }
   }
 
@@ -121,6 +151,65 @@ export function SettingsPage() {
       setNotice(`连接测试通过：模型 ${result.model} 已响应，用时 ${result.latencyMs} 毫秒。`);
     } catch (err) {
       setError(formatConnectionError(err));
+    } finally {
+      setBusy('');
+    }
+  }
+
+  async function refreshLocalDataFromButton() {
+    setBusy('local-refresh');
+    setNotice('');
+    setError('');
+    await refreshLocalData();
+    setBusy('');
+  }
+
+  async function clearSubtitleCache() {
+    setBusy('subtitle-clear');
+    setNotice('');
+    setError('');
+    try {
+      const result = await requestSW<LocalDataOperationResult>('CLEAR_CURRENT_VIDEO_SUBTITLE_CACHE');
+      setNotice(buildLocalDataOperationMessage(result));
+      await refreshLocalData();
+    } catch (err) {
+      setLocalDataError(formatLocalDataError(err));
+    } finally {
+      setBusy('');
+    }
+  }
+
+  async function rebuildSmartFavoriteIndex() {
+    setBusy('index-rebuild');
+    setNotice('');
+    setError('');
+    try {
+      const result = await requestSW<SmartFavoriteIndexRebuildResult>('REBUILD_SMART_FAVORITE_INDEX');
+      setNotice(buildSmartFavoriteRebuildMessage(result));
+      await refreshLocalData();
+    } catch (err) {
+      setLocalDataError(formatLocalDataError(err));
+    } finally {
+      setBusy('');
+    }
+  }
+
+  async function clearAllLocalData() {
+    setBusy('clear-all');
+    setNotice('');
+    setError('');
+    try {
+      const result = await requestSW<LocalDataOperationResult>('CLEAR_ALL_LOCAL_DATA', {
+        confirmation: clearConfirmText.trim(),
+      });
+      const message = buildLocalDataOperationMessage(result);
+      setClearConfirmVisible(false);
+      setClearConfirmText('');
+      await refreshConfig();
+      await refreshLocalData();
+      setNotice(message);
+    } catch (err) {
+      setLocalDataError(formatLocalDataError(err));
     } finally {
       setBusy('');
     }
@@ -268,8 +357,119 @@ export function SettingsPage() {
       <section className="settings-panel">
         <div className="settings-section-head">
           <div>
+            <h3>本地数据与隐私管理</h3>
+            <p>这里只展示本地数据的数量、覆盖范围和最近时间，不展示完整记录、敏感标识或本地文件路径。</p>
+          </div>
+          <span className="settings-pill">
+            {localData ? '状态已读取' : '等待读取'}
+          </span>
+        </div>
+
+        {localDataError && <div className="settings-alert settings-alert-error">{localDataError}</div>}
+
+        <div className="settings-data-grid">
+          {localDataCards.length > 0
+            ? localDataCards.map(card => (
+              <article className="settings-data-card" key={card.id}>
+                <span>{card.title}</span>
+                <strong>{card.value}</strong>
+                <p>{card.detail}</p>
+                <small>{card.meta}</small>
+              </article>
+            ))
+            : (
+              <div className="settings-data-empty">
+                正在读取本地数据摘要...
+              </div>
+            )}
+        </div>
+
+        {localData && (
+          <div className="settings-data-subgrid">
+            <DataStat label="待索引收藏" value={localData.favorites.pendingIndexItems} />
+            <DataStat label="索引失败" value={localData.favorites.failedIndexItems} />
+            <DataStat label="过期字幕片段" value={localData.currentVideoSubtitles.staleSegmentCount} />
+            <DataStat label="动态反馈" value={localData.dynamicBill.feedbackCount} />
+          </div>
+        )}
+
+        <div className="settings-actions">
+          <button type="button" className="settings-action" onClick={refreshLocalDataFromButton} disabled={!!busy}>
+            {busy === 'local-refresh' ? '刷新中...' : '刷新状态'}
+          </button>
+          <button
+            type="button"
+            className="settings-action"
+            onClick={clearSubtitleCache}
+            disabled={!!busy || !localData || localData.currentVideoSubtitles.segmentCount === 0}
+          >
+            {busy === 'subtitle-clear' ? '清理中...' : '清理字幕缓存'}
+          </button>
+          <button
+            type="button"
+            className="settings-action"
+            onClick={rebuildSmartFavoriteIndex}
+            disabled={!!busy || !localData || localData.favorites.storedItems === 0}
+          >
+            {busy === 'index-rebuild' ? '重建中...' : '重建智能收藏索引'}
+          </button>
+          <button
+            type="button"
+            className="settings-action settings-action-danger"
+            onClick={() => setClearConfirmVisible(true)}
+            disabled={!!busy}
+          >
+            清理本地数据
+          </button>
+        </div>
+
+        {clearConfirmVisible && (
+          <div className="settings-danger-box">
+            <div>
+              <strong>确认清理本地数据</strong>
+              <p>这会删除 Bili-Bill 保存在浏览器扩展里的本地内容数据和本地设置，不会修改 B 站账号、关注关系、收藏夹或视频数据。</p>
+            </div>
+            <ul>
+              {dangerousLocalDataClearScope().map(item => <li key={item}>{item}</li>)}
+            </ul>
+            <label className="settings-field">
+              <span>输入“{LOCAL_DATA_CLEAR_CONFIRMATION}”确认</span>
+              <input
+                value={clearConfirmText}
+                onInput={(event) => setClearConfirmText(event.currentTarget.value)}
+                autoComplete="off"
+              />
+            </label>
+            <div className="settings-actions">
+              <button
+                type="button"
+                className="settings-action settings-action-danger"
+                onClick={clearAllLocalData}
+                disabled={!!busy || !canConfirmClear}
+              >
+                {busy === 'clear-all' ? '清理中...' : '确认清理'}
+              </button>
+              <button
+                type="button"
+                className="settings-action"
+                onClick={() => {
+                  setClearConfirmVisible(false);
+                  setClearConfirmText('');
+                }}
+                disabled={!!busy}
+              >
+                取消
+              </button>
+            </div>
+          </div>
+        )}
+      </section>
+
+      <section className="settings-panel">
+        <div className="settings-section-head">
+          <div>
             <h3>隐私边界</h3>
-            <p>这里记录 Bili-Bill 的本地数据和 AI 请求边界，后续本地数据管理会在单独切片接入。</p>
+            <p>这里记录 Bili-Bill 的本地数据和 AI 请求边界。</p>
           </div>
         </div>
         <ul className="settings-privacy-list">
@@ -279,6 +479,15 @@ export function SettingsPage() {
           <li>动态账单、收藏和当前视频功能不会写回 B 站关注关系、收藏夹或视频数据。</li>
         </ul>
       </section>
+    </div>
+  );
+}
+
+function DataStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="settings-data-stat">
+      <span>{label}</span>
+      <strong>{value}</strong>
     </div>
   );
 }

--- a/dashboard/styles/dashboard.css
+++ b/dashboard/styles/dashboard.css
@@ -450,6 +450,12 @@ button {
   background: var(--bili-pink);
 }
 
+.settings-action-danger {
+  border-color: rgba(255, 107, 107, 0.48);
+  color: #FFFFFF;
+  background: rgba(255, 107, 107, 0.2);
+}
+
 .settings-action:disabled {
   cursor: not-allowed;
   opacity: 0.58;
@@ -524,6 +530,105 @@ button {
 .settings-privacy-list {
   display: grid;
   gap: 8px;
+  padding-left: 18px;
+}
+
+.settings-data-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.settings-data-card,
+.settings-data-empty,
+.settings-data-stat,
+.settings-danger-box {
+  border: 1px solid #333355;
+  border-radius: 8px;
+  background: #1A1A2E;
+}
+
+.settings-data-card {
+  display: grid;
+  gap: 6px;
+  min-height: 138px;
+  padding: 12px;
+}
+
+.settings-data-card span,
+.settings-data-stat span {
+  color: #8FDDF6;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.settings-data-card strong {
+  color: #FFFFFF;
+  font-size: 22px;
+  line-height: 1.1;
+}
+
+.settings-data-card p,
+.settings-data-card small,
+.settings-danger-box p,
+.settings-danger-box li {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.settings-data-card p {
+  margin: 0;
+}
+
+.settings-data-empty {
+  grid-column: 1 / -1;
+  min-height: 96px;
+  padding: 18px;
+  color: var(--text-secondary);
+}
+
+.settings-data-subgrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.settings-data-stat {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 42px;
+  padding: 10px 12px;
+}
+
+.settings-data-stat strong {
+  color: #FFFFFF;
+  font-size: 16px;
+}
+
+.settings-danger-box {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+  border-color: rgba(255, 107, 107, 0.36);
+  background: rgba(255, 107, 107, 0.08);
+}
+
+.settings-danger-box strong {
+  color: #FFD0D0;
+  font-size: 14px;
+}
+
+.settings-danger-box p {
+  margin: 5px 0 0;
+}
+
+.settings-danger-box ul {
+  display: grid;
+  gap: 6px;
+  margin: 0;
   padding-left: 18px;
 }
 
@@ -1505,6 +1610,8 @@ button {
   .dynamic-bill-status-grid,
   .dynamic-bill-board,
   .creator-follow-board,
+  .settings-data-grid,
+  .settings-data-subgrid,
   .settings-toggle-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -1586,6 +1693,8 @@ button {
 
   .settings-hero,
   .settings-form-grid,
+  .settings-data-grid,
+  .settings-data-subgrid,
   .settings-toggle-grid {
     grid-template-columns: 1fr;
   }
@@ -1608,6 +1717,8 @@ button {
   .dynamic-bill-board,
   .creator-follow-board,
   .creator-secondary-grid,
+  .settings-data-grid,
+  .settings-data-subgrid,
   .settings-toggle-grid {
     grid-template-columns: 1fr;
   }

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -13,6 +13,8 @@ import type {
 } from '../../shared/types/current-video-segment-retrieval';
 import type { VideoKnowledgeJumpResponse } from '../../shared/types/video-knowledge';
 import type { DynamicBillFeedbackScope, DynamicBillStatusFilter } from '../../shared/types/dynamic-bill';
+import type { SmartIndexResult } from '../../shared/types/favorite';
+import type { SmartFavoriteIndexRebuildResult } from '../../shared/types/local-data-privacy';
 import { normalizePageLimit, runInitialBackfill } from '../sync/initial-backfill';
 import { probeHistoryTailCoverage } from '../sync/history-tail-probe';
 import {
@@ -71,6 +73,15 @@ import {
   resolveCurrentVideoTabState,
   type CurrentVideoTabSnapshot,
 } from '../current-video-context-resolver';
+import {
+  clearSmartFavoriteIndex,
+  countFavoriteItems,
+} from '../storage/favorite-repo';
+import {
+  clearAllLocalData,
+  clearCurrentVideoSubtitleCache,
+  getLocalDataPrivacySummary,
+} from '../storage/local-data-privacy-repo';
 import {
   getDynamicBillFilterPreference,
   getDynamicBillItems,
@@ -315,6 +326,14 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
     }
     case 'TEST_AI_CONNECTION':
       return { success: true, data: await testAiConnection(normalizeAiConfigParam(request.params?.ai)) as T };
+    case 'GET_LOCAL_DATA_PRIVACY_SUMMARY':
+      return { success: true, data: await getLocalDataPrivacySummary() as T };
+    case 'CLEAR_CURRENT_VIDEO_SUBTITLE_CACHE':
+      return { success: true, data: await clearCurrentVideoSubtitleCache() as T };
+    case 'REBUILD_SMART_FAVORITE_INDEX':
+      return { success: true, data: await rebuildSmartFavoriteIndex(request.params) as T };
+    case 'CLEAR_ALL_LOCAL_DATA':
+      return { success: true, data: await clearAllLocalData(request.params?.confirmation) as T };
     case 'GET_CURRENT_VIDEO_CONTEXT':
       return { success: true, data: await getCurrentVideoContextForActiveTab(currentVideoLookupOptions(request.params)) as T };
     case 'PROBE_CURRENT_VIDEO_SUBTITLE_SOURCE':
@@ -849,6 +868,47 @@ function normalizeAiConfigParam(value: unknown): UserConfig['ai'] {
     apiKey: typeof raw.apiKey === 'string' ? raw.apiKey : '',
     chatModel: typeof raw.chatModel === 'string' ? raw.chatModel.trim() : '',
   };
+}
+
+async function rebuildSmartFavoriteIndex(
+  params: Record<string, unknown> | undefined,
+): Promise<SmartFavoriteIndexRebuildResult> {
+  const batchSize = Math.min(normalizePositiveInteger(params?.batchSize, 25), 100);
+  const totalItems = await countFavoriteItems();
+  const clearedIndexes = await clearSmartFavoriteIndex();
+  const result: SmartIndexResult = {
+    processed: 0,
+    indexed: 0,
+    failed: 0,
+    skipped: 0,
+    notes: [],
+  };
+  let guard = Math.ceil(totalItems / batchSize) + 2;
+
+  while (result.processed < totalItems && guard-- > 0) {
+    const batch = await buildSmartFavoriteIndex(batchSize, { includeFailed: false });
+    mergeSmartIndexResult(result, batch);
+    if (batch.processed === 0) break;
+  }
+
+  return {
+    totalItems,
+    clearedIndexes,
+    ...result,
+    completedAt: Date.now(),
+  };
+}
+
+function mergeSmartIndexResult(target: SmartIndexResult, batch: SmartIndexResult): void {
+  target.processed += batch.processed;
+  target.indexed += batch.indexed;
+  target.failed += batch.failed;
+  target.skipped += batch.skipped;
+  for (const note of batch.notes) {
+    if (!target.notes.includes(note)) {
+      target.notes.push(note);
+    }
+  }
 }
 
 function videoUrl(bvid: string): string {

--- a/src/background/storage/favorite-repo.ts
+++ b/src/background/storage/favorite-repo.ts
@@ -139,6 +139,12 @@ export async function countIndexedFavorites(): Promise<number> {
   return db.smartFavoriteIndex.where({ status: 'indexed' }).count();
 }
 
+export async function clearSmartFavoriteIndex(): Promise<number> {
+  const count = await db.smartFavoriteIndex.count();
+  await db.smartFavoriteIndex.clear();
+  return count;
+}
+
 async function attachExistingFavoriteFolderIds(folders: FavoriteFolder[]): Promise<FavoriteFolder[]> {
   if (folders.length === 0) return [];
   const mediaIds = folders.map(folder => folder.mediaId);

--- a/src/background/storage/local-data-privacy-repo.ts
+++ b/src/background/storage/local-data-privacy-repo.ts
@@ -1,0 +1,249 @@
+import { LOCAL_DATA_CLEAR_CONFIRMATION } from '../../shared/local-data-privacy.ts';
+import type {
+  LocalDataOperationResult,
+  LocalDataPrivacySummary,
+} from '../../shared/types/local-data-privacy.ts';
+import { getDynamicSyncState } from './dynamic-bill-repo.ts';
+import { db } from './db.ts';
+import {
+  getBackfillComplete,
+  getHistorySyncing,
+  getLastSyncTime,
+} from './config-store.ts';
+
+export async function getLocalDataPrivacySummary(): Promise<LocalDataPrivacySummary> {
+  const [
+    history,
+    favorites,
+    currentVideoSubtitles,
+    dynamicBill,
+  ] = await Promise.all([
+    summarizeHistory(),
+    summarizeFavorites(),
+    summarizeCurrentVideoSubtitles(),
+    summarizeDynamicBill(),
+  ]);
+
+  return {
+    checkedAt: Date.now(),
+    history,
+    favorites,
+    currentVideoSubtitles,
+    dynamicBill,
+  };
+}
+
+export async function clearCurrentVideoSubtitleCache(): Promise<LocalDataOperationResult> {
+  const [sourceCount, segmentCount] = await Promise.all([
+    db.currentVideoTranscriptSources.count(),
+    db.currentVideoTranscriptSegments.count(),
+  ]);
+
+  await db.transaction(
+    'rw',
+    db.currentVideoTranscriptSources,
+    db.currentVideoTranscriptSegments,
+    async () => {
+      await db.currentVideoTranscriptSources.clear();
+      await db.currentVideoTranscriptSegments.clear();
+    },
+  );
+
+  return {
+    operation: 'clear_current_video_subtitle_cache',
+    completedAt: Date.now(),
+    cleared: {
+      currentVideoSubtitleSources: sourceCount,
+      currentVideoSubtitleSegments: segmentCount,
+    },
+  };
+}
+
+export async function clearAllLocalData(confirmation: unknown): Promise<LocalDataOperationResult> {
+  if (confirmation !== LOCAL_DATA_CLEAR_CONFIRMATION) {
+    throw new Error('LOCAL_DATA_CLEAR_CONFIRMATION_REQUIRED');
+  }
+  if (await getHistorySyncing()) {
+    throw new Error('HISTORY_SYNC_IN_PROGRESS');
+  }
+
+  const counts = await collectClearCounts();
+  await db.transaction('rw', db.tables, async () => {
+    for (const table of db.tables) {
+      await table.clear();
+    }
+  });
+  await chrome.storage.local.clear();
+
+  return {
+    operation: 'clear_all_local_data',
+    completedAt: Date.now(),
+    cleared: {
+      ...counts,
+      localSettings: true,
+    },
+  };
+}
+
+async function summarizeHistory(): Promise<LocalDataPrivacySummary['history']> {
+  const [totalRecords, oldest, newest, lastSyncedAt, syncing, backfillComplete] = await Promise.all([
+    db.watchHistory.count(),
+    db.watchHistory.orderBy('viewAt').first(),
+    db.watchHistory.orderBy('viewAt').last(),
+    getLastSyncTime(),
+    getHistorySyncing(),
+    getBackfillComplete(),
+  ]);
+
+  return {
+    totalRecords,
+    oldestViewAt: oldest?.viewAt ?? null,
+    newestViewAt: newest?.viewAt ?? null,
+    lastSyncedAt: normalizeNullableTimestamp(lastSyncedAt),
+    syncing,
+    backfillComplete,
+  };
+}
+
+async function summarizeFavorites(): Promise<LocalDataPrivacySummary['favorites']> {
+  const [
+    folders,
+    storedItems,
+    indexedItems,
+    failedIndexItems,
+    lastSyncedFolder,
+    lastSyncedItem,
+    lastIndexedItem,
+  ] = await Promise.all([
+    db.favoriteFolders.toArray(),
+    db.favoriteItems.count(),
+    db.smartFavoriteIndex.where({ status: 'indexed' }).count(),
+    db.smartFavoriteIndex.where({ status: 'failed' }).count(),
+    db.favoriteFolders.orderBy('syncedAt').last(),
+    db.favoriteItems.orderBy('syncedAt').last(),
+    db.smartFavoriteIndex.orderBy('indexedAt').last(),
+  ]);
+  const reportedItems = folders.reduce((sum, folder) => sum + Math.max(0, Number(folder.mediaCount) || 0), 0);
+  const diagnostics = folders
+    .map(folder => folder.lastSyncDiagnostic)
+    .filter(diagnostic => diagnostic !== undefined);
+  const incompleteFolders = diagnostics.filter(diagnostic => diagnostic.completenessState === 'incomplete').length;
+
+  return {
+    folderCount: folders.length,
+    reportedItems,
+    storedItems,
+    indexedItems,
+    failedIndexItems,
+    pendingIndexItems: Math.max(0, storedItems - indexedItems - failedIndexItems),
+    incompleteFolders,
+    syncComplete: diagnostics.length > 0 && incompleteFolders === 0,
+    lastSyncedAt: latestTimestamp(lastSyncedFolder?.syncedAt, lastSyncedItem?.syncedAt),
+    lastIndexedAt: normalizeNullableTimestamp(lastIndexedItem?.indexedAt),
+  };
+}
+
+async function summarizeCurrentVideoSubtitles(): Promise<LocalDataPrivacySummary['currentVideoSubtitles']> {
+  const [sources, segmentCount, staleSegmentCount, lastUpdated] = await Promise.all([
+    db.currentVideoTranscriptSources.toArray(),
+    db.currentVideoTranscriptSegments.count(),
+    db.currentVideoTranscriptSegments.where({ stale: true }).count(),
+    db.currentVideoTranscriptSources.orderBy('updatedAt').last(),
+  ]);
+  const cachedVideoCount = new Set(sources.map(source => source.bvid).filter(Boolean)).size;
+
+  return {
+    sourceCount: sources.length,
+    segmentCount,
+    staleSegmentCount,
+    cachedVideoCount,
+    lastUpdatedAt: normalizeNullableTimestamp(lastUpdated?.updatedAt),
+  };
+}
+
+async function summarizeDynamicBill(): Promise<LocalDataPrivacySummary['dynamicBill']> {
+  const [creators, updatesCount, items, feedbackCount, explanationCount, syncState] = await Promise.all([
+    db.followedCreators.toArray(),
+    db.followedVideoUpdates.count(),
+    db.dynamicBillItems.toArray(),
+    db.dynamicBillFeedback.count(),
+    db.dynamicBillExplanations.count(),
+    getDynamicSyncState(),
+  ]);
+  const statusCounts = items.reduce<Record<string, number>>((counts, item) => {
+    counts[item.status] = (counts[item.status] ?? 0) + 1;
+    return counts;
+  }, {});
+  const lastGeneratedAt = items.reduce((latest, item) => Math.max(latest, item.generatedAt ?? 0), 0);
+
+  return {
+    activeFollowedCreatorCount: creators.filter(creator => creator.isActive !== false).length,
+    followedVideoUpdateCount: updatesCount,
+    billItemCount: items.length,
+    unopenedItems: statusCounts.unopened ?? 0,
+    openedItems: statusCounts.opened ?? 0,
+    consumedItems: statusCounts.consumed ?? 0,
+    processedItems: statusCounts.processed ?? 0,
+    feedbackCount,
+    explanationCount,
+    lastGeneratedAt: normalizeNullableTimestamp(lastGeneratedAt),
+    lastSyncedAt: normalizeNullableTimestamp(syncState.lastSuccessAt),
+    syncStatus: syncState.status,
+  };
+}
+
+async function collectClearCounts(): Promise<Required<Omit<LocalDataOperationResult['cleared'], 'localSettings'>>> {
+  const [
+    historyRecords,
+    playerEvents,
+    dailyAggregates,
+    favoriteFolders,
+    favoriteItems,
+    smartFavoriteIndexes,
+    followedCreators,
+    followedVideoUpdates,
+    dynamicBillItems,
+    dynamicBillExplanations,
+    dynamicBillFeedback,
+    currentVideoSubtitleSources,
+    currentVideoSubtitleSegments,
+  ] = await Promise.all([
+    db.watchHistory.count(),
+    db.playerEvents.count(),
+    db.dailyAggregates.count(),
+    db.favoriteFolders.count(),
+    db.favoriteItems.count(),
+    db.smartFavoriteIndex.count(),
+    db.followedCreators.count(),
+    db.followedVideoUpdates.count(),
+    db.dynamicBillItems.count(),
+    db.dynamicBillExplanations.count(),
+    db.dynamicBillFeedback.count(),
+    db.currentVideoTranscriptSources.count(),
+    db.currentVideoTranscriptSegments.count(),
+  ]);
+
+  return {
+    historyRecords,
+    playerEvents,
+    dailyAggregates,
+    favoriteFolders,
+    favoriteItems,
+    smartFavoriteIndexes,
+    followedCreators,
+    followedVideoUpdates,
+    dynamicBillItems,
+    dynamicBillExplanations,
+    dynamicBillFeedback,
+    currentVideoSubtitleSources,
+    currentVideoSubtitleSegments,
+  };
+}
+
+function latestTimestamp(...values: Array<number | null | undefined>): number | null {
+  return normalizeNullableTimestamp(Math.max(0, ...values.map(value => Number(value) || 0)));
+}
+
+function normalizeNullableTimestamp(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
+}

--- a/src/shared/local-data-privacy.ts
+++ b/src/shared/local-data-privacy.ts
@@ -1,0 +1,109 @@
+import type {
+  LocalDataOperationResult,
+  LocalDataPrivacySummary,
+  SmartFavoriteIndexRebuildResult,
+} from './types/local-data-privacy';
+
+export const LOCAL_DATA_CLEAR_CONFIRMATION = '清理本地数据';
+
+export interface LocalDataSummaryCard {
+  id: 'history' | 'favorites' | 'subtitles' | 'dynamicBill';
+  title: string;
+  value: string;
+  detail: string;
+  meta: string;
+}
+
+export function buildLocalDataSummaryCards(summary: LocalDataPrivacySummary): LocalDataSummaryCard[] {
+  return [
+    {
+      id: 'history',
+      title: '观看历史',
+      value: `${summary.history.totalRecords} 条`,
+      detail: summary.history.totalRecords > 0
+        ? `覆盖 ${formatLocalDate(summary.history.oldestViewAt, 'seconds')} 至 ${formatLocalDate(summary.history.newestViewAt, 'seconds')}`
+        : '还没有本地观看记录。',
+      meta: summary.history.syncing
+        ? '正在同步观看历史。'
+        : `最近同步：${formatLocalDate(summary.history.lastSyncedAt, 'milliseconds')}`,
+    },
+    {
+      id: 'favorites',
+      title: '收藏与智能索引',
+      value: `${summary.favorites.storedItems} 条`,
+      detail: `B 站报告 ${summary.favorites.reportedItems} 条，本地保存 ${summary.favorites.storedItems} 条，已索引 ${summary.favorites.indexedItems} 条。`,
+      meta: summary.favorites.incompleteFolders > 0
+        ? `有 ${summary.favorites.incompleteFolders} 个收藏夹可能未同步完整。`
+        : `最近同步：${formatLocalDate(summary.favorites.lastSyncedAt, 'milliseconds')}`,
+    },
+    {
+      id: 'subtitles',
+      title: '当前视频字幕缓存',
+      value: `${summary.currentVideoSubtitles.segmentCount} 段`,
+      detail: summary.currentVideoSubtitles.segmentCount > 0
+        ? `已缓存 ${summary.currentVideoSubtitles.cachedVideoCount} 个视频的字幕正文证据。`
+        : '还没有缓存的字幕正文。',
+      meta: `最近缓存：${formatLocalDate(summary.currentVideoSubtitles.lastUpdatedAt, 'milliseconds')}`,
+    },
+    {
+      id: 'dynamicBill',
+      title: '动态账单',
+      value: `${summary.dynamicBill.billItemCount} 项`,
+      detail: `关注快照 ${summary.dynamicBill.activeFollowedCreatorCount} 位，近期待处理视频 ${summary.dynamicBill.followedVideoUpdateCount} 条。`,
+      meta: `最近生成：${formatLocalDate(summary.dynamicBill.lastGeneratedAt, 'milliseconds')}`,
+    },
+  ];
+}
+
+export function buildLocalDataOperationMessage(result: LocalDataOperationResult): string {
+  if (result.operation === 'clear_current_video_subtitle_cache') {
+    const sourceCount = result.cleared.currentVideoSubtitleSources ?? 0;
+    const segmentCount = result.cleared.currentVideoSubtitleSegments ?? 0;
+    return `已清理当前视频字幕缓存：移除 ${sourceCount} 条来源记录和 ${segmentCount} 段字幕正文。`;
+  }
+
+  return [
+    `已清理本地数据：观看历史 ${result.cleared.historyRecords ?? 0} 条、收藏 ${result.cleared.favoriteItems ?? 0} 条、字幕正文 ${result.cleared.currentVideoSubtitleSegments ?? 0} 段、动态账单 ${result.cleared.dynamicBillItems ?? 0} 项。`,
+    result.cleared.localSettings ? '本地 AI 设置和功能开关也已恢复为默认状态。' : '',
+  ].filter(Boolean).join(' ');
+}
+
+export function buildSmartFavoriteRebuildMessage(result: SmartFavoriteIndexRebuildResult): string {
+  return [
+    `智能收藏索引已重新生成：本地收藏 ${result.totalItems} 条，处理 ${result.processed} 条，成功 ${result.indexed} 条，失败 ${result.failed} 条，跳过 ${result.skipped} 条。`,
+    result.failed > 0 ? '失败项可在确认 AI 设置后再次重建。' : '',
+  ].filter(Boolean).join(' ');
+}
+
+export function dangerousLocalDataClearScope(): string[] {
+  return [
+    '观看历史、播放器事件和统计聚合。',
+    '收藏夹快照、智能收藏索引和收藏问答本地依据。',
+    '当前视频字幕缓存、动态账单记录、动态账单反馈和解释。',
+    '本地 AI 服务设置、API Key 保存状态和功能开关。',
+  ];
+}
+
+export function formatLocalDataError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message === 'LOCAL_DATA_CLEAR_CONFIRMATION_REQUIRED') {
+    return `请输入“${LOCAL_DATA_CLEAR_CONFIRMATION}”后再确认清理。`;
+  }
+  if (message === 'HISTORY_SYNC_IN_PROGRESS') {
+    return '观看历史正在同步中。请先停止或等待同步结束，再清理本地数据。';
+  }
+  return '本地数据操作失败，请稍后重试。';
+}
+
+function formatLocalDate(value: number | null, unit: 'milliseconds' | 'seconds'): string {
+  if (!value || value <= 0) return '暂无记录';
+  const timestamp = unit === 'seconds' ? value * 1000 : value;
+  return new Date(timestamp).toLocaleString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}

--- a/src/shared/types/local-data-privacy.ts
+++ b/src/shared/types/local-data-privacy.ts
@@ -1,0 +1,82 @@
+import type { DynamicSyncStatus } from './dynamic-bill';
+
+export interface LocalDataPrivacySummary {
+  checkedAt: number;
+  history: {
+    totalRecords: number;
+    oldestViewAt: number | null;
+    newestViewAt: number | null;
+    lastSyncedAt: number | null;
+    syncing: boolean;
+    backfillComplete: boolean;
+  };
+  favorites: {
+    folderCount: number;
+    reportedItems: number;
+    storedItems: number;
+    indexedItems: number;
+    failedIndexItems: number;
+    pendingIndexItems: number;
+    incompleteFolders: number;
+    syncComplete: boolean;
+    lastSyncedAt: number | null;
+    lastIndexedAt: number | null;
+  };
+  currentVideoSubtitles: {
+    sourceCount: number;
+    segmentCount: number;
+    staleSegmentCount: number;
+    cachedVideoCount: number;
+    lastUpdatedAt: number | null;
+  };
+  dynamicBill: {
+    activeFollowedCreatorCount: number;
+    followedVideoUpdateCount: number;
+    billItemCount: number;
+    unopenedItems: number;
+    openedItems: number;
+    consumedItems: number;
+    processedItems: number;
+    feedbackCount: number;
+    explanationCount: number;
+    lastGeneratedAt: number | null;
+    lastSyncedAt: number | null;
+    syncStatus: DynamicSyncStatus;
+  };
+}
+
+export type LocalDataOperationKind =
+  | 'clear_current_video_subtitle_cache'
+  | 'clear_all_local_data';
+
+export interface LocalDataOperationResult {
+  operation: LocalDataOperationKind;
+  completedAt: number;
+  cleared: {
+    historyRecords?: number;
+    playerEvents?: number;
+    dailyAggregates?: number;
+    favoriteFolders?: number;
+    favoriteItems?: number;
+    smartFavoriteIndexes?: number;
+    followedCreators?: number;
+    followedVideoUpdates?: number;
+    dynamicBillItems?: number;
+    dynamicBillExplanations?: number;
+    dynamicBillFeedback?: number;
+    currentVideoSubtitleSources?: number;
+    currentVideoSubtitleSegments?: number;
+    localSettings?: boolean;
+  };
+}
+
+export interface SmartFavoriteIndexRebuildResult {
+  totalItems: number;
+  clearedIndexes: number;
+  processed: number;
+  indexed: number;
+  failed: number;
+  skipped: number;
+  notes: string[];
+  completedAt: number;
+}

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -39,6 +39,11 @@ import type { VideoKnowledgeJumpResponse, VideoKnowledgeResult } from './video-k
 import type { HistoryTailProbeReport } from './history-tail-probe';
 import type { HistorySyncCursorSnapshot, HistorySyncMode } from './history-sync';
 import type { AiConnectionTestResult } from './config';
+import type {
+  LocalDataOperationResult,
+  LocalDataPrivacySummary,
+  SmartFavoriteIndexRebuildResult,
+} from './local-data-privacy';
 
 // 弹窗 / 面板 → Service Worker
 export type RequestAction =
@@ -54,6 +59,10 @@ export type RequestAction =
   | 'GET_CONFIG'
   | 'UPDATE_CONFIG'
   | 'TEST_AI_CONNECTION'
+  | 'GET_LOCAL_DATA_PRIVACY_SUMMARY'
+  | 'CLEAR_CURRENT_VIDEO_SUBTITLE_CACHE'
+  | 'REBUILD_SMART_FAVORITE_INDEX'
+  | 'CLEAR_ALL_LOCAL_DATA'
   | 'EXPORT_DATA'
   | 'EXPORT_DATA_PAGE'
   | 'GET_SYNC_STATUS'
@@ -201,3 +210,6 @@ export type DynamicBillFilterResponse = BiliVizResponse<DynamicBillFilterPrefere
 export type DynamicBillFeedbackResponse = BiliVizResponse<DynamicBillFeedbackResult>;
 export type HistoryTailProbeResponse = BiliVizResponse<HistoryTailProbeReport>;
 export type AiConnectionTestResponse = BiliVizResponse<AiConnectionTestResult>;
+export type LocalDataPrivacySummaryResponse = BiliVizResponse<LocalDataPrivacySummary>;
+export type LocalDataOperationResponse = BiliVizResponse<LocalDataOperationResult>;
+export type SmartFavoriteIndexRebuildResponse = BiliVizResponse<SmartFavoriteIndexRebuildResult>;

--- a/tests/settings-local-data-privacy.mock.html
+++ b/tests/settings-local-data-privacy.mock.html
@@ -1,0 +1,345 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Bili-Bill 本地数据与隐私 Mock</title>
+  <style>
+    :root {
+      --pink: #fb7299;
+      --blue: #00a1d6;
+      --mint: #14b8a6;
+      --bg: #f5f7fb;
+      --panel: #222244;
+      --panel-strong: #1a1a2e;
+      --border: #333355;
+      --muted: #a0a0b0;
+      --danger: #ff6b6b;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: #fff;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", Arial, sans-serif;
+    }
+    main {
+      display: grid;
+      gap: 14px;
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 22px;
+    }
+    .panel {
+      display: grid;
+      gap: 14px;
+      padding: 16px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--panel);
+    }
+    .head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 14px;
+    }
+    h1,
+    h2,
+    p {
+      margin: 0;
+    }
+    p,
+    small,
+    li {
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.6;
+    }
+    .pill {
+      flex: none;
+      padding: 5px 9px;
+      border: 1px solid rgba(20, 184, 166, 0.32);
+      border-radius: 999px;
+      color: #a8fff0;
+      background: rgba(20, 184, 166, 0.12);
+      font-size: 12px;
+      font-weight: 800;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 10px;
+    }
+    .card,
+    .stat,
+    .danger-box,
+    .notice {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--panel-strong);
+    }
+    .card {
+      display: grid;
+      gap: 6px;
+      min-height: 138px;
+      padding: 12px;
+    }
+    .card span,
+    .stat span {
+      color: #8fddf6;
+      font-size: 12px;
+      font-weight: 800;
+    }
+    .card strong {
+      font-size: 22px;
+    }
+    .stat-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 8px;
+    }
+    .stat {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      min-height: 42px;
+      padding: 10px 12px;
+    }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    button {
+      min-height: 36px;
+      padding: 0 12px;
+      border: 1px solid #3b3b62;
+      border-radius: 7px;
+      color: #d8d8e8;
+      background: var(--panel-strong);
+      cursor: pointer;
+      font: inherit;
+      font-size: 13px;
+      font-weight: 750;
+    }
+    button.primary {
+      border-color: rgba(0, 161, 214, 0.5);
+      color: #fff;
+      background: var(--blue);
+    }
+    button.danger {
+      border-color: rgba(255, 107, 107, 0.48);
+      color: #fff;
+      background: rgba(255, 107, 107, 0.2);
+    }
+    button:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+    .notice {
+      display: none;
+      padding: 11px 12px;
+      border-color: rgba(20, 184, 166, 0.34);
+      color: #c7fff5;
+      background: rgba(20, 184, 166, 0.12);
+      font-size: 13px;
+    }
+    .notice.show {
+      display: block;
+    }
+    .danger-box {
+      display: none;
+      gap: 12px;
+      padding: 14px;
+      border-color: rgba(255, 107, 107, 0.36);
+      background: rgba(255, 107, 107, 0.08);
+    }
+    .danger-box.show {
+      display: grid;
+    }
+    .danger-box strong {
+      color: #ffd0d0;
+    }
+    label {
+      display: grid;
+      gap: 6px;
+      color: #fff;
+      font-size: 12px;
+      font-weight: 800;
+    }
+    input {
+      min-height: 38px;
+      padding: 8px 10px;
+      border: 1px solid #3b3b62;
+      border-radius: 7px;
+      color: #fff;
+      background: #18182b;
+      font: inherit;
+    }
+    @media (max-width: 900px) {
+      .grid,
+      .stat-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+    @media (max-width: 620px) {
+      main {
+        padding: 12px;
+      }
+      .head {
+        display: grid;
+      }
+      .grid,
+      .stat-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="panel">
+      <div class="head">
+        <div>
+          <h1>设置</h1>
+          <p>AI 与本地数据。这里展示本地数据摘要，并提供缓存清理、索引重建和危险清理入口。</p>
+        </div>
+        <span class="pill">状态已读取</span>
+      </div>
+    </section>
+
+    <section class="panel" aria-label="本地数据与隐私管理">
+      <div class="head">
+        <div>
+          <h2>本地数据与隐私管理</h2>
+          <p>这里只展示数量、覆盖范围和最近时间，不展示完整记录、敏感标识或本地文件路径。</p>
+        </div>
+      </div>
+
+      <div id="notice" class="notice" role="status"></div>
+
+      <div class="grid">
+        <article class="card">
+          <span>观看历史</span>
+          <strong id="history-count">128 条</strong>
+          <p>覆盖 2026/05/20 10:30 至 2026/06/19 09:10</p>
+          <small>最近同步：2026/06/19 09:15</small>
+        </article>
+        <article class="card">
+          <span>收藏与智能索引</span>
+          <strong id="favorite-count">24 条</strong>
+          <p id="favorite-detail">B 站报告 28 条，本地保存 24 条，已索引 21 条。</p>
+          <small>最近同步：2026/06/18 22:10</small>
+        </article>
+        <article class="card">
+          <span>当前视频字幕缓存</span>
+          <strong id="subtitle-count">42 段</strong>
+          <p id="subtitle-detail">已缓存 2 个视频的字幕正文证据。</p>
+          <small id="subtitle-time">最近缓存：2026/06/19 08:40</small>
+        </article>
+        <article class="card">
+          <span>动态账单</span>
+          <strong id="dynamic-count">6 项</strong>
+          <p>关注快照 12 位，近期待处理视频 8 条。</p>
+          <small>最近生成：2026/06/19 09:05</small>
+        </article>
+      </div>
+
+      <div class="stat-grid">
+        <div class="stat"><span>待索引收藏</span><strong id="pending-index">2</strong></div>
+        <div class="stat"><span>索引失败</span><strong id="failed-index">1</strong></div>
+        <div class="stat"><span>过期字幕片段</span><strong id="stale-subtitle">4</strong></div>
+        <div class="stat"><span>动态反馈</span><strong id="dynamic-feedback">3</strong></div>
+      </div>
+
+      <div class="actions">
+        <button id="refresh" type="button">刷新状态</button>
+        <button id="clear-subtitles" type="button">清理字幕缓存</button>
+        <button id="rebuild-index" class="primary" type="button">重建智能收藏索引</button>
+        <button id="show-danger" class="danger" type="button">清理本地数据</button>
+      </div>
+
+      <div id="danger-box" class="danger-box">
+        <div>
+          <strong>确认清理本地数据</strong>
+          <p>这会删除 Bili-Bill 保存在浏览器扩展里的本地内容数据和本地设置，不会修改 B 站账号、关注关系、收藏夹或视频数据。</p>
+        </div>
+        <ul>
+          <li>观看历史、播放器事件和统计聚合。</li>
+          <li>收藏夹快照、智能收藏索引和收藏问答本地依据。</li>
+          <li>当前视频字幕缓存、动态账单记录、动态账单反馈和解释。</li>
+          <li>本地 AI 服务设置、API Key 保存状态和功能开关。</li>
+        </ul>
+        <label>
+          输入“清理本地数据”确认
+          <input id="confirm-text" autocomplete="off" />
+        </label>
+        <div class="actions">
+          <button id="confirm-clear" class="danger" type="button" disabled>确认清理</button>
+          <button id="cancel-clear" type="button">取消</button>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const notice = document.getElementById('notice');
+    const dangerBox = document.getElementById('danger-box');
+    const confirmText = document.getElementById('confirm-text');
+    const confirmClear = document.getElementById('confirm-clear');
+
+    function showNotice(text) {
+      notice.textContent = text;
+      notice.classList.add('show');
+    }
+
+    document.getElementById('refresh').addEventListener('click', () => {
+      showNotice('本地数据状态已刷新。');
+    });
+
+    document.getElementById('clear-subtitles').addEventListener('click', () => {
+      document.getElementById('subtitle-count').textContent = '0 段';
+      document.getElementById('subtitle-detail').textContent = '还没有缓存的字幕正文。';
+      document.getElementById('subtitle-time').textContent = '最近缓存：暂无记录';
+      document.getElementById('stale-subtitle').textContent = '0';
+      document.getElementById('clear-subtitles').disabled = true;
+      showNotice('已清理当前视频字幕缓存：移除 3 条来源记录和 42 段字幕正文。');
+    });
+
+    document.getElementById('rebuild-index').addEventListener('click', () => {
+      document.getElementById('favorite-detail').textContent = 'B 站报告 28 条，本地保存 24 条，已索引 24 条。';
+      document.getElementById('pending-index').textContent = '0';
+      document.getElementById('failed-index').textContent = '0';
+      showNotice('智能收藏索引已重新生成：本地收藏 24 条，处理 24 条，成功 24 条，失败 0 条，跳过 0 条。');
+    });
+
+    document.getElementById('show-danger').addEventListener('click', () => {
+      dangerBox.classList.add('show');
+      confirmText.focus();
+    });
+
+    confirmText.addEventListener('input', () => {
+      confirmClear.disabled = confirmText.value.trim() !== '清理本地数据';
+    });
+
+    document.getElementById('cancel-clear').addEventListener('click', () => {
+      dangerBox.classList.remove('show');
+      confirmText.value = '';
+      confirmClear.disabled = true;
+    });
+
+    confirmClear.addEventListener('click', () => {
+      document.getElementById('history-count').textContent = '0 条';
+      document.getElementById('favorite-count').textContent = '0 条';
+      document.getElementById('dynamic-count').textContent = '0 项';
+      document.getElementById('favorite-detail').textContent = 'B 站报告 0 条，本地保存 0 条，已索引 0 条。';
+      document.getElementById('pending-index').textContent = '0';
+      document.getElementById('failed-index').textContent = '0';
+      document.getElementById('dynamic-feedback').textContent = '0';
+      dangerBox.classList.remove('show');
+      showNotice('已清理本地数据：观看历史 128 条、收藏 24 条、字幕正文 0 段、动态账单 6 项。本地 AI 设置和功能开关也已恢复为默认状态。');
+    });
+  </script>
+</body>
+</html>

--- a/tests/settings-local-data-privacy.test.ts
+++ b/tests/settings-local-data-privacy.test.ts
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildLocalDataOperationMessage,
+  buildLocalDataSummaryCards,
+  buildSmartFavoriteRebuildMessage,
+  dangerousLocalDataClearScope,
+  LOCAL_DATA_CLEAR_CONFIRMATION,
+} from '../src/shared/local-data-privacy.ts';
+import type {
+  LocalDataOperationResult,
+  LocalDataPrivacySummary,
+  SmartFavoriteIndexRebuildResult,
+} from '../src/shared/types/local-data-privacy.ts';
+
+test('settings local data cards expose natural Chinese summaries only', () => {
+  const cards = buildLocalDataSummaryCards(makeSummary());
+  assert.deepEqual(cards.map(card => card.title), [
+    '观看历史',
+    '收藏与智能索引',
+    '当前视频字幕缓存',
+    '动态账单',
+  ]);
+  assert.match(cards.map(card => card.value).join('\n'), /128 条/);
+  assertCleanUserCopy(JSON.stringify(cards));
+});
+
+test('settings local data operation messages stay bounded to counts', () => {
+  const subtitleMessage = buildLocalDataOperationMessage({
+    operation: 'clear_current_video_subtitle_cache',
+    completedAt: 1_718_000_000_000,
+    cleared: {
+      currentVideoSubtitleSources: 3,
+      currentVideoSubtitleSegments: 42,
+    },
+  });
+  assert.equal(subtitleMessage, '已清理当前视频字幕缓存：移除 3 条来源记录和 42 段字幕正文。');
+
+  const clearAllMessage = buildLocalDataOperationMessage({
+    operation: 'clear_all_local_data',
+    completedAt: 1_718_000_000_000,
+    cleared: {
+      historyRecords: 128,
+      favoriteItems: 24,
+      currentVideoSubtitleSegments: 42,
+      dynamicBillItems: 6,
+      localSettings: true,
+    },
+  } satisfies LocalDataOperationResult);
+  assert.match(clearAllMessage, /本地 AI 设置和功能开关也已恢复为默认状态/);
+  assertCleanUserCopy([subtitleMessage, clearAllMessage].join('\n'));
+});
+
+test('settings dangerous clear scope requires explicit Chinese confirmation', () => {
+  assert.equal(LOCAL_DATA_CLEAR_CONFIRMATION, '清理本地数据');
+  const scope = dangerousLocalDataClearScope().join('\n');
+  assert.match(scope, /本地 AI 服务设置/);
+  assertCleanUserCopy(scope);
+});
+
+test('settings smart favorite rebuild message summarizes the run', () => {
+  const message = buildSmartFavoriteRebuildMessage({
+    totalItems: 24,
+    clearedIndexes: 21,
+    processed: 24,
+    indexed: 22,
+    failed: 2,
+    skipped: 0,
+    notes: [],
+    completedAt: 1_718_000_000_000,
+  } satisfies SmartFavoriteIndexRebuildResult);
+  assert.match(message, /本地收藏 24 条/);
+  assert.match(message, /失败项可在确认 AI 设置后再次重建/);
+  assertCleanUserCopy(message);
+});
+
+function makeSummary(): LocalDataPrivacySummary {
+  return {
+    checkedAt: 1_718_000_000_000,
+    history: {
+      totalRecords: 128,
+      oldestViewAt: 1_700_000_000,
+      newestViewAt: 1_718_000_000,
+      lastSyncedAt: 1_718_000_000_000,
+      syncing: false,
+      backfillComplete: true,
+    },
+    favorites: {
+      folderCount: 4,
+      reportedItems: 28,
+      storedItems: 24,
+      indexedItems: 21,
+      failedIndexItems: 1,
+      pendingIndexItems: 2,
+      incompleteFolders: 0,
+      syncComplete: true,
+      lastSyncedAt: 1_718_000_000_000,
+      lastIndexedAt: 1_718_000_000_000,
+    },
+    currentVideoSubtitles: {
+      sourceCount: 3,
+      segmentCount: 42,
+      staleSegmentCount: 4,
+      cachedVideoCount: 2,
+      lastUpdatedAt: 1_718_000_000_000,
+    },
+    dynamicBill: {
+      activeFollowedCreatorCount: 12,
+      followedVideoUpdateCount: 8,
+      billItemCount: 6,
+      unopenedItems: 2,
+      openedItems: 1,
+      consumedItems: 2,
+      processedItems: 1,
+      feedbackCount: 3,
+      explanationCount: 5,
+      lastGeneratedAt: 1_718_000_000_000,
+      lastSyncedAt: 1_718_000_000_000,
+      syncStatus: 'success',
+    },
+  };
+}
+
+function assertCleanUserCopy(text: string): void {
+  const forbidden = [
+    'G' + 'ET_',
+    'C' + 'LEAR_',
+    'R' + 'EBUILD_',
+    'source' + 'Hash',
+    'segment' + 'Id',
+    'subtitle' + '_url',
+    'DB ' + 'table',
+    'Key' + '.txt',
+  ];
+  for (const token of forbidden) {
+    assert.doesNotMatch(text, new RegExp(escapeRegExp(token), 'i'));
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
﻿## Scope

- Add a local data and privacy management section to the Settings page.
- Show bounded local summaries for watch history, favorites plus Smart Favorites index, current-video subtitle cache, and Dynamic Bill.
- Add Settings actions for refreshing local status, clearing current-video subtitle cache, rebuilding the Smart Favorites index, and clearing local data with an inline second confirmation.
- Add background message handlers and storage helpers that return counts/timestamps only, plus focused shared copy helpers and mock QA coverage.

## Root Cause / Product Judgment

Settings became the unified place for AI and privacy after the settings MVP, but local data state and cleanup still lived outside the Settings workflow. This PR centralizes local-data visibility without turning Settings into a raw database panel: the UI only shows natural Chinese count/time summaries, while destructive operations are handled by explicit message actions and guarded confirmation.

## Validation

- `npm ci`
- `node --test tests/settings-local-data-privacy.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm run test:favorites`
- `npm run test:current-video-transcript`
- `git diff --check`
- `rg -n "未消费|猜你喜欢" dashboard popup public src README.md tests` returned no matches.
- Sensitive/user-visible scan: new Settings copy and mock QA do not render raw cache identifiers, local paths, action names, or full secrets; existing broad hits are in older defensive tests only.
- Playwright mock QA on `tests/settings-local-data-privacy.mock.html`: desktop status cards, subtitle cache clear, Smart Favorites index rebuild, dangerous clear second confirmation, and mobile no-overflow check passed.

Build note: Vite still reports the existing large `chunks/theme-*.js` and dynamic-import chunking warnings; no new build failure.

## Blockers / Must Fix / Follow-up

- Blockers: none.
- Must fix: none known.
- Follow-up: a later settings/privacy slice could add safe diagnostic export and a separate “clear AI key only” action if product wants finer-grained deletion than the current local-data reset.

## Privacy Boundary

- Did not read local key files, Cookie files, browser profiles, Bilibili login-state files, or local personal profile data.
- New summaries send only counts and timestamps to Settings; they do not expose full history, full favorites, full following lists, feedback raw records, source hashes, segment IDs, subtitle URLs, tokens, or local paths.
- Clear actions are local-only and do not write back to Bilibili.

Closes #133
