### PR TITLE
[codex] Implement real random blind box candidates

### DIFF
--- a/dashboard/modules/experiments/ExperimentsPage.tsx
+++ b/dashboard/modules/experiments/ExperimentsPage.tsx
@@ -58,9 +58,9 @@ export function ExperimentsPage() {
           borderRadius: '16px',
           padding: '16px',
         }}>
-          <div style={{ color: '#FFFFFF', fontSize: '18px', fontWeight: 700, marginBottom: '8px' }}>本地视频盲盒</div>
+          <div style={{ color: '#FFFFFF', fontSize: '18px', fontWeight: 700, marginBottom: '8px' }}>视频盲盒</div>
           <div style={{ color: '#D4D8E8', fontSize: '13px', lineHeight: 1.7 }}>
-            这里只从本地历史和本地收藏里挑具体视频，不假装 B 站推荐排序，也不会写回 B 站。
+            随机探索会从真实 B 站相关视频候选池里随机抽取；其它盲盒仍只使用本地历史和本地收藏证据。这里不做推荐排序，也不会写回 B 站。
           </div>
           <div style={{ color: '#8F97B5', fontSize: '12px', marginTop: '8px' }}>
             最近生成时间：{new Date(data.generatedAt).toLocaleString('zh-CN')}
@@ -76,6 +76,11 @@ export function ExperimentsPage() {
             const isRevealed = revealed[box.id] === true;
             const isReady = box.state === 'ready';
             const accent = CARD_ACCENT[box.id];
+            const statusLabel = isReady
+              ? '可揭晓'
+              : box.id === 'random_explore'
+                ? '候选源不可用'
+                : '本地证据不足';
             return (
               <article
                 key={box.id}
@@ -105,7 +110,7 @@ export function ExperimentsPage() {
                     fontSize: '11px',
                     whiteSpace: 'nowrap',
                   }}>
-                    {isReady ? '可揭晓' : '本地证据不足'}
+                    {statusLabel}
                   </span>
                 </div>
 
@@ -123,8 +128,10 @@ export function ExperimentsPage() {
                   }}>
                     <div style={{ color: '#DCE2F8', fontSize: '13px', lineHeight: 1.7 }}>
                       {isReady
-                        ? '这盒里是一个可以直接打开的具体视频。揭晓后会显示标题、UP 主、来源、理由和本地证据。'
-                        : '这盒不会拿泛泛建议充数。揭晓后只会告诉你为什么本地证据还不够。'}
+                        ? '这盒里是一个可以直接打开的具体视频。揭晓后会显示标题、UP 主、来源、理由和证据。'
+                        : box.id === 'random_explore'
+                          ? '这盒不会显示空卡，也不会用本地库存冒充真实候选。揭晓后会说明候选源为什么暂时不可用。'
+                          : '这盒不会拿泛泛建议充数。揭晓后只会告诉你为什么本地证据还不够。'}
                     </div>
                     <button
                       type="button"
@@ -207,7 +214,7 @@ export function ExperimentsPage() {
         }}>
           <div style={{ color: '#FFFFFF', fontSize: '13px', fontWeight: 600, marginBottom: '8px' }}>说明</div>
           <div style={{ color: '#A8B0CE', fontSize: '12px', lineHeight: 1.7 }}>
-            盲盒只使用本地历史、收藏和收藏分类路径来挑视频。打开动作只会新开一个 B 站视频页，不会回写收藏、关注或观看状态。
+            随机探索只使用少量本地 BV 号作为种子，请求公开相关视频候选后在本地随机抽取；不会上传完整历史、收藏、关注或反馈。打开动作只会新开一个 B 站视频页，不会回写收藏、关注或观看状态。
           </div>
         </section>
       </div>

--- a/src/background/analytics/suggestions.ts
+++ b/src/background/analytics/suggestions.ts
@@ -2,17 +2,19 @@ import type {
   ExperimentBlindBox,
   ExperimentBlindBoxId,
   ExperimentData,
+  ExperimentRealCandidatePool,
   ExperimentVideoCandidate,
 } from '../../shared/types/analytics';
 import type { FavoriteItem, SmartFavoriteIndex } from '../../shared/types/favorite';
 import type { WatchHistoryRecord } from '../../shared/types/watch-event';
+import type { RelatedVideoSeed } from '../api/video-blind-box-candidates.ts';
 import { db } from '../storage/db.ts';
 import { getFavoriteItems, getSmartFavoriteIndexMap } from '../storage/favorite-repo.ts';
 
 const DAY_MS = 86_400_000;
 const RECENT_ACTIVITY_DAYS = 45;
 const RECENT_VIDEO_BLOCK_DAYS = 90;
-const RANDOM_VIDEO_BLOCK_DAYS = 14;
+const RANDOM_RELATED_SEED_LIMIT = 3;
 const MIN_INTEREST_RECORDS = 4;
 const MIN_INTEREST_POSITIVE_RECORDS = 2;
 const POSITIVE_COMPLETION = 0.75;
@@ -29,6 +31,7 @@ interface BlindBoxContext {
   watchCountByBvid: Map<string, number>;
   lastWatchByBvid: Map<string, number>;
   usedBvids: Set<string>;
+  randomExplorePool?: ExperimentRealCandidatePool;
 }
 
 interface FavoriteTaste {
@@ -36,21 +39,20 @@ interface FavoriteTaste {
   matchLabels: string[];
 }
 
-interface RandomPoolEntry {
-  source: string;
-  reason: string;
-  evidence: string[];
-  video: ExperimentVideoCandidate;
-}
-
 export async function getExperimentData(): Promise<ExperimentData> {
+  const nowMs = Date.now();
   const [records, favorites, smartIndexByItemKey] = await Promise.all([
     db.watchHistory.toArray(),
     getFavoriteItems(),
     getSmartFavoriteIndexMap(),
   ]);
+  const { fetchRelatedVideoCandidates } = await import('../api/video-blind-box-candidates.ts');
+  const randomExplorePool = await fetchRelatedVideoCandidates(
+    selectRelatedVideoSeeds(records, nowMs),
+    { seedLimit: RANDOM_RELATED_SEED_LIMIT },
+  );
 
-  return buildExperimentData(records, favorites, smartIndexByItemKey, Date.now());
+  return buildExperimentData(records, favorites, smartIndexByItemKey, nowMs, randomExplorePool);
 }
 
 export function buildExperimentData(
@@ -58,6 +60,7 @@ export function buildExperimentData(
   favorites: FavoriteItem[],
   smartIndexByItemKey: Map<string, SmartFavoriteIndex>,
   nowMs = Date.now(),
+  randomExplorePool?: ExperimentRealCandidatePool,
 ): ExperimentData {
   const recentCutoffMs = nowMs - RECENT_ACTIVITY_DAYS * DAY_MS;
   const recentRecords = records.filter(record => toEpochMs(record.viewAt) >= recentCutoffMs);
@@ -79,6 +82,7 @@ export function buildExperimentData(
     watchCountByBvid: countByBvid(records),
     lastWatchByBvid: buildLastWatchByBvid(records),
     usedBvids: new Set<string>(),
+    randomExplorePool,
   };
 
   return {
@@ -354,76 +358,105 @@ function buildReviveInterestBox(ctx: BlindBoxContext): ExperimentBlindBox {
 }
 
 function buildRandomExploreBox(ctx: BlindBoxContext): ExperimentBlindBox {
-  const pool = buildRandomPool(ctx)
-    .filter(entry => !ctx.usedBvids.has(entry.video.bvid))
-    .sort((a, b) => a.video.bvid.localeCompare(b.video.bvid, 'en'));
-
-  if (pool.length === 0) {
+  const sourceLabel = '来自相关视频候选';
+  if (!ctx.randomExplorePool || ctx.randomExplorePool.seedCount === 0) {
     return emptyBox(
       'random_explore',
       '随机探索',
-      '不做推荐排序，只从本地视频池里随机抽一条。',
-      ['本地视频池里暂时没有可以安全抽取的候选。'],
-      '先积累可抽取的视频池',
-      `这盒会排除最近 ${RANDOM_VIDEO_BLOCK_DAYS} 天刚看过的视频，以及其他盲盒已经占用的候选。等本地池子再大一点，它就能开出来。`,
+      '不做推荐排序，只从真实候选池里随机抽一条。',
+      ['本地还没有可作为公开相关视频候选种子的 BV 号。'],
+      '真实候选源还没有可用种子',
+      `随机探索现在需要先用最近少量本地历史作为种子，请求 B 站公开视频的相关视频候选池。等本地有可用 BV 号后，它才会开出真实候选。`,
+      sourceLabel,
+      '没有可请求的种子，未生成空白视频卡。',
     );
   }
 
-  const index = stableHash(`${Math.floor(ctx.nowMs / DAY_MS)}:${pool.length}`) % pool.length;
+  const pool = ctx.randomExplorePool.candidates
+    .filter(candidate => !ctx.usedBvids.has(candidate.bvid) && !ctx.recentBvids.has(candidate.bvid))
+    .sort((a, b) => a.bvid.localeCompare(b.bvid, 'en'));
+
+  if (pool.length === 0) {
+    const failureSummary = formatRelatedCandidateFailures(ctx.randomExplorePool);
+    return emptyBox(
+      'random_explore',
+      '随机探索',
+      '不做推荐排序，只从真实候选池里随机抽一条。',
+      [
+        `已尝试 ${ctx.randomExplorePool.seedCount} 个种子视频的相关视频候选。`,
+        failureSummary,
+        `同时会排除最近 ${RECENT_VIDEO_BLOCK_DAYS} 天看过的视频和本页其它盲盒已占用的视频。`,
+      ],
+      '相关视频候选暂时不可用',
+      '这次没有拿到可安全展示的真实候选，Bili-Bill 不会用本地库存视频冒充随机探索候选。',
+      sourceLabel,
+      '真实候选源失败或为空，未生成空白视频卡。',
+    );
+  }
+
+  const index = stableHash(`${Math.floor(ctx.nowMs / DAY_MS)}:${pool.length}:${pool[0]?.seedBvid ?? ''}`) % pool.length;
   const pick = pool[index];
-  ctx.usedBvids.add(pick.video.bvid);
+  ctx.usedBvids.add(pick.bvid);
 
   return {
     id: 'random_explore',
     title: '随机探索',
-    teaser: '不做推荐排序，只从本地视频池里随机抽一条。',
-    source: pick.source,
-    reason: pick.reason,
+    teaser: '不做推荐排序，只从真实候选池里随机抽一条。',
+    source: `${sourceLabel} / 种子视频「${pick.seedTitle || pick.seedBvid}」`,
+    reason: `Bili-Bill 没有保留平台排序，只是在 ${pool.length} 条公开相关视频候选里随机抽取一条。`,
     evidence: [
-      `这次从本地视频池 ${pool.length} 条候选里随机抽取，并排除了最近 ${RANDOM_VIDEO_BLOCK_DAYS} 天看过的视频。`,
-      ...pick.evidence,
+      `候选来自 B 站公开视频的相关视频候选池，使用 ${ctx.randomExplorePool.seedCount} 个本地种子视频逐个请求。`,
+      `抽取前已排除最近 ${RECENT_VIDEO_BLOCK_DAYS} 天看过的视频，以及其它盲盒已经占用的候选。`,
+      `本次种子视频：${pick.seedTitle || pick.seedBvid}。`,
     ],
     state: 'ready',
-    video: pick.video,
+    video: pick,
   };
 }
 
-function buildRandomPool(ctx: BlindBoxContext): RandomPoolEntry[] {
-  const entries = new Map<string, RandomPoolEntry>();
-  const randomCutoffMs = ctx.nowMs - RANDOM_VIDEO_BLOCK_DAYS * DAY_MS;
+function selectRelatedVideoSeeds(records: WatchHistoryRecord[], nowMs: number): RelatedVideoSeed[] {
+  const recentCutoffMs = nowMs - RECENT_VIDEO_BLOCK_DAYS * DAY_MS;
+  const seeds: RelatedVideoSeed[] = [];
+  const seen = new Set<string>();
+  const sortedRecords = [...records]
+    .filter(record => record.business === 'archive' && cleanText(record.bvid))
+    .sort((a, b) => toEpochMs(b.viewAt) - toEpochMs(a.viewAt));
 
-  for (const record of ctx.records) {
-    const video = toHistoryVideo(record);
-    if (!video || !isPositiveRecord(record)) continue;
-    if (toEpochMs(record.viewAt) >= randomCutoffMs) continue;
-    if (entries.has(video.bvid)) continue;
-
-    entries.set(video.bvid, {
-      source: `本地历史 / 标签「${cleanText(record.tagName) || '未标注'}」`,
-      reason: '这盒不猜你会不会点开，只从你自己的本地历史池里随机抽一条代表视频。',
-      evidence: [
-        `它来自本地历史，标签是「${cleanText(record.tagName) || '未标注'}」，上次观看距今 ${daysSince(record.viewAt, ctx.nowMs)} 天。`,
-      ],
-      video,
+  for (const record of sortedRecords) {
+    const bvid = cleanText(record.bvid);
+    if (!isLikelyBvid(bvid) || seen.has(bvid)) continue;
+    const watchedAt = toEpochMs(record.viewAt);
+    if (watchedAt < recentCutoffMs && seeds.length > 0) break;
+    seen.add(bvid);
+    seeds.push({
+      bvid,
+      title: cleanText(record.title) || bvid,
     });
+    if (seeds.length >= RANDOM_RELATED_SEED_LIMIT) break;
   }
 
-  for (const item of ctx.favorites) {
-    const video = toFavoriteVideo(item);
-    if (!video) continue;
-    if ((ctx.lastWatchByBvid.get(video.bvid) ?? 0) >= randomCutoffMs) continue;
+  return seeds;
+}
 
-    entries.set(video.bvid, {
-      source: `本地收藏 / 收藏夹「${item.folderTitle}」`,
-      reason: '这盒不看推荐排序，只从你已经留下来的本地视频池里随机抽取。',
-      evidence: [
-        `它来自收藏夹「${item.folderTitle}」，收藏于 ${daysSince(item.favTime, ctx.nowMs)} 天前。`,
-      ],
-      video,
-    });
+function formatRelatedCandidateFailures(pool: ExperimentRealCandidatePool): string {
+  if (pool.candidates.length > 0) {
+    return `相关视频候选返回 ${pool.candidates.length} 条，但都已被近期观看、重复候选或其它盲盒占用。`;
+  }
+  if (pool.failures.length === 0) {
+    return '相关视频候选没有返回可展示的视频。';
   }
 
-  return [...entries.values()];
+  const counts = pool.failures.reduce<Record<string, number>>((acc, failure) => {
+    acc[failure.reason] = (acc[failure.reason] ?? 0) + 1;
+    return acc;
+  }, {});
+  const parts = [
+    counts.request_failed ? `请求失败 ${counts.request_failed} 个` : '',
+    counts.empty_response ? `空响应 ${counts.empty_response} 个` : '',
+    counts.no_valid_candidates ? `无有效 BV 候选 ${counts.no_valid_candidates} 个` : '',
+  ].filter(Boolean);
+
+  return `相关视频候选暂不可用：${parts.join('，') || '未返回有效候选'}。`;
 }
 
 function emptyBox(
@@ -433,13 +466,15 @@ function emptyBox(
   evidence: string[],
   emptyTitle: string,
   emptyDescription: string,
+  source = '仅使用本地历史 / 本地收藏',
+  reason = '这盒没有足够的本地证据，不会拿泛泛建议来凑数。',
 ): ExperimentBlindBox {
   return {
     id,
     title,
     teaser,
-    source: '仅使用本地历史 / 本地收藏',
-    reason: '这盒没有足够的本地证据，不会拿泛泛建议来凑数。',
+    source,
+    reason,
     evidence,
     state: 'empty',
     emptyTitle,
@@ -541,6 +576,10 @@ function formatPercent(value: number): string {
 
 function cleanText(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function isLikelyBvid(value: string): boolean {
+  return /^BV[0-9A-Za-z]{8,}$/.test(value);
 }
 
 function toEpochMs(value: number): number {

--- a/src/background/api/video-blind-box-candidates.ts
+++ b/src/background/api/video-blind-box-candidates.ts
@@ -1,0 +1,181 @@
+import { RELATED_VIDEO_ENDPOINT } from '../../shared/constants';
+import type {
+  ExperimentRealCandidateFailure,
+  ExperimentRealCandidatePool,
+  ExperimentRealVideoCandidate,
+} from '../../shared/types/analytics';
+import { biliGet } from './client';
+
+const DEFAULT_SEED_LIMIT = 3;
+const DEFAULT_PER_SEED_LIMIT = 20;
+const DEFAULT_SEED_TIMEOUT_MS = 8_000;
+
+export interface RelatedVideoSeed {
+  bvid: string;
+  title: string;
+}
+
+export interface RelatedVideoCandidateOptions {
+  seedLimit?: number;
+  perSeedLimit?: number;
+  seedTimeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+interface RelatedArchiveOwner {
+  mid?: number;
+  name?: string;
+}
+
+interface RelatedArchiveItem {
+  aid?: number;
+  bvid?: string;
+  cid?: number;
+  title?: string;
+  owner?: RelatedArchiveOwner;
+  pic?: string;
+  cover43?: string;
+  duration?: number;
+  pubdate?: number;
+  ctime?: number;
+  tname?: string;
+}
+
+export async function fetchRelatedVideoCandidates(
+  seeds: RelatedVideoSeed[],
+  options: RelatedVideoCandidateOptions = {},
+): Promise<ExperimentRealCandidatePool> {
+  const selectedSeeds = normalizeSeeds(seeds).slice(0, clampPositive(options.seedLimit, DEFAULT_SEED_LIMIT));
+  const perSeedLimit = clampPositive(options.perSeedLimit, DEFAULT_PER_SEED_LIMIT);
+  const seedTimeoutMs = clampPositive(options.seedTimeoutMs, DEFAULT_SEED_TIMEOUT_MS);
+  const candidates: ExperimentRealVideoCandidate[] = [];
+  const failures: ExperimentRealCandidateFailure[] = [];
+  const seenBvids = new Set(selectedSeeds.map(seed => seed.bvid));
+
+  for (const seed of selectedSeeds) {
+    if (options.signal?.aborted) throw new Error('SYNC_CANCELLED');
+    const seedController = new AbortController();
+    const seedTimer = setTimeout(() => seedController.abort(), seedTimeoutMs);
+    const abortFromExternal = () => seedController.abort();
+    options.signal?.addEventListener('abort', abortFromExternal, { once: true });
+
+    try {
+      const data = await biliGet<RelatedArchiveItem[]>(
+        RELATED_VIDEO_ENDPOINT,
+        { bvid: seed.bvid },
+        2,
+        false,
+        seedController.signal,
+      );
+      const relatedItems = Array.isArray(data) ? data : [];
+      if (relatedItems.length === 0) {
+        failures.push(toFailure(seed, 'empty_response'));
+        continue;
+      }
+
+      let accepted = 0;
+      for (const item of relatedItems) {
+        if (accepted >= perSeedLimit) break;
+        const candidate = toRelatedCandidate(item, seed);
+        if (!candidate || seenBvids.has(candidate.bvid)) continue;
+        seenBvids.add(candidate.bvid);
+        candidates.push(candidate);
+        accepted += 1;
+      }
+
+      if (accepted === 0) {
+        failures.push(toFailure(seed, 'no_valid_candidates'));
+      }
+    } catch (error) {
+      if (options.signal?.aborted && error instanceof Error && error.message === 'SYNC_CANCELLED') throw error;
+      failures.push(toFailure(seed, 'request_failed'));
+    } finally {
+      clearTimeout(seedTimer);
+      options.signal?.removeEventListener('abort', abortFromExternal);
+    }
+  }
+
+  return {
+    sourceKind: 'bilibili_related',
+    sourceLabel: '相关视频候选',
+    seedCount: selectedSeeds.length,
+    candidates,
+    failures,
+  };
+}
+
+function toFailure(
+  seed: RelatedVideoSeed,
+  reason: ExperimentRealCandidateFailure['reason'],
+): ExperimentRealCandidateFailure {
+  return {
+    seedBvid: seed.bvid,
+    seedTitle: seed.title,
+    reason,
+  };
+}
+
+function toRelatedCandidate(
+  item: RelatedArchiveItem,
+  seed: RelatedVideoSeed,
+): ExperimentRealVideoCandidate | null {
+  const bvid = cleanText(item.bvid);
+  const title = cleanText(item.title);
+  if (!isLikelyBvid(bvid) || !title) return null;
+
+  return {
+    sourceKind: 'bilibili_related',
+    sourceLabel: '相关视频候选',
+    seedBvid: seed.bvid,
+    seedTitle: seed.title,
+    bvid,
+    avid: positiveNumber(item.aid),
+    cid: positiveNumber(item.cid),
+    title,
+    authorName: cleanText(item.owner?.name) || '未知 UP',
+    authorMid: positiveNumber(item.owner?.mid),
+    cover: cleanText(item.pic) || cleanText(item.cover43),
+    duration: positiveNumber(item.duration),
+    pubtime: positiveNumber(item.pubdate) ?? positiveNumber(item.ctime),
+    tagName: cleanText(item.tname),
+    url: buildVideoUrl(bvid),
+  };
+}
+
+function normalizeSeeds(seeds: RelatedVideoSeed[]): RelatedVideoSeed[] {
+  const normalized: RelatedVideoSeed[] = [];
+  const seen = new Set<string>();
+  for (const seed of seeds) {
+    const bvid = cleanText(seed.bvid);
+    if (!isLikelyBvid(bvid) || seen.has(bvid)) continue;
+    seen.add(bvid);
+    normalized.push({
+      bvid,
+      title: cleanText(seed.title) || bvid,
+    });
+  }
+  return normalized;
+}
+
+function cleanText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function positiveNumber(value: unknown): number | undefined {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : undefined;
+}
+
+function clampPositive(value: unknown, fallback: number): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return fallback;
+  return Math.max(1, Math.floor(numeric));
+}
+
+function isLikelyBvid(value: string): boolean {
+  return /^BV[0-9A-Za-z]{8,}$/.test(value);
+}
+
+function buildVideoUrl(bvid: string): string {
+  return `https://www.bilibili.com/video/${encodeURIComponent(bvid)}`;
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,6 +1,7 @@
 export const API_BASE = 'https://api.bilibili.com';
 export const HISTORY_ENDPOINT = '/x/web-interface/history/cursor';
 export const VIDEO_INFO_ENDPOINT = '/x/web-interface/view';
+export const RELATED_VIDEO_ENDPOINT = '/x/web-interface/archive/related';
 export const NAV_ENDPOINT = '/x/web-interface/nav';
 export const FAVORITE_FOLDERS_ENDPOINT = '/x/v3/fav/folder/created/list-all';
 export const FAVORITE_RESOURCES_ENDPOINT = '/x/v3/fav/resource/list';

--- a/src/shared/types/analytics.ts
+++ b/src/shared/types/analytics.ts
@@ -180,10 +180,38 @@ export type ExperimentBlindBoxState = 'ready' | 'empty';
 export interface ExperimentVideoCandidate {
   bvid: string;
   avid?: number;
+  cid?: number;
   title: string;
   authorName: string;
+  authorMid?: number;
   cover: string;
+  duration?: number;
+  pubtime?: number;
+  tagName?: string;
   url: string;
+}
+
+export type ExperimentRealCandidateSourceKind = 'bilibili_related';
+
+export interface ExperimentRealVideoCandidate extends ExperimentVideoCandidate {
+  sourceKind: ExperimentRealCandidateSourceKind;
+  sourceLabel: string;
+  seedBvid: string;
+  seedTitle: string;
+}
+
+export interface ExperimentRealCandidateFailure {
+  seedBvid: string;
+  seedTitle: string;
+  reason: 'request_failed' | 'empty_response' | 'no_valid_candidates';
+}
+
+export interface ExperimentRealCandidatePool {
+  sourceKind: ExperimentRealCandidateSourceKind;
+  sourceLabel: string;
+  seedCount: number;
+  candidates: ExperimentRealVideoCandidate[];
+  failures: ExperimentRealCandidateFailure[];
 }
 
 export interface ExperimentBlindBox {

--- a/tests/experiment-blind-boxes.test.ts
+++ b/tests/experiment-blind-boxes.test.ts
@@ -1,12 +1,13 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { buildExperimentData } from '../src/background/analytics/suggestions.ts';
+import type { ExperimentRealCandidatePool } from '../src/shared/types/analytics';
 import type { FavoriteItem, SmartFavoriteIndex } from '../src/shared/types/favorite';
 import type { WatchHistoryRecord } from '../src/shared/types/watch-event';
 
 const NOW_MS = Date.UTC(2026, 5, 13, 12, 0, 0);
 
-test('builds four local blind boxes with concrete video candidates', () => {
+test('builds blind boxes with a real random explore candidate source', () => {
   const bannedGuessWord = `猜${'你喜欢'}`;
   const records: WatchHistoryRecord[] = [
     createRecord({ bvid: 'BVREC001', tagName: '游戏', daysAgo: 3, actualCompletion: 0.82, title: '最近游戏 1' }),
@@ -54,7 +55,13 @@ test('builds four local blind boxes with concrete video candidates', () => {
     ['random', createSmartIndex('random', ['生活', '旅行'])],
   ]);
 
-  const data = buildExperimentData(records, favorites, smartIndexByItemKey, NOW_MS);
+  const data = buildExperimentData(
+    records,
+    favorites,
+    smartIndexByItemKey,
+    NOW_MS,
+    createRelatedPool(),
+  );
 
   assert.deepEqual(data.blindBoxes.map(box => box.id), [
     'variety',
@@ -78,7 +85,10 @@ test('builds four local blind boxes with concrete video candidates', () => {
   assert.match(reviveInterest.source, /本地历史/);
 
   assert.equal(randomExplore.state, 'ready');
-  assert.ok(randomExplore.video?.bvid);
+  assert.equal(randomExplore.video?.bvid, 'BV1REALRND01');
+  assert.match(randomExplore.source, /相关视频候选/);
+  assert.match(randomExplore.source, /种子视频/);
+  assert.match(randomExplore.reason, /没有保留平台排序|随机抽取/);
   assert.notEqual(randomExplore.video?.bvid, variety.video?.bvid);
   assert.notEqual(randomExplore.video?.bvid, hiddenFavorite.video?.bvid);
   assert.notEqual(randomExplore.video?.bvid, reviveInterest.video?.bvid);
@@ -109,6 +119,34 @@ test('returns Chinese empty states instead of generic filler when local evidence
     assert.equal(box.reason.includes(bannedGuessWord), false);
     assert.equal(box.reason.includes(bannedUnconsumedWord), false);
   }
+});
+
+test('does not fall back to a local random video when related candidates fail', () => {
+  const records: WatchHistoryRecord[] = [
+    createRecord({ bvid: 'BV1LOCAL001', tagName: '游戏', daysAgo: 3, actualCompletion: 0.92, title: '本地种子视频' }),
+    createRecord({ bvid: 'BV1LOCAL002', tagName: '游戏', daysAgo: 40, actualCompletion: 0.91, title: '本地备用视频' }),
+  ];
+  const failedPool: ExperimentRealCandidatePool = {
+    sourceKind: 'bilibili_related',
+    sourceLabel: '相关视频候选',
+    seedCount: 1,
+    candidates: [],
+    failures: [{
+      seedBvid: 'BV1LOCAL001',
+      seedTitle: '本地种子视频',
+      reason: 'request_failed',
+    }],
+  };
+
+  const data = buildExperimentData(records, [], new Map(), NOW_MS, failedPool);
+  const randomExplore = data.blindBoxes.find(box => box.id === 'random_explore');
+
+  assert.ok(randomExplore);
+  assert.equal(randomExplore.state, 'empty');
+  assert.equal(randomExplore.video, undefined);
+  assert.match(randomExplore.source, /相关视频候选/);
+  assert.match(randomExplore.emptyDescription ?? '', /不会用本地库存视频冒充/);
+  assert.ok(randomExplore.evidence.some(line => line.includes('请求失败')));
 });
 
 function createRecord(input: {
@@ -184,5 +222,31 @@ function createSmartIndex(itemKey: string, path: string[]): SmartFavoriteIndex {
     model: 'test-model',
     status: 'indexed',
     indexedAt: Math.floor(NOW_MS / 1000),
+  };
+}
+
+function createRelatedPool(): ExperimentRealCandidatePool {
+  return {
+    sourceKind: 'bilibili_related',
+    sourceLabel: '相关视频候选',
+    seedCount: 2,
+    candidates: [{
+      sourceKind: 'bilibili_related',
+      sourceLabel: '相关视频候选',
+      seedBvid: 'BV1SEED0001',
+      seedTitle: '种子视频',
+      bvid: 'BV1REALRND01',
+      avid: 12345,
+      cid: 54321,
+      title: '真实相关候选视频',
+      authorName: '公开候选UP',
+      authorMid: 67890,
+      cover: 'https://example.com/related.jpg',
+      duration: 960,
+      pubtime: 1_717_000_000,
+      tagName: '科技',
+      url: 'https://www.bilibili.com/video/BV1REALRND01',
+    }],
+    failures: [],
   };
 }


### PR DESCRIPTION
﻿## Summary

- Implements Issue #138 random explore MVP using Bilibili `/x/web-interface/archive/related` as the real candidate source.
- Random explore now uses a small set of local BV seeds, maps public related-video fields into display candidates, and shows source copy like `来自相关视频候选 / 种子视频 ...`.
- If related candidates are unavailable, empty, filtered, or time out, the card shows a clear degradation state instead of falling back to a local inventory card.

Issue: #138

## Notes

- This does not implement #139 variety real candidates, #140 boundary cleanup, settings, or current-video Agent work.
- No Cookie files, browser profiles, Bilibili login-state files, local key files, or `C:\Users\LittleNub\Desktop\Key.txt` were read.
- Candidate requests are limited to a few public BV seeds and mapped public candidate fields; no full history/favorites/following/feedback upload is added.

## Validation

- `npm run test:experiments`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- `rg -n "未消费|猜你喜欢" dashboard popup public src README.md tests` (no matches)
- Browser mock QA on localhost: verified real-candidate card source copy, Bilibili video link href/target, failure degradation copy, nonblank render, and no console warnings/errors.

Build keeps the existing Vite warnings for large `theme` chunk and dynamic/static import overlap.
