### PR TITLE
[codex] Add current video related favorites

### DIFF
--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -11,6 +11,7 @@ import type {
   CurrentVideoTimestampJumpResponse,
   CurrentVideoTimestampReturnResponse,
 } from '../../shared/types/current-video-segment-retrieval';
+import type { CurrentVideoRelatedFavoritesResponse } from '../../shared/types/current-video-related-favorites';
 import type { VideoKnowledgeJumpResponse } from '../../shared/types/video-knowledge';
 import type { DynamicBillFeedbackScope, DynamicBillStatusFilter } from '../../shared/types/dynamic-bill';
 import type { SmartIndexResult } from '../../shared/types/favorite';
@@ -42,6 +43,10 @@ import {
 } from '../../shared/current-video-transcript-cache';
 import { searchCurrentVideoSegments } from '../../shared/current-video-segment-retrieval';
 import { searchCurrentVideoSegmentsWithAiRerank } from '../current-video-segment-rerank';
+import {
+  buildCurrentVideoRelatedFavoritesHint,
+  emptyCurrentVideoRelatedFavoritesResponse,
+} from '../../shared/current-video-related-favorites';
 import {
   blockedTimestampJumpResponse,
   blockedTimestampReturnResponse,
@@ -364,6 +369,13 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
         }) as T,
       };
     }
+    case 'GET_CURRENT_VIDEO_RELATED_FAVORITES': {
+      const context = await getCurrentVideoContextForActiveTab();
+      return {
+        success: true,
+        data: await getCurrentVideoRelatedFavorites(context, request.params) as T,
+      };
+    }
     case 'REQUEST_CURRENT_VIDEO_SEGMENT_JUMP':
       return { success: true, data: await requestCurrentVideoSegmentJump(request.params) as T };
     case 'RETURN_CURRENT_VIDEO_SEGMENT_JUMP':
@@ -467,6 +479,41 @@ async function handleRequest<T>(request: BiliVizRequest): Promise<BiliVizRespons
     default:
       return { success: false, error: `Unknown action: ${request.action}` };
   }
+}
+
+async function getCurrentVideoRelatedFavorites(
+  context: CurrentVideoContextResult,
+  params?: Record<string, unknown>,
+): Promise<CurrentVideoRelatedFavoritesResponse> {
+  const now = Date.now();
+  if (context.kind !== 'video') {
+    return emptyCurrentVideoRelatedFavoritesResponse(context, now);
+  }
+
+  const hint = buildCurrentVideoRelatedFavoritesHint(context, {
+    question: typeof params?.question === 'string' ? params.question : null,
+    summaryHint: typeof params?.summaryHint === 'string' ? params.summaryHint : null,
+  });
+
+  if (!hint.query) {
+    return emptyCurrentVideoRelatedFavoritesResponse(context, now);
+  }
+
+  const requestedLimit = Number(params?.limit);
+  const limit = Number.isFinite(requestedLimit)
+    ? Math.max(1, Math.min(Math.floor(requestedLimit), 8))
+    : 5;
+  const favorites = await answerSmartFavoriteQuestion(hint.query, limit);
+
+  return {
+    status: 'ready',
+    contextTitle: context.title,
+    query: hint.query,
+    hintSourceLabels: hint.sourceLabels,
+    favorites,
+    generatedAt: now,
+    limitations: hint.limitations,
+  };
 }
 
 async function requestVideoKnowledgeJump(params: Record<string, unknown> | undefined): Promise<VideoKnowledgeJumpResponse> {

--- a/src/content/player-monitor/assistant-status.ts
+++ b/src/content/player-monitor/assistant-status.ts
@@ -11,6 +11,12 @@ import type {
   CurrentVideoTimestampJumpResponse,
   CurrentVideoTimestampReturnResponse,
 } from '../../shared/types/current-video-segment-retrieval';
+import type { CurrentVideoRelatedFavoritesResponse } from '../../shared/types/current-video-related-favorites';
+import type {
+  SmartFavoriteQaCitedVideo,
+  SmartFavoriteQaResponse,
+  SmartFavoriteQaSynthesisStatus,
+} from '../../shared/types/favorite';
 import type {
   VideoKnowledgeEvidenceSourceStatus,
   VideoKnowledgeNode,
@@ -534,6 +540,11 @@ interface AssistantState {
   segmentJumpLoading: boolean;
   segmentReturnAvailable: boolean;
   segmentReturnLoading: boolean;
+  relatedFavorites: CurrentVideoRelatedFavoritesResponse | null;
+  relatedFavoritesContextKey: string;
+  relatedFavoritesLoading: boolean;
+  relatedFavoritesError: string | null;
+  relatedFavoritesRequestId: number;
   subtitleRefreshing: boolean;
   subtitleStatus: string | null;
   subtitleRequestId: number;
@@ -564,6 +575,11 @@ const assistantState: AssistantState = {
   segmentJumpLoading: false,
   segmentReturnAvailable: false,
   segmentReturnLoading: false,
+  relatedFavorites: null,
+  relatedFavoritesContextKey: '',
+  relatedFavoritesLoading: false,
+  relatedFavoritesError: null,
+  relatedFavoritesRequestId: 0,
   subtitleRefreshing: false,
   subtitleStatus: null,
   subtitleRequestId: 0,
@@ -610,6 +626,10 @@ function updateAssistantContext(context: CurrentVideoContextResult): void {
     assistantState.segmentJumpLoading = false;
     assistantState.segmentReturnAvailable = false;
     assistantState.segmentReturnLoading = false;
+    assistantState.relatedFavorites = null;
+    assistantState.relatedFavoritesContextKey = '';
+    assistantState.relatedFavoritesError = null;
+    assistantState.relatedFavoritesLoading = false;
     assistantState.subtitleStatus = null;
   }
   assistantState.context = context;
@@ -703,6 +723,7 @@ function renderExpandedPanel(root: HTMLElement): void {
   if (context?.kind === 'video') {
     appendSegmentSearch(body, context);
     appendSummary(body);
+    appendRelatedFavorites(body, context);
     appendVideoKnowledge(body, context);
     appendSubtitleDiagnostics(body, context);
     appendVideoIdentity(body, context);
@@ -854,6 +875,179 @@ function appendSegmentSearch(parent: HTMLElement, context: CurrentVideoContext):
   }
 
   parent.appendChild(block);
+}
+
+function appendRelatedFavorites(parent: HTMLElement, context: CurrentVideoContext): void {
+  const block = section('相关收藏');
+  const head = block.querySelector('.bdc-assistant-section-head');
+  const hasFreshResult = Boolean(
+    assistantState.relatedFavorites
+    && assistantState.relatedFavoritesContextKey === assistantState.contextKey,
+  );
+  head?.appendChild(button(
+    assistantState.relatedFavoritesLoading
+      ? '查找中...'
+      : hasFreshResult
+        ? '刷新相关收藏'
+        : '查找相关收藏',
+    hasFreshResult
+      ? 'bdc-assistant-button bdc-assistant-button-quiet'
+      : 'bdc-assistant-button bdc-assistant-button-primary',
+    () => {
+      void loadCurrentVideoRelatedFavoritesFromPage(true);
+    },
+    assistantState.relatedFavoritesLoading || !context.bvid,
+  ));
+
+  appendText(
+    block,
+    'div',
+    'bdc-assistant-muted',
+    '来自当前已同步收藏，只作为延伸阅读；上方当前视频回答仍只引用当前视频字幕或本地节点证据。',
+  );
+
+  if (assistantState.relatedFavoritesError) {
+    const error = appendText(block, 'div', 'bdc-assistant-retrieval-status', assistantState.relatedFavoritesError);
+    error.style.color = '#ffcf8a';
+  }
+
+  if (assistantState.relatedFavoritesLoading) {
+    const loading = appendText(block, 'div', 'bdc-assistant-retrieval-status', '正在用当前视频线索查找已同步收藏...');
+    loading.style.color = '#c8e6ff';
+  }
+
+  if (!hasFreshResult) {
+    appendText(
+      block,
+      'div',
+      'bdc-assistant-subtitle-detail',
+      '会使用当前视频标题、UP、简介摘要，以及你在上方输入的问题作为线索；不会读取完整收藏库、历史、关注或本地敏感文件。',
+    );
+    parent.appendChild(block);
+    return;
+  }
+
+  appendRelatedFavoritesResult(block, assistantState.relatedFavorites as CurrentVideoRelatedFavoritesResponse);
+  parent.appendChild(block);
+}
+
+function appendRelatedFavoritesResult(
+  parent: HTMLElement,
+  result: CurrentVideoRelatedFavoritesResponse,
+): void {
+  const qa = result.favorites;
+  if (result.status !== 'ready' || !qa) {
+    const status = appendText(parent, 'div', 'bdc-assistant-retrieval-status', safeVisibleText(result.limitations[0] ?? '当前没有可用的相关收藏线索。'));
+    status.style.color = '#ffcf8a';
+    return;
+  }
+
+  const status = appendText(
+    parent,
+    'div',
+    'bdc-assistant-retrieval-status',
+    safeVisibleText(relatedFavoritesNotice(qa)),
+  );
+  status.style.color = relatedFavoritesStatusColor(qa);
+
+  const meta = document.createElement('div');
+  meta.className = 'bdc-assistant-candidate-meta';
+  appendBadge(meta, '来源：当前已同步收藏');
+  appendBadge(meta, `引用收藏 ${qa.citedVideos.length} 条`);
+  if (result.hintSourceLabels.length > 0) {
+    appendBadge(meta, `线索：${result.hintSourceLabels.slice(0, 3).join('、')}`);
+  }
+  appendBadge(meta, `AI ${relatedFavoritesAiStatusLabel(qa.synthesis?.status)}`);
+  parent.appendChild(meta);
+
+  const coverage = relatedFavoritesCoverageNotice(qa);
+  if (coverage) {
+    appendText(parent, 'div', 'bdc-assistant-subtitle-detail', safeVisibleText(coverage));
+  }
+
+  if (qa.citedVideos.length === 0) {
+    appendText(parent, 'div', 'bdc-assistant-answer-text', safeVisibleText(qa.answer));
+    appendRelatedFavoritesLimitations(parent, result, qa);
+    appendRelatedFavoritesSettingsLink(parent, qa);
+    return;
+  }
+
+  const list = document.createElement('div');
+  list.className = 'bdc-assistant-candidate-list';
+  for (const [index, video] of qa.citedVideos.slice(0, 5).entries()) {
+    list.appendChild(relatedFavoriteCard(video, index));
+  }
+  parent.appendChild(list);
+  appendRelatedFavoritesLimitations(parent, result, qa);
+  appendRelatedFavoritesSettingsLink(parent, qa);
+}
+
+function relatedFavoriteCard(video: SmartFavoriteQaCitedVideo, index: number): HTMLElement {
+  const card = document.createElement('article');
+  card.className = 'bdc-assistant-candidate-card';
+
+  const head = document.createElement('div');
+  head.className = 'bdc-assistant-candidate-head';
+  appendText(head, 'div', 'bdc-assistant-candidate-title', `收藏 ${index + 1} · ${safeVisibleText(video.title)}`);
+  appendText(
+    head,
+    'div',
+    'bdc-assistant-candidate-strength',
+    `证据强度 ${relatedFavoriteConfidenceLabel(video.confidence)}`,
+  );
+  card.appendChild(head);
+
+  const meta = document.createElement('div');
+  meta.className = 'bdc-assistant-candidate-meta';
+  if (video.authorName) appendBadge(meta, `UP ${safeVisibleText(video.authorName)}`);
+  if (video.folderTitle) appendBadge(meta, `收藏夹 ${safeVisibleText(video.folderTitle)}`);
+  if (video.smartPath.length > 0) appendBadge(meta, `智能路径 ${safeVisibleText(video.smartPath.slice(0, 3).join(' / '))}`);
+  card.appendChild(meta);
+
+  appendText(card, 'div', 'bdc-assistant-candidate-evidence', safeVisibleText(video.evidence));
+
+  if (video.matchReasons.length > 0) {
+    const reasons = document.createElement('ul');
+    reasons.className = 'bdc-assistant-candidate-reasons';
+    for (const reason of video.matchReasons.slice(0, 3)) {
+      const item = document.createElement('li');
+      item.textContent = safeVisibleText(reason);
+      reasons.appendChild(item);
+    }
+    card.appendChild(reasons);
+  }
+
+  if (video.link) {
+    const link = document.createElement('a');
+    link.className = 'bdc-assistant-link bdc-assistant-button-quiet';
+    link.href = video.link;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = '打开收藏视频';
+    card.appendChild(link);
+  }
+
+  return card;
+}
+
+function appendRelatedFavoritesLimitations(
+  parent: HTMLElement,
+  result: CurrentVideoRelatedFavoritesResponse,
+  qa: SmartFavoriteQaResponse,
+): void {
+  const notes = [
+    ...result.limitations,
+    ...qa.status.notes.slice(0, 2),
+  ].map(safeVisibleText);
+  if (notes.length > 0) {
+    appendText(parent, 'div', 'bdc-assistant-subtitle-detail', notes.join(' '));
+  }
+}
+
+function appendRelatedFavoritesSettingsLink(parent: HTMLElement, qa: SmartFavoriteQaResponse): void {
+  if (needsAiSettingsLink(qa.synthesis?.status ?? '')) {
+    parent.appendChild(dashboardLink('前往设置', '#settings'));
+  }
 }
 
 function appendSegmentRetrievalResult(
@@ -1342,6 +1536,49 @@ function appendVideoKnowledgeLimitations(parent: HTMLElement, knowledge: VideoKn
   const limitations = knowledge.limitations.slice(0, 2).map(safeVisibleText).join(' ');
   if (limitations) {
     appendText(parent, 'div', 'bdc-assistant-subtitle-detail', limitations);
+  }
+}
+
+async function loadCurrentVideoRelatedFavoritesFromPage(force: boolean): Promise<void> {
+  if (assistantState.context?.kind !== 'video') return;
+  if (assistantState.relatedFavoritesLoading) return;
+  if (
+    !force
+    && assistantState.relatedFavorites
+    && assistantState.relatedFavoritesContextKey === assistantState.contextKey
+  ) {
+    return;
+  }
+
+  const requestId = assistantState.relatedFavoritesRequestId + 1;
+  const contextKey = assistantState.contextKey;
+  assistantState.relatedFavoritesRequestId = requestId;
+  assistantState.relatedFavoritesLoading = true;
+  assistantState.relatedFavoritesError = null;
+  renderAssistantShell();
+
+  try {
+    const summaryHint = assistantState.summary
+      && assistantState.summaryContextKey === contextKey
+      && (assistantState.summary.sourceTier === 'description_summary' || assistantState.summary.sourceTier === 'metadata_summary')
+      ? assistantState.summary.summary
+      : null;
+    const result = await sendRuntimeRequest<CurrentVideoRelatedFavoritesResponse>('GET_CURRENT_VIDEO_RELATED_FAVORITES', {
+      question: assistantState.segmentQuery,
+      summaryHint,
+      limit: 5,
+    });
+    if (assistantState.relatedFavoritesRequestId !== requestId || assistantState.contextKey !== contextKey) return;
+    assistantState.relatedFavorites = result;
+    assistantState.relatedFavoritesContextKey = contextKey;
+  } catch {
+    if (assistantState.relatedFavoritesRequestId !== requestId) return;
+    assistantState.relatedFavoritesError = '相关收藏查找失败：请确认当前 B 站视频页仍然打开，并稍后重试。';
+  } finally {
+    if (assistantState.relatedFavoritesRequestId === requestId) {
+      assistantState.relatedFavoritesLoading = false;
+      renderAssistantShell();
+    }
   }
 }
 
@@ -1969,6 +2206,79 @@ function qaSourceStateLabel(result: CurrentVideoSegmentRetrievalResult): string 
   if (result.qa.sourceState.hasOnlyMetadataHints) return '仅弱提示';
   if (!result.qa.sourceState.contextFresh) return '上下文需刷新';
   return '缺少字幕正文';
+}
+
+function relatedFavoritesNotice(qa: SmartFavoriteQaResponse): string {
+  if (qa.citedVideos.length > 0) {
+    return `在当前已同步收藏中找到 ${qa.citedVideos.length} 个相关收藏，可作为延伸阅读。`;
+  }
+  if (qa.answerType === 'insufficient_evidence') {
+    return '当前收藏检索只能使用收藏元数据和智能索引，未找到足够可引用的相关收藏。';
+  }
+  return '当前已同步收藏中暂未找到匹配收藏。';
+}
+
+function relatedFavoritesCoverageNotice(qa: SmartFavoriteQaResponse): string {
+  if (!qa.status.syncCoverage.complete) {
+    return '收藏同步可能不完整，结果只覆盖当前已同步收藏。';
+  }
+  if (qa.status.indexCoverage.indexMissing) {
+    return '智能索引缺失，本次使用本地元数据结果。';
+  }
+  if (qa.status.indexCoverage.staleIndex) {
+    return '智能索引可能过期或不完整，本次仍保留本地元数据结果。';
+  }
+  if (qa.synthesis?.status === 'disabled') {
+    return 'AI 收藏问答未启用，已保留本地引用结果。';
+  }
+  if (qa.synthesis?.status === 'not_configured') {
+    return 'AI 收藏问答尚未配置，已保留本地引用结果。';
+  }
+  if (qa.synthesis?.status === 'failed' || qa.synthesis?.status === 'rejected') {
+    return 'AI 整理未采用，已保留本地引用结果。';
+  }
+  return '';
+}
+
+function relatedFavoritesStatusColor(qa: SmartFavoriteQaResponse): string {
+  switch (qa.status.kind) {
+    case 'ok':
+      return '#a0e7a0';
+    case 'no_result':
+      return '#c8e6ff';
+    case 'low_confidence':
+    case 'stale_index':
+    case 'incomplete_sync':
+    case 'index_missing':
+    case 'insufficient_evidence':
+    default:
+      return '#ffcf8a';
+  }
+}
+
+function relatedFavoritesAiStatusLabel(status: SmartFavoriteQaSynthesisStatus | undefined): string {
+  switch (status) {
+    case 'generated':
+      return '已整理';
+    case 'disabled':
+      return '未启用';
+    case 'not_configured':
+      return '未配置';
+    case 'failed':
+      return '请求失败';
+    case 'rejected':
+      return '未采用';
+    case 'local_fallback':
+      return '本地引用';
+    default:
+      return '未请求';
+  }
+}
+
+function relatedFavoriteConfidenceLabel(value: SmartFavoriteQaCitedVideo['confidence']): string {
+  if (value === 'high') return '高';
+  if (value === 'medium') return '中';
+  return '低';
 }
 
 function escapeRegExp(value: string): string {

--- a/src/shared/current-video-related-favorites.ts
+++ b/src/shared/current-video-related-favorites.ts
@@ -1,0 +1,92 @@
+import type { CurrentVideoContext, CurrentVideoContextResult } from './types/current-video-context';
+import type {
+  CurrentVideoRelatedFavoritesHint,
+  CurrentVideoRelatedFavoritesResponse,
+} from './types/current-video-related-favorites';
+
+const MAX_QUESTION_HINT_LENGTH = 140;
+const MAX_TITLE_HINT_LENGTH = 140;
+const MAX_AUTHOR_HINT_LENGTH = 80;
+const MAX_PART_HINT_LENGTH = 100;
+const MAX_SUMMARY_HINT_LENGTH = 180;
+const MAX_QUERY_LENGTH = 520;
+
+export interface BuildCurrentVideoRelatedFavoritesHintOptions {
+  question?: string | null;
+  summaryHint?: string | null;
+}
+
+export function buildCurrentVideoRelatedFavoritesHint(
+  context: CurrentVideoContext,
+  options: BuildCurrentVideoRelatedFavoritesHintOptions = {},
+): CurrentVideoRelatedFavoritesHint {
+  const title = cleanText(context.title, MAX_TITLE_HINT_LENGTH);
+  const author = cleanText(context.authorName, MAX_AUTHOR_HINT_LENGTH);
+  const partTitle = context.currentPart.title && normalizeComparable(context.currentPart.title) !== normalizeComparable(context.title)
+    ? cleanText(context.currentPart.title, MAX_PART_HINT_LENGTH)
+    : '';
+  const summary = cleanText(options.summaryHint || context.description.text, MAX_SUMMARY_HINT_LENGTH);
+  const question = cleanText(options.question, MAX_QUESTION_HINT_LENGTH);
+
+  const parts = uniqueHintParts([
+    { label: '你的问题', value: question },
+    { label: '当前视频标题', value: title },
+    { label: 'UP 名称', value: author },
+    { label: '当前分 P 标题', value: partTitle },
+    { label: '简介摘要', value: summary },
+  ]);
+
+  return {
+    query: cleanText(parts.map(part => part.value).join(' '), MAX_QUERY_LENGTH),
+    sourceLabels: parts.map(part => part.label),
+    limitations: [
+      '相关收藏只来自当前已同步收藏，作为延伸阅读，不作为当前视频回答依据。',
+      '检索线索只使用当前视频可见元数据、简介摘要和你的问题，不读取历史、关注或本地敏感文件。',
+    ],
+  };
+}
+
+export function emptyCurrentVideoRelatedFavoritesResponse(
+  context: CurrentVideoContextResult,
+  now = Date.now(),
+): CurrentVideoRelatedFavoritesResponse {
+  const title = context.kind === 'video' ? context.title : null;
+  return {
+    status: context.kind === 'video' ? 'no_hint' : 'no_context',
+    contextTitle: title,
+    query: '',
+    hintSourceLabels: [],
+    favorites: null,
+    generatedAt: now,
+    limitations: context.kind === 'video'
+      ? ['当前视频缺少可用于检索收藏的标题、UP、简介或问题线索。']
+      : ['请在 B 站视频页内使用相关收藏。'],
+  };
+}
+
+interface HintPart {
+  label: string;
+  value: string;
+}
+
+function uniqueHintParts(parts: HintPart[]): HintPart[] {
+  const seen = new Set<string>();
+  const result: HintPart[] = [];
+  for (const part of parts) {
+    const comparable = normalizeComparable(part.value);
+    if (!comparable || seen.has(comparable)) continue;
+    seen.add(comparable);
+    result.push(part);
+  }
+  return result;
+}
+
+function cleanText(value: string | null | undefined, maxLength: number): string {
+  const normalized = String(value ?? '').replace(/\s+/g, ' ').trim();
+  if (!normalized) return '';
+  return normalized.length <= maxLength ? normalized : `${normalized.slice(0, maxLength - 1)}…`;
+}
+
+function normalizeComparable(value: string | null | undefined): string {
+  return String(value ?? '').replace(/\s+/g, '').toLocaleLowerCase();
+}

--- a/src/shared/types/current-video-related-favorites.ts
+++ b/src/shared/types/current-video-related-favorites.ts
@@ -1,0 +1,19 @@
+import type { SmartFavoriteQaResponse } from './favorite';
+
+export type CurrentVideoRelatedFavoritesStatus = 'ready' | 'no_context' | 'no_hint';
+
+export interface CurrentVideoRelatedFavoritesHint {
+  query: string;
+  sourceLabels: string[];
+  limitations: string[];
+}
+
+export interface CurrentVideoRelatedFavoritesResponse {
+  status: CurrentVideoRelatedFavoritesStatus;
+  contextTitle: string | null;
+  query: string;
+  hintSourceLabels: string[];
+  favorites: SmartFavoriteQaResponse | null;
+  generatedAt: number;
+  limitations: string[];
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,6 +1,7 @@
 export * from './watch-event';
 export * from './video-info';
 export * from './current-video-context';
+export * from './current-video-related-favorites';
 export * from './current-video-transcript';
 export * from './current-video-segment-retrieval';
 export * from './analytics';

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -34,6 +34,7 @@ import type {
   CurrentVideoTimestampJumpResponse,
   CurrentVideoTimestampReturnResponse,
 } from './current-video-segment-retrieval';
+import type { CurrentVideoRelatedFavoritesResponse } from './current-video-related-favorites';
 import type { CurrentVideoSummaryResult } from './current-video-summary';
 import type { VideoKnowledgeJumpResponse, VideoKnowledgeResult } from './video-knowledge';
 import type { HistoryTailProbeReport } from './history-tail-probe';
@@ -73,6 +74,7 @@ export type RequestAction =
   | 'GET_CURRENT_VIDEO_SUMMARY'
   | 'GET_VIDEO_KNOWLEDGE'
   | 'SEARCH_CURRENT_VIDEO_SEGMENTS'
+  | 'GET_CURRENT_VIDEO_RELATED_FAVORITES'
   | 'REQUEST_CURRENT_VIDEO_SEGMENT_JUMP'
   | 'RETURN_CURRENT_VIDEO_SEGMENT_JUMP'
   | 'REQUEST_VIDEO_KNOWLEDGE_JUMP'
@@ -197,6 +199,7 @@ export type CurrentVideoTranscriptEvidenceResponse = BiliVizResponse<CurrentVide
 export type CurrentVideoSummaryResponse = BiliVizResponse<CurrentVideoSummaryResult>;
 export type VideoKnowledgeResponse = BiliVizResponse<VideoKnowledgeResult>;
 export type CurrentVideoSegmentRetrievalResponse = BiliVizResponse<CurrentVideoSegmentRetrievalResult>;
+export type CurrentVideoRelatedFavoritesMessageResponse = BiliVizResponse<CurrentVideoRelatedFavoritesResponse>;
 export type CurrentVideoTimestampJumpMessageResponse = BiliVizResponse<CurrentVideoTimestampJumpResponse>;
 export type CurrentVideoTimestampReturnMessageResponse = BiliVizResponse<CurrentVideoTimestampReturnResponse>;
 export type VideoKnowledgeJumpMessageResponse = BiliVizResponse<VideoKnowledgeJumpResponse>;

--- a/tests/current-video-qa.test.ts
+++ b/tests/current-video-qa.test.ts
@@ -8,6 +8,7 @@ import {
   answerCurrentVideoQuestion,
   buildCurrentVideoQaAiPayload,
 } from '../src/shared/current-video-qa.ts';
+import { buildCurrentVideoRelatedFavoritesHint } from '../src/shared/current-video-related-favorites.ts';
 import { searchCurrentVideoSegments } from '../src/shared/current-video-segment-retrieval.ts';
 import type { CurrentVideoContext } from '../src/shared/types/current-video-context.ts';
 import type { CurrentVideoTranscriptSegment } from '../src/shared/types/current-video-transcript.ts';
@@ -210,6 +211,26 @@ test('audits current-video QA AI payload allowlist and rejects sensitive fields'
   assert.match(report, /\$\.video\.authorMid/);
   assert.match(report, /Cookie\/login token/);
   assert.match(report, /C:\\Users\\LittleNub\\Desktop\\Key\.txt/);
+});
+
+test('keeps related favorites hints separate from current-video answer payload', () => {
+  const context = withTranscriptEvidence(videoContext({
+    title: 'Subagent workflow demo',
+    descriptionText: 'Visible description about agent handoff and saved learning videos.',
+  }));
+  const local = localQaResult(context);
+  const relatedHint = buildCurrentVideoRelatedFavoritesHint(context, {
+    question: 'Find related saved subagent videos',
+  });
+  const built = buildCurrentVideoQaAiPayload(context, local);
+  const rawPayload = JSON.stringify(built.payload);
+
+  assert.match(relatedHint.query, /Find related saved subagent videos/);
+  assert.match(relatedHint.query, /Subagent workflow demo/);
+  assert.equal('relatedFavorites' in built.payload, false);
+  assert.equal('citedVideos' in built.payload, false);
+  assert.doesNotMatch(rawPayload, /saved learning videos|related saved|favorite|favorites|收藏|itemKey|mediaId/i);
+  assert.equal(rawPayload.includes(relatedHint.query), false);
 });
 
 function localQaResult(context: CurrentVideoContext) {

--- a/tests/current-video-related-favorites.mock.html
+++ b/tests/current-video-related-favorites.mock.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <title>Current Video Related Favorites Mock QA</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --panel: rgba(255, 255, 255, 0.055);
+      --line: rgba(255, 255, 255, 0.12);
+      --text: #f4f7fb;
+      --muted: #aeb4c4;
+      --green: #a0e7a0;
+      --blue: #c8e6ff;
+      --warn: #ffcf8a;
+      --pink: #fb7299;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      width: 390px;
+      background: #181a2b;
+      color: var(--text);
+      font-family: Arial, "Microsoft YaHei", sans-serif;
+    }
+
+    main {
+      display: grid;
+      gap: 10px;
+      padding: 12px;
+    }
+
+    section,
+    article {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--panel);
+      padding: 10px;
+    }
+
+    h1 {
+      margin: 0 0 8px;
+      color: #ffd6e2;
+      font-size: 13px;
+      line-height: 1.35;
+    }
+
+    .muted,
+    .detail {
+      color: var(--muted);
+      font-size: 11px;
+      line-height: 1.5;
+    }
+
+    .status {
+      color: var(--green);
+      font-size: 11px;
+      line-height: 1.5;
+    }
+
+    .status.warn {
+      color: var(--warn);
+    }
+
+    .answer {
+      margin-top: 6px;
+      color: var(--text);
+      font-size: 12px;
+      line-height: 1.55;
+    }
+
+    .badges {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 5px;
+      margin-top: 7px;
+    }
+
+    .badge {
+      border-radius: 6px;
+      background: rgba(251, 114, 153, 0.16);
+      color: #ffd6e2;
+      font-size: 11px;
+      font-weight: 700;
+      padding: 4px 6px;
+    }
+
+    .cards {
+      display: grid;
+      gap: 8px;
+      margin-top: 8px;
+    }
+
+    .title-row {
+      display: flex;
+      justify-content: space-between;
+      gap: 8px;
+    }
+
+    .title {
+      min-width: 0;
+      color: #fff;
+      font-size: 12px;
+      font-weight: 800;
+      line-height: 1.35;
+    }
+
+    .strength {
+      flex: 0 0 auto;
+      color: var(--green);
+      font-size: 11px;
+      font-weight: 700;
+    }
+
+    .evidence {
+      margin-top: 7px;
+      color: var(--blue);
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    a {
+      display: inline-flex;
+      margin-top: 8px;
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      border-radius: 6px;
+      color: var(--blue);
+      font-size: 12px;
+      font-weight: 700;
+      padding: 6px 9px;
+      text-decoration: none;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section data-testid="current-video-answer">
+      <h1>当前视频问答</h1>
+      <div class="status">回答：有证据 · 证据强度 高 86%</div>
+      <p class="answer">有。当前视频证据里找到 1 个可引用片段，回答只基于当前视频字幕证据。</p>
+      <div class="badges">
+        <span class="badge">当前视频证据</span>
+        <span class="badge">引用片段 1 条</span>
+        <span class="badge">AI 回答 本地引用</span>
+      </div>
+    </section>
+
+    <section data-testid="related-favorites">
+      <h1>相关收藏</h1>
+      <p class="muted">来自当前已同步收藏，只作为延伸阅读；上方当前视频回答仍只引用当前视频字幕或本地节点证据。</p>
+      <div class="status warn">收藏同步可能不完整，结果只覆盖当前已同步收藏。</div>
+      <div class="badges">
+        <span class="badge">来源：当前已同步收藏</span>
+        <span class="badge">引用收藏 2 条</span>
+        <span class="badge">线索：当前视频标题、UP 名称、你的问题</span>
+      </div>
+      <div class="cards">
+        <article>
+          <div class="title-row">
+            <div class="title">收藏 1 · Subagent workflow guide</div>
+            <div class="strength">证据强度 高</div>
+          </div>
+          <div class="detail">UP Agent Lab · 收藏夹 Agent research · 智能路径 AI / Workflow</div>
+          <div class="evidence">本地词项命中标题、智能关键词：subagent、handoff。</div>
+          <a href="https://www.bilibili.com/video/BV1RelatedFav01" target="_blank" rel="noopener noreferrer">打开收藏视频</a>
+        </article>
+        <article>
+          <div class="title-row">
+            <div class="title">收藏 2 · Agent handoff checklist</div>
+            <div class="strength">证据强度 中</div>
+          </div>
+          <div class="detail">UP Local Notes · 收藏夹 Agent research</div>
+          <div class="evidence">本地词项命中简介和标签：workflow、handoff。</div>
+          <a href="https://www.bilibili.com/video/BV1RelatedFav02" target="_blank" rel="noopener noreferrer">打开收藏视频</a>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/tests/smart-favorites-qa.test.ts
+++ b/tests/smart-favorites-qa.test.ts
@@ -2,12 +2,14 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import type { AiConfig, UserConfig } from '../src/shared/types/config.ts';
 import type { FavoriteFolder, FavoriteFolderSyncDiagnostic, FavoriteItem, SmartFavoriteIndex } from '../src/shared/types/favorite.ts';
+import type { CurrentVideoContext } from '../src/shared/types/current-video-context.ts';
 import {
   assertAssistantPayloadAudit,
   auditAssistantPayload,
   smartFavoriteQaPayloadContract,
 } from '../src/shared/assistant-payload-audit.ts';
 import { buildSmartFavoriteQaResponse } from '../src/background/favorites/qa-core.ts';
+import { buildCurrentVideoRelatedFavoritesHint } from '../src/shared/current-video-related-favorites.ts';
 import {
   buildSmartFavoriteQaAiPayload,
   synthesizeSmartFavoriteQaAnswerFromLocal,
@@ -115,6 +117,44 @@ test('scopes answers to currently synced data when sync diagnostics are incomple
   assert.equal(response.status.syncCoverage.problemFolders, 1);
   assert.match(response.answer, /当前已同步收藏中/);
   assert.match(response.status.notes.join(' '), /索引覆盖：B站报告 20 条，本地保存 1 条，已索引 0 条，失败 0 条，待索引 1 条/);
+});
+
+test('current-video related favorites hints retrieve cited videos from currently synced favorites only', () => {
+  const context = makeCurrentVideoContext({
+    title: 'Subagent workflow demo',
+    authorName: 'Agent Lab',
+    descriptionText: 'A visible intro about agent orchestration and project handoff.',
+  });
+  const hint = buildCurrentVideoRelatedFavoritesHint(context, {
+    question: 'Find related subagent favorites',
+  });
+  const item = makeFavoriteItem(1, {
+    title: 'Subagent workflow guide',
+    folderTitle: 'Agent research',
+    authorName: 'Agent Lab',
+    intro: 'Project handoff and agent orchestration notes.',
+    tags: ['agent', 'workflow'],
+  });
+  const response = buildSmartFavoriteQaResponse({
+    query: hint.query,
+    items: [item],
+    indexes: new Map([[item.itemKey, makeIndex(item, {
+      keywords: ['subagent', 'handoff'],
+      summary: 'Agent orchestration and handoff guide.',
+    })]]),
+    folders: [makeFolder({ lastSyncDiagnostic: makeIncompleteDiagnostic() })],
+  });
+  const rawHint = JSON.stringify(hint);
+
+  assert.match(hint.query, /Subagent workflow demo/);
+  assert.match(hint.query, /Agent Lab/);
+  assert.match(hint.query, /Find related subagent favorites/);
+  assert.deepEqual(hint.sourceLabels.slice(0, 3), ['你的问题', '当前视频标题', 'UP 名称']);
+  assert.doesNotMatch(rawHint, /authorMid|mediaId|Cookie|Key\.txt|BV1RelatedCurrent/i);
+  assert.equal(response.status.kind, 'incomplete_sync');
+  assert.equal(response.status.syncCoverage.complete, false);
+  assert.equal(response.citedVideos.length, 1);
+  assert.equal(response.citedVideos[0].bvid, item.bvid);
 });
 
 test('reports index coverage counts for Bilibili reported, locally stored, indexed, failed, and pending items', () => {
@@ -409,6 +449,49 @@ function makeConfig(overrides: {
     dynamicBill: {
       aiExplanationsEnabled: false,
     },
+  };
+}
+
+function makeCurrentVideoContext(overrides: {
+  title?: string;
+  authorName?: string;
+  descriptionText?: string | null;
+} = {}): CurrentVideoContext {
+  const descriptionText = 'descriptionText' in overrides
+    ? overrides.descriptionText
+    : 'A visible current-video intro.';
+  return {
+    kind: 'video',
+    url: 'https://www.bilibili.com/video/BV1RelatedCurrent',
+    collectedAt: 1_000,
+    bvid: 'BV1RelatedCurrent',
+    aid: 123,
+    cid: 456,
+    title: overrides.title ?? 'Current related video',
+    authorName: overrides.authorName ?? 'Current UP',
+    authorMid: 789,
+    durationSeconds: 600,
+    currentPart: {
+      page: 1,
+      title: 'Main part',
+      total: 1,
+    },
+    parts: [{ page: 1, cid: 456, title: 'Main part', durationSeconds: 600 }],
+    chapters: [],
+    description: {
+      availability: descriptionText ? 'available' : 'unavailable',
+      text: descriptionText,
+      length: descriptionText?.length ?? null,
+    },
+    sources: {
+      metadata: 'available',
+      description: descriptionText ? 'available' : 'unavailable',
+      pages: 'available',
+      chapters: 'unknown',
+      transcript: 'unavailable',
+      contentText: 'unavailable',
+    },
+    warnings: [],
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds an independent current-video "related favorites" section backed by Smart Favorites QA/retrieval.
- Builds bounded retrieval hints from current-video metadata and the user's question, then returns top-N videos from currently synced favorites.
- Keeps related favorites as extension reading only; current-video answers still cite only current-video evidence.

## Payload and privacy
- Does not upload full favorites libraries, folder structures, history, following, feedback, cookies, keys, browser profiles, or local login state.
- Hint construction excludes raw BVID/CID/authorMid/mediaId and other internal IDs.
- Ordinary UI copy says results come from currently synced favorites and avoids internal action names or sensitive field names.

## Validation
- npm run test:favorites
- node --test tests/current-video-qa.test.ts tests/current-video-segment-retrieval.test.ts
- npm run typecheck
- npm run build
- git diff --check
- git diff --cached --check
- forbidden copy scans for disallowed product terms and internal/sensitive UI strings
- static mock QA for current-video answer plus related favorites coexistence

## Notes
- Browser file URL mock navigation was blocked by the in-app browser URL policy, so visual QA used the committed static mock plus DOM/text checks.
