### PR TITLE
[codex] Implement real variety blind box candidates

### DIFF
--- a/dashboard/modules/experiments/ExperimentsPage.tsx
+++ b/dashboard/modules/experiments/ExperimentsPage.tsx
@@ -60,7 +60,7 @@ export function ExperimentsPage() {
         }}>
           <div style={{ color: '#FFFFFF', fontSize: '18px', fontWeight: 700, marginBottom: '8px' }}>视频盲盒</div>
           <div style={{ color: '#D4D8E8', fontSize: '13px', lineHeight: 1.7 }}>
-            随机探索会从真实 B 站相关视频候选池里随机抽取；其它盲盒仍只使用本地历史和本地收藏证据。这里不做推荐排序，也不会写回 B 站。
+            随机探索会从真实 B 站相关视频候选池里随机抽取；换口味会先用本地长期兴趣和近期冷却选择方向，再从 B 站公开分区新视频候选池抽取。冷门收藏和久未观看兴趣仍按本地证据工作；这里不做推荐排序，也不会写回 B 站。
           </div>
           <div style={{ color: '#8F97B5', fontSize: '12px', marginTop: '8px' }}>
             最近生成时间：{new Date(data.generatedAt).toLocaleString('zh-CN')}
@@ -76,11 +76,8 @@ export function ExperimentsPage() {
             const isRevealed = revealed[box.id] === true;
             const isReady = box.state === 'ready';
             const accent = CARD_ACCENT[box.id];
-            const statusLabel = isReady
-              ? '可揭晓'
-              : box.id === 'random_explore'
-                ? '候选源不可用'
-                : '本地证据不足';
+            const statusLabel = box.statusLabel ?? (isReady ? '可揭晓' : '本地证据不足');
+            const usesRealCandidateSource = box.id === 'random_explore' || box.id === 'variety';
             return (
               <article
                 key={box.id}
@@ -129,8 +126,8 @@ export function ExperimentsPage() {
                     <div style={{ color: '#DCE2F8', fontSize: '13px', lineHeight: 1.7 }}>
                       {isReady
                         ? '这盒里是一个可以直接打开的具体视频。揭晓后会显示标题、UP 主、来源、理由和证据。'
-                        : box.id === 'random_explore'
-                          ? '这盒不会显示空卡，也不会用本地库存冒充真实候选。揭晓后会说明候选源为什么暂时不可用。'
+                        : usesRealCandidateSource
+                          ? '这盒不会显示空卡，也不会用本地库存冒充真实候选。揭晓后会说明候选源或冷却方向为什么暂时不可用。'
                           : '这盒不会拿泛泛建议充数。揭晓后只会告诉你为什么本地证据还不够。'}
                     </div>
                     <button
@@ -214,7 +211,7 @@ export function ExperimentsPage() {
         }}>
           <div style={{ color: '#FFFFFF', fontSize: '13px', fontWeight: 600, marginBottom: '8px' }}>说明</div>
           <div style={{ color: '#A8B0CE', fontSize: '12px', lineHeight: 1.7 }}>
-            随机探索只使用少量本地 BV 号作为种子，请求公开相关视频候选后在本地随机抽取；不会上传完整历史、收藏、关注或反馈。打开动作只会新开一个 B 站视频页，不会回写收藏、关注或观看状态。
+            随机探索只使用少量本地 BV 号作为种子，请求公开相关视频候选后在本地随机抽取；换口味只把本地历史用于选择冷却方向和解释，候选视频来自 B 站公开分区新视频池；冷门收藏和久未观看兴趣仍使用本地历史或收藏。打开动作只会新开一个 B 站视频页，不会回写收藏、关注或观看状态。
           </div>
         </section>
       </div>

--- a/src/background/analytics/suggestions.ts
+++ b/src/background/analytics/suggestions.ts
@@ -7,7 +7,11 @@ import type {
 } from '../../shared/types/analytics';
 import type { FavoriteItem, SmartFavoriteIndex } from '../../shared/types/favorite';
 import type { WatchHistoryRecord } from '../../shared/types/watch-event';
-import type { RelatedVideoSeed } from '../api/video-blind-box-candidates.ts';
+import type {
+  RelatedVideoSeed,
+  VarietyRegionCandidatePool,
+  VarietyRegionDirection,
+} from '../api/video-blind-box-candidates.ts';
 import { db } from '../storage/db.ts';
 import { getFavoriteItems, getSmartFavoriteIndexMap } from '../storage/favorite-repo.ts';
 
@@ -15,6 +19,8 @@ const DAY_MS = 86_400_000;
 const RECENT_ACTIVITY_DAYS = 45;
 const RECENT_VIDEO_BLOCK_DAYS = 90;
 const RANDOM_RELATED_SEED_LIMIT = 3;
+const VARIETY_LONG_WINDOW_DAYS = 180;
+const VARIETY_RECENT_WINDOW_DAYS = 30;
 const MIN_INTEREST_RECORDS = 4;
 const MIN_INTEREST_POSITIVE_RECORDS = 2;
 const POSITIVE_COMPLETION = 0.75;
@@ -32,11 +38,12 @@ interface BlindBoxContext {
   lastWatchByBvid: Map<string, number>;
   usedBvids: Set<string>;
   randomExplorePool?: ExperimentRealCandidatePool;
+  varietyRegionPool?: VarietyRegionCandidatePool;
 }
 
-interface FavoriteTaste {
-  displayLabel: string;
-  matchLabels: string[];
+interface ExperimentBuildOptions {
+  randomExplorePool?: ExperimentRealCandidatePool;
+  varietyRegionPool?: VarietyRegionCandidatePool;
 }
 
 export async function getExperimentData(): Promise<ExperimentData> {
@@ -46,13 +53,25 @@ export async function getExperimentData(): Promise<ExperimentData> {
     getFavoriteItems(),
     getSmartFavoriteIndexMap(),
   ]);
-  const { fetchRelatedVideoCandidates } = await import('../api/video-blind-box-candidates.ts');
-  const randomExplorePool = await fetchRelatedVideoCandidates(
-    selectRelatedVideoSeeds(records, nowMs),
-    { seedLimit: RANDOM_RELATED_SEED_LIMIT },
-  );
+  const {
+    fetchRelatedVideoCandidates,
+    fetchVarietyRegionCandidatePool,
+    buildVarietyRegionSourceFailure,
+  } = await import('../api/video-blind-box-candidates.ts');
 
-  return buildExperimentData(records, favorites, smartIndexByItemKey, nowMs, randomExplorePool);
+  const [randomExplorePool, varietyRegionPool] = await Promise.all([
+    fetchRelatedVideoCandidates(
+      selectRelatedVideoSeeds(records, nowMs),
+      { seedLimit: RANDOM_RELATED_SEED_LIMIT },
+    ),
+    fetchVarietyRegionCandidatePool(records, { nowMs })
+      .catch(error => buildVarietyRegionSourceFailure(records, nowMs, error)),
+  ]);
+
+  return buildExperimentData(records, favorites, smartIndexByItemKey, nowMs, {
+    randomExplorePool,
+    varietyRegionPool,
+  });
 }
 
 export function buildExperimentData(
@@ -60,8 +79,9 @@ export function buildExperimentData(
   favorites: FavoriteItem[],
   smartIndexByItemKey: Map<string, SmartFavoriteIndex>,
   nowMs = Date.now(),
-  randomExplorePool?: ExperimentRealCandidatePool,
+  optionsOrRandomPool: ExperimentBuildOptions | ExperimentRealCandidatePool = {},
 ): ExperimentData {
+  const options = normalizeExperimentBuildOptions(optionsOrRandomPool);
   const recentCutoffMs = nowMs - RECENT_ACTIVITY_DAYS * DAY_MS;
   const recentRecords = records.filter(record => toEpochMs(record.viewAt) >= recentCutoffMs);
 
@@ -82,7 +102,8 @@ export function buildExperimentData(
     watchCountByBvid: countByBvid(records),
     lastWatchByBvid: buildLastWatchByBvid(records),
     usedBvids: new Set<string>(),
-    randomExplorePool,
+    randomExplorePool: options.randomExplorePool,
+    varietyRegionPool: options.varietyRegionPool,
   };
 
   return {
@@ -96,93 +117,170 @@ export function buildExperimentData(
   };
 }
 
+function normalizeExperimentBuildOptions(
+  value: ExperimentBuildOptions | ExperimentRealCandidatePool,
+): ExperimentBuildOptions {
+  if ('sourceKind' in value && 'candidates' in value && 'failures' in value) {
+    return { randomExplorePool: value };
+  }
+  return value;
+}
+
 function buildVarietyBox(ctx: BlindBoxContext): ExperimentBlindBox {
-  if (ctx.favorites.length === 0) {
+  const title = '换口味';
+  const teaser = '从长期兴趣里找一条近期少看的真实 B 站新视频。';
+  const pool = ctx.varietyRegionPool;
+
+  if (!pool) {
     return emptyBox(
       'variety',
-      '换口味',
-      '从本地收藏里挑一条和最近口味不一样的。',
-      ['本地收藏 0 条，暂时没有可以换口味的视频池。'],
-      '先把收藏同步进来',
-      '这盒只从本地收藏里挑视频。同步收藏后，我才能从你已经留住的视频里找一条明显不同的口味。',
+      title,
+      teaser,
+      ['真实候选源尚未返回，暂不使用本地收藏冒充候选全集。'],
+      '真实候选池还没准备好',
+      '换口味需要先根据本地长期兴趣选择冷却分区，再从 B 站分区新视频候选池抽取。当前没有拿到候选源结果，所以不显示空卡。',
+      '候选源未返回',
+      'B 站分区新视频',
+      '真实候选源尚未返回，换口味不会退回本地收藏夹凑数。',
     );
   }
 
-  if (ctx.recentRecords.length < 6 || ctx.recentTopTags.length === 0) {
+  if (pool.status !== 'ready' || pool.candidates.length === 0 || pool.directions.length === 0) {
     return emptyBox(
       'variety',
-      '换口味',
-      '从本地收藏里挑一条和最近口味不一样的。',
-      [`最近 ${RECENT_ACTIVITY_DAYS} 天本地历史只有 ${ctx.recentRecords.length} 条，口味轮廓还不够稳定。`],
-      '最近历史还不够成型',
-      '等最近再多积累一点观看记录，我才能判断你现在的主口味，并从收藏里挑一条真正“换口味”的视频。',
+      title,
+      teaser,
+      pool.evidence.length > 0 ? pool.evidence : ['没有留下可解释的真实候选池证据。'],
+      varietyEmptyTitle(pool.status),
+      varietyEmptyDescription(pool),
+      varietyEmptyStatusLabel(pool.status),
+      pool.sourceLabel,
+      varietyEmptyReason(pool),
     );
   }
 
-  const dominantTag = ctx.recentTopTags[0];
-  const candidates = ctx.favorites
-    .map(item => {
-      const video = toFavoriteVideo(item);
-      if (!video || ctx.usedBvids.has(video.bvid) || ctx.recentBvids.has(video.bvid)) return null;
-
-      const smart = ctx.smartIndexByItemKey.get(item.itemKey);
-      const taste = getFavoriteTaste(item, smart);
-      const tasteDiff = taste.matchLabels.every(label => !ctx.recentTopTags.includes(label));
-      if (!tasteDiff) return null;
-
-      const favoriteAgeDays = daysSince(item.favTime, ctx.nowMs);
-      const score = favoriteAgeDays
-        + (smart?.status === 'indexed' ? 20 : 0)
-        + (ctx.recentAuthorMids.has(item.authorMid) ? 0 : 12);
-
-      return {
-        item,
-        taste,
-        smart,
-        video,
-        favoriteAgeDays,
-        score,
-      };
-    })
-    .filter((candidate): candidate is NonNullable<typeof candidate> => Boolean(candidate))
-    .sort((a, b) => b.score - a.score);
-
+  const candidates = pool.candidates.filter(video => !ctx.usedBvids.has(video.bvid) && !ctx.recentBvids.has(video.bvid));
   if (candidates.length === 0) {
-    const indexedCount = ctx.favorites.filter(item => ctx.smartIndexByItemKey.get(item.itemKey)?.status === 'indexed').length;
     return emptyBox(
       'variety',
-      '换口味',
-      '从本地收藏里挑一条和最近口味不一样的。',
+      title,
+      teaser,
       [
-        `最近 ${RECENT_ACTIVITY_DAYS} 天高频主题：${ctx.recentTopTags.join('、')}。`,
-        `本地收藏 ${ctx.favorites.length} 条，其中已生成智能路径 ${indexedCount} 条。`,
+        ...pool.evidence,
+        `真实候选池有 ${pool.candidates.length} 条，但都已被本页其他盲盒占用或在本地最近 ${RECENT_VIDEO_BLOCK_DAYS} 天看过。`,
       ],
-      indexedCount === 0 ? '先生成收藏分类路径' : '收藏和最近口味太接近',
-      indexedCount === 0
-        ? '这盒需要靠本地收藏路径来判断“不同口味”。先同步收藏并生成智能索引，再回来开盒。'
-        : '你最近看的主题和本地收藏重合度很高，暂时挑不出一条明显反差的换口味视频。',
+      '候选都被近期记录挡住了',
+      '换口味不会从近期已经看过的视频里硬抽，也不会退回本地收藏夹凑数。稍后刷新或等分区新视频更新后再试。',
+      '候选已冷却过滤',
+      pool.sourceLabel,
+      '真实候选池有结果，但经过近期观看和本页占用过滤后没有剩余视频。',
     );
   }
 
-  const pick = candidates[0];
-  ctx.usedBvids.add(pick.video.bvid);
+  const pick = candidates[stableHash(`${Math.floor(ctx.nowMs / DAY_MS)}:${pool.directions[0].rid}:${candidates.length}`) % candidates.length];
+  const direction = pool.directions.find(item => item.rid === pick.regionRid) ?? pool.directions[0];
+  ctx.usedBvids.add(pick.bvid);
 
   return {
     id: 'variety',
-    title: '换口味',
-    teaser: '从本地收藏里挑一条和最近口味不一样的。',
-    source: pick.smart?.status === 'indexed'
-      ? `本地收藏 / 智能路径「${pick.taste.displayLabel}」`
-      : `本地收藏 / 收藏夹「${pick.item.folderTitle}」`,
-    reason: `最近 ${RECENT_ACTIVITY_DAYS} 天你更常看「${dominantTag}」，这条收藏落在「${pick.taste.displayLabel}」，适合作为一次主动换口味。`,
+    title,
+    teaser,
+    source: pick.sourceLabel ?? `${pool.sourceLabel} / ${direction.regionName}`,
+    reason: buildVarietyReason(direction, pick),
     evidence: [
-      `最近 ${RECENT_ACTIVITY_DAYS} 天共有 ${ctx.recentRecords.length} 条本地观看，主口味集中在：${ctx.recentTopTags.join('、')}。`,
-      `这条视频收藏于 ${pick.favoriteAgeDays} 天前，来自 ${pick.smart?.status === 'indexed' ? `智能路径「${pick.taste.displayLabel}」` : `收藏夹「${pick.item.folderTitle}」`}。`,
-      `本地最近 ${RECENT_VIDEO_BLOCK_DAYS} 天没有再看过它${ctx.recentAuthorMids.has(pick.item.authorMid) ? '' : '，这位 UP 也不在你最近的高频观看里'}。`,
+      ...buildVarietyReadyEvidence(direction, pick, pool),
+      `这条候选来自公开分区「${pick.regionName ?? direction.regionName}」，Bili-Bill 只保留 bvid、标题、UP、封面、时长和播放页链接用于展示。`,
+      '本地历史和收藏只参与选择冷却方向与解释，不作为本次换口味的候选全集。',
     ],
     state: 'ready',
-    video: pick.video,
+    statusLabel: '真实候选',
+    video: pick,
   };
+}
+
+function buildVarietyReason(
+  direction: VarietyRegionDirection,
+  video: ExperimentVideoCandidate,
+): string {
+  const recentHigh = direction.recentHighLabels.length > 0
+    ? direction.recentHighLabels.join('、')
+    : '暂无明显高频口味';
+  return `你长期看过「${direction.label}」，但最近 ${VARIETY_RECENT_WINDOW_DAYS} 天这个方向正向观看 ${direction.recentPositiveCount} 次，低于长期 ${VARIETY_LONG_WINDOW_DAYS} 天节奏；这条来自 B 站「${video.regionName ?? direction.regionName}」分区新视频候选，和最近高频的「${recentHigh}」拉开距离。`;
+}
+
+function buildVarietyReadyEvidence(
+  direction: VarietyRegionDirection,
+  video: ExperimentVideoCandidate,
+  pool: VarietyRegionCandidatePool,
+): string[] {
+  const recentHigh = direction.recentHighLabels.length > 0
+    ? direction.recentHighLabels.join('、')
+    : '暂无明显高频口味';
+  return [
+    `长期 ${VARIETY_LONG_WINDOW_DAYS} 天里，「${direction.label}」有 ${direction.longWatchedCount} 条观看、${direction.longPositiveCount} 条正向观看。`,
+    `近期 ${VARIETY_RECENT_WINDOW_DAYS} 天里，这个方向正向观看 ${direction.recentPositiveCount} 条；按长期节奏预期约 ${formatCount(direction.expectedRecentPositive)} 条。`,
+    `最近高频口味是：${recentHigh}；本次只从冷却方向「${video.regionName ?? direction.regionName}」分区取新视频候选。`,
+    `真实候选池返回 ${pool.candidates.length} 条可打开视频，已排除最近 ${RECENT_VIDEO_BLOCK_DAYS} 天本地看过的同 bvid ${pool.excludedRecentBvidCount} 条。`,
+  ];
+}
+
+function varietyEmptyTitle(status: VarietyRegionCandidatePool['status']): string {
+  switch (status) {
+    case 'insufficient_local_evidence':
+      return '本地冷却方向还不够明确';
+    case 'unmapped_interest':
+      return '长期兴趣暂时映射不到公开分区';
+    case 'source_failed':
+      return '分区新视频候选源暂不可用';
+    case 'empty':
+      return '真实候选池这次没有留下可打开视频';
+    case 'ready':
+      return '真实候选池暂时为空';
+  }
+}
+
+function varietyEmptyDescription(pool: VarietyRegionCandidatePool): string {
+  switch (pool.status) {
+    case 'insufficient_local_evidence':
+      return '换口味需要先从本地长期历史里找出“长期相关、近期低频”的方向。当前证据不足时不会退回本地收藏夹凑数。';
+    case 'unmapped_interest':
+      return '本地长期兴趣还不能保守映射到 B 站公开分区，所以暂不请求不相关候选，也不从近期高频口味里抽。';
+    case 'source_failed':
+      return `已找到冷却方向，但 B 站分区新视频候选源请求失败${pool.failureReason ? `：${pool.failureReason}` : ''}。本卡保留降级说明，不显示空视频。`;
+    case 'empty':
+      return '已找到冷却方向并尝试真实候选源，但本轮没有可打开的新视频候选。刷新后可重试，当前不会改用本地收藏作为候选全集。';
+    case 'ready':
+      return '真实候选池返回了结果，但候选列表为空。当前不显示空卡。';
+  }
+}
+
+function varietyEmptyReason(pool: VarietyRegionCandidatePool): string {
+  switch (pool.status) {
+    case 'insufficient_local_evidence':
+      return '本地长期兴趣和近期冷却差异还不够明确，暂不生成换口味真实候选。';
+    case 'unmapped_interest':
+      return '本地长期兴趣暂时不能保守映射到 B 站分区，暂不硬抽无关候选。';
+    case 'source_failed':
+      return '已找到换口味冷却方向，但真实分区新视频候选源暂不可用。';
+    case 'empty':
+      return '已请求真实分区新视频候选池，但本轮没有留下可打开候选。';
+    case 'ready':
+      return '真实分区新视频候选池没有返回可展示视频。';
+  }
+}
+
+function varietyEmptyStatusLabel(status: VarietyRegionCandidatePool['status']): string {
+  switch (status) {
+    case 'source_failed':
+      return '候选源暂不可用';
+    case 'empty':
+    case 'ready':
+      return '真实候选为空';
+    case 'unmapped_interest':
+      return '分区未映射';
+    case 'insufficient_local_evidence':
+      return '冷却证据不足';
+  }
 }
 
 function buildHiddenFavoriteBox(ctx: BlindBoxContext): ExperimentBlindBox {
@@ -366,7 +464,8 @@ function buildRandomExploreBox(ctx: BlindBoxContext): ExperimentBlindBox {
       '不做推荐排序，只从真实候选池里随机抽一条。',
       ['本地还没有可作为公开相关视频候选种子的 BV 号。'],
       '真实候选源还没有可用种子',
-      `随机探索现在需要先用最近少量本地历史作为种子，请求 B 站公开视频的相关视频候选池。等本地有可用 BV 号后，它才会开出真实候选。`,
+      '随机探索现在需要先用最近少量本地历史作为种子，请求 B 站公开视频的相关视频候选池。等本地有可用 BV 号后，它才会开出真实候选。',
+      '候选源未准备好',
       sourceLabel,
       '没有可请求的种子，未生成空白视频卡。',
     );
@@ -389,6 +488,7 @@ function buildRandomExploreBox(ctx: BlindBoxContext): ExperimentBlindBox {
       ],
       '相关视频候选暂时不可用',
       '这次没有拿到可安全展示的真实候选，Bili-Bill 不会用本地库存视频冒充随机探索候选。',
+      '候选源暂不可用',
       sourceLabel,
       '真实候选源失败或为空，未生成空白视频卡。',
     );
@@ -466,17 +566,19 @@ function emptyBox(
   evidence: string[],
   emptyTitle: string,
   emptyDescription: string,
-  source = '仅使用本地历史 / 本地收藏',
-  reason = '这盒没有足够的本地证据，不会拿泛泛建议来凑数。',
+  statusLabel?: string,
+  source?: string,
+  reason?: string,
 ): ExperimentBlindBox {
   return {
     id,
     title,
     teaser,
-    source,
-    reason,
+    source: source ?? '仅使用本地历史 / 本地收藏',
+    reason: reason ?? '这盒没有足够的本地证据，不会拿泛泛建议来凑数。',
     evidence,
     state: 'empty',
+    statusLabel,
     emptyTitle,
     emptyDescription,
   };
@@ -503,18 +605,6 @@ function toFavoriteVideo(item: FavoriteItem): ExperimentVideoCandidate | null {
     authorName: cleanText(item.authorName) || '未知 UP',
     cover: cleanText(item.cover),
     url: buildVideoUrl(item.bvid, item.avid),
-  };
-}
-
-function getFavoriteTaste(item: FavoriteItem, smart: SmartFavoriteIndex | undefined): FavoriteTaste {
-  const path = smart?.status === 'indexed'
-    ? smart.path.map(cleanText).filter(Boolean)
-    : [];
-  const fallback = [item.tagName, item.folderTitle].map(cleanText).filter(Boolean);
-  const displayParts = path.length > 0 ? path : fallback.length > 0 ? fallback : ['未命名口味'];
-  return {
-    displayLabel: displayParts.join(' / '),
-    matchLabels: uniqueTexts([...displayParts, item.tagName, item.folderTitle]),
   };
 }
 
@@ -553,18 +643,6 @@ function topLabels(labels: string[], limit: number): string[] {
     .map(([label]) => label);
 }
 
-function uniqueTexts(values: string[]): string[] {
-  const result: string[] = [];
-  const seen = new Set<string>();
-  for (const value of values.map(cleanText).filter(Boolean)) {
-    const key = value.toLocaleLowerCase();
-    if (seen.has(key)) continue;
-    seen.add(key);
-    result.push(value);
-  }
-  return result;
-}
-
 function isPositiveRecord(record: WatchHistoryRecord): boolean {
   return record.actualCompletion >= POSITIVE_COMPLETION
     || Math.max(0, record.progress) >= Math.min(Math.max(0, record.duration), 900);
@@ -572,6 +650,10 @@ function isPositiveRecord(record: WatchHistoryRecord): boolean {
 
 function formatPercent(value: number): string {
   return `${Math.round(value * 100)}%`;
+}
+
+function formatCount(value: number): string {
+  return String(Math.round(value * 10) / 10);
 }
 
 function cleanText(value: unknown): string {

--- a/src/background/api/video-blind-box-candidates.ts
+++ b/src/background/api/video-blind-box-candidates.ts
@@ -1,14 +1,25 @@
-import { RELATED_VIDEO_ENDPOINT } from '../../shared/constants';
 import type {
   ExperimentRealCandidateFailure,
   ExperimentRealCandidatePool,
   ExperimentRealVideoCandidate,
+  ExperimentVideoCandidate,
 } from '../../shared/types/analytics';
-import { biliGet } from './client';
+import type { WatchHistoryRecord } from '../../shared/types/watch-event';
 
+const DAY_MS = 86_400_000;
+const RELATED_VIDEO_ENDPOINT = '/x/web-interface/archive/related';
 const DEFAULT_SEED_LIMIT = 3;
 const DEFAULT_PER_SEED_LIMIT = 20;
 const DEFAULT_SEED_TIMEOUT_MS = 8_000;
+
+const LONG_WINDOW_DAYS = 180;
+const RECENT_WINDOW_DAYS = 30;
+const RECENT_VIDEO_BLOCK_DAYS = 90;
+const POSITIVE_COMPLETION = 0.75;
+const MIN_LONG_POSITIVE_COUNT = 2;
+const MAX_REGION_DIRECTIONS = 3;
+const REGION_PAGE_SIZE = 20;
+const REGION_SOURCE_LABEL = 'B 站分区新视频';
 
 export interface RelatedVideoSeed {
   bvid: string;
@@ -22,7 +33,66 @@ export interface RelatedVideoCandidateOptions {
   signal?: AbortSignal;
 }
 
-interface RelatedArchiveOwner {
+export type VarietyRegionCandidatePoolStatus =
+  | 'ready'
+  | 'insufficient_local_evidence'
+  | 'unmapped_interest'
+  | 'source_failed'
+  | 'empty';
+
+export type VarietyRegionInterestKind = 'category' | 'tag';
+
+export interface VarietyRegionDirection {
+  key: string;
+  kind: VarietyRegionInterestKind;
+  label: string;
+  rid: number;
+  regionName: string;
+  longWatchedCount: number;
+  longPositiveCount: number;
+  recentWatchedCount: number;
+  recentPositiveCount: number;
+  expectedRecentPositive: number;
+  cooldownRatio: number;
+  daysSinceLastWatch: number | null;
+  recentHighLabels: string[];
+  score: number;
+}
+
+export interface VarietyRegionCandidatePool {
+  status: VarietyRegionCandidatePoolStatus;
+  sourceLabel: string;
+  directions: VarietyRegionDirection[];
+  candidates: ExperimentVideoCandidate[];
+  evidence: string[];
+  failureReason?: string;
+  checkedRegionCount: number;
+  excludedRecentBvidCount: number;
+  excludedInvalidCandidateCount: number;
+}
+
+interface VarietyRegionCandidateOptions {
+  nowMs?: number;
+  maxDirections?: number;
+  pageSize?: number;
+  signal?: AbortSignal;
+}
+
+interface InterestSignal {
+  key: string;
+  kind: VarietyRegionInterestKind;
+  label: string;
+  rid: number;
+  regionName: string;
+}
+
+interface RegionMapping {
+  rid: number;
+  regionName: string;
+  labels: string[];
+}
+
+interface ArchiveOwner {
   mid?: number;
   name?: string;
 }
@@ -32,7 +102,7 @@ interface RelatedArchiveItem {
   bvid?: string;
   cid?: number;
   title?: string;
-  owner?: RelatedArchiveOwner;
+  owner?: ArchiveOwner;
   pic?: string;
   cover43?: string;
   duration?: number;
@@ -40,6 +110,49 @@ interface RelatedArchiveItem {
   ctime?: number;
   tname?: string;
 }
+
+interface BiliRegionArchive {
+  aid?: number;
+  bvid?: string;
+  cid?: number;
+  title?: string;
+  owner?: ArchiveOwner;
+  author?: string;
+  pic?: string;
+  cover?: string;
+  first_frame?: string;
+  duration?: number;
+  pubdate?: number;
+  ctime?: number;
+  tname?: string;
+}
+
+interface BiliRegionResponse {
+  archives?: BiliRegionArchive[];
+  items?: BiliRegionArchive[];
+  list?: BiliRegionArchive[];
+  result?: BiliRegionArchive[];
+}
+
+const REGION_MAPPINGS: RegionMapping[] = [
+  { rid: 1, regionName: '动画', labels: ['动画', 'mad', 'mmd', '手书', '配音'] },
+  { rid: 13, regionName: '番剧', labels: ['番剧', '追番', '动漫番剧'] },
+  { rid: 167, regionName: '国创', labels: ['国创', '国产动画'] },
+  { rid: 3, regionName: '音乐', labels: ['音乐', '歌曲', '演奏', '翻唱', '乐器'] },
+  { rid: 129, regionName: '舞蹈', labels: ['舞蹈', '宅舞'] },
+  { rid: 4, regionName: '游戏', labels: ['游戏', '单机游戏', '网络游戏', '手游', '电竞'] },
+  { rid: 36, regionName: '知识', labels: ['知识', '科普', '学习', '教程', '公开课', '财经', '人文历史', '社科'] },
+  { rid: 188, regionName: '科技', labels: ['科技', '数码', '编程', '程序员', '开发', 'ai', 'aigc', '人工智能', '机器学习', '电脑装机'] },
+  { rid: 234, regionName: '运动', labels: ['运动', '健身', '篮球', '足球'] },
+  { rid: 223, regionName: '汽车', labels: ['汽车', '新能源车'] },
+  { rid: 160, regionName: '生活', labels: ['生活', '日常', 'vlog', '家居', '手工', '绘画'] },
+  { rid: 211, regionName: '美食', labels: ['美食', '料理', '探店'] },
+  { rid: 119, regionName: '鬼畜', labels: ['鬼畜'] },
+  { rid: 155, regionName: '时尚', labels: ['时尚', '美妆', '穿搭'] },
+  { rid: 5, regionName: '娱乐', labels: ['娱乐', '综艺', '明星'] },
+  { rid: 181, regionName: '影视', labels: ['影视', '电影解说', '电视剧', '纪录片'] },
+  { rid: 202, regionName: '资讯', labels: ['资讯', '新闻'] },
+];
 
 export async function fetchRelatedVideoCandidates(
   seeds: RelatedVideoSeed[],
@@ -51,6 +164,7 @@ export async function fetchRelatedVideoCandidates(
   const candidates: ExperimentRealVideoCandidate[] = [];
   const failures: ExperimentRealCandidateFailure[] = [];
   const seenBvids = new Set(selectedSeeds.map(seed => seed.bvid));
+  const { biliGet } = await import('./client.ts');
 
   for (const seed of selectedSeeds) {
     if (options.signal?.aborted) throw new Error('SYNC_CANCELLED');
@@ -69,7 +183,7 @@ export async function fetchRelatedVideoCandidates(
       );
       const relatedItems = Array.isArray(data) ? data : [];
       if (relatedItems.length === 0) {
-        failures.push(toFailure(seed, 'empty_response'));
+        failures.push(toRelatedFailure(seed, 'empty_response'));
         continue;
       }
 
@@ -84,11 +198,11 @@ export async function fetchRelatedVideoCandidates(
       }
 
       if (accepted === 0) {
-        failures.push(toFailure(seed, 'no_valid_candidates'));
+        failures.push(toRelatedFailure(seed, 'no_valid_candidates'));
       }
     } catch (error) {
       if (options.signal?.aborted && error instanceof Error && error.message === 'SYNC_CANCELLED') throw error;
-      failures.push(toFailure(seed, 'request_failed'));
+      failures.push(toRelatedFailure(seed, 'request_failed'));
     } finally {
       clearTimeout(seedTimer);
       options.signal?.removeEventListener('abort', abortFromExternal);
@@ -104,7 +218,204 @@ export async function fetchRelatedVideoCandidates(
   };
 }
 
-function toFailure(
+export async function fetchVarietyRegionCandidatePool(
+  records: WatchHistoryRecord[],
+  options: VarietyRegionCandidateOptions = {},
+): Promise<VarietyRegionCandidatePool> {
+  const nowMs = options.nowMs ?? Date.now();
+  const directions = buildVarietyRegionDirections(records, {
+    nowMs,
+    maxDirections: options.maxDirections ?? MAX_REGION_DIRECTIONS,
+  });
+
+  if (directions.length === 0) {
+    return buildNoDirectionPool(records, nowMs);
+  }
+
+  const recentBvids = recentWatchedBvids(records, nowMs);
+  const candidatesByBvid = new Map<string, ExperimentVideoCandidate>();
+  const failures: string[] = [];
+  let checkedRegionCount = 0;
+  let excludedRecentBvidCount = 0;
+  let excludedInvalidCandidateCount = 0;
+  const { biliGet } = await import('./client.ts');
+
+  for (const direction of directions) {
+    checkedRegionCount += 1;
+    try {
+      const data = await biliGet<BiliRegionResponse>(
+        '/x/web-interface/dynamic/region',
+        {
+          rid: String(direction.rid),
+          pn: '1',
+          ps: String(options.pageSize ?? REGION_PAGE_SIZE),
+        },
+        2,
+        false,
+        options.signal,
+      );
+      for (const archive of getRegionArchives(data)) {
+        const video = toRegionVideoCandidate(archive, direction);
+        if (!video) {
+          excludedInvalidCandidateCount += 1;
+          continue;
+        }
+        if (recentBvids.has(video.bvid)) {
+          excludedRecentBvidCount += 1;
+          continue;
+        }
+        if (!candidatesByBvid.has(video.bvid)) {
+          candidatesByBvid.set(video.bvid, video);
+        }
+      }
+    } catch (error) {
+      failures.push(`${direction.regionName}: ${readableCandidateError(error)}`);
+    }
+  }
+
+  const candidates = [...candidatesByBvid.values()];
+  if (candidates.length > 0) {
+    return {
+      status: 'ready',
+      sourceLabel: REGION_SOURCE_LABEL,
+      directions,
+      candidates,
+      evidence: buildDirectionEvidence(directions[0], candidates.length, excludedRecentBvidCount),
+      checkedRegionCount,
+      excludedRecentBvidCount,
+      excludedInvalidCandidateCount,
+    };
+  }
+
+  const status = failures.length >= checkedRegionCount ? 'source_failed' : 'empty';
+  return {
+    status,
+    sourceLabel: REGION_SOURCE_LABEL,
+    directions,
+    candidates: [],
+    evidence: [
+      ...buildDirectionEvidence(directions[0], 0, excludedRecentBvidCount),
+      status === 'source_failed'
+        ? `分区新视频候选源暂时不可用：${failures.join('；') || '请求失败'}。`
+        : '已找到冷却方向，但这次分区新视频候选池没有留下可打开候选。',
+    ],
+    failureReason: failures.join('；') || undefined,
+    checkedRegionCount,
+    excludedRecentBvidCount,
+    excludedInvalidCandidateCount,
+  };
+}
+
+export function buildVarietyRegionSourceFailure(
+  records: WatchHistoryRecord[],
+  nowMs: number,
+  error: unknown,
+): VarietyRegionCandidatePool {
+  const directions = buildVarietyRegionDirections(records, {
+    nowMs,
+    maxDirections: MAX_REGION_DIRECTIONS,
+  });
+  return {
+    status: 'source_failed',
+    sourceLabel: REGION_SOURCE_LABEL,
+    directions,
+    candidates: [],
+    evidence: directions[0]
+      ? [
+        ...buildDirectionEvidence(directions[0], 0, 0),
+        `真实候选源请求失败：${readableCandidateError(error)}。`,
+      ]
+      : ['本地历史还没有形成可映射到 B 站分区的冷却方向。'],
+    failureReason: readableCandidateError(error),
+    checkedRegionCount: 0,
+    excludedRecentBvidCount: 0,
+    excludedInvalidCandidateCount: 0,
+  };
+}
+
+export function buildVarietyRegionDirections(
+  records: WatchHistoryRecord[],
+  options: { nowMs?: number; maxDirections?: number } = {},
+): VarietyRegionDirection[] {
+  const nowMs = options.nowMs ?? Date.now();
+  const longCutoffMs = nowMs - LONG_WINDOW_DAYS * DAY_MS;
+  const recentCutoffMs = nowMs - RECENT_WINDOW_DAYS * DAY_MS;
+  const longRecords = records.filter(record => toEpochMs(record.viewAt) >= longCutoffMs);
+  const recentRecords = longRecords.filter(record => toEpochMs(record.viewAt) >= recentCutoffMs);
+  const totalLongPositive = Math.max(1, longRecords.filter(isPositiveRecord).length);
+  const recentHighLabels = buildRecentHighLabels(recentRecords);
+  const recentHighKeys = new Set(recentHighLabels.map(normalizeLabel));
+  const groups = new Map<string, { signal: InterestSignal; records: WatchHistoryRecord[] }>();
+
+  for (const record of longRecords) {
+    for (const signal of getRecordSignals(record)) {
+      const existing = groups.get(signal.key);
+      if (existing) {
+        existing.records.push(record);
+      } else {
+        groups.set(signal.key, { signal, records: [record] });
+      }
+    }
+  }
+
+  const directionsByRid = new Map<number, VarietyRegionDirection>();
+
+  for (const group of groups.values()) {
+    const positiveRecords = group.records.filter(isPositiveRecord);
+    if (positiveRecords.length < MIN_LONG_POSITIVE_COUNT) continue;
+    if (recentHighKeys.has(normalizeLabel(group.signal.label))) continue;
+
+    const recentGroupRecords = group.records.filter(record => toEpochMs(record.viewAt) >= recentCutoffMs);
+    const recentPositiveRecords = recentGroupRecords.filter(isPositiveRecord);
+    const expectedRecentPositive = positiveRecords.length * (RECENT_WINDOW_DAYS / LONG_WINDOW_DAYS);
+    const cooldownRatio = expectedRecentPositive > 0
+      ? recentPositiveRecords.length / expectedRecentPositive
+      : 0;
+
+    if (cooldownRatio > 0.85) continue;
+
+    const lastWatchMs = Math.max(...group.records.map(record => toEpochMs(record.viewAt)));
+    const daysSinceLastWatch = lastWatchMs > 0
+      ? Math.max(1, Math.floor((nowMs - lastWatchMs) / DAY_MS))
+      : null;
+    const longPositiveShare = positiveRecords.length / totalLongPositive;
+    const cooldownStrength = 1 - Math.min(cooldownRatio, 1);
+    const staleBoost = daysSinceLastWatch == null ? 0 : Math.min(daysSinceLastWatch / RECENT_WINDOW_DAYS, 2);
+    const score = positiveRecords.length * 8
+      + longPositiveShare * 35
+      + cooldownStrength * 24
+      + staleBoost * 4
+      + (group.signal.kind === 'tag' ? 1.5 : 0);
+
+    const direction: VarietyRegionDirection = {
+      key: group.signal.key,
+      kind: group.signal.kind,
+      label: group.signal.label,
+      rid: group.signal.rid,
+      regionName: group.signal.regionName,
+      longWatchedCount: group.records.length,
+      longPositiveCount: positiveRecords.length,
+      recentWatchedCount: recentGroupRecords.length,
+      recentPositiveCount: recentPositiveRecords.length,
+      expectedRecentPositive,
+      cooldownRatio,
+      daysSinceLastWatch,
+      recentHighLabels,
+      score: Math.round(score * 100) / 100,
+    };
+
+    const existing = directionsByRid.get(direction.rid);
+    if (!existing || direction.score > existing.score) {
+      directionsByRid.set(direction.rid, direction);
+    }
+  }
+
+  return [...directionsByRid.values()]
+    .sort((a, b) => b.score - a.score || a.regionName.localeCompare(b.regionName, 'zh-CN'))
+    .slice(0, options.maxDirections ?? MAX_REGION_DIRECTIONS);
+}
+
+function toRelatedFailure(
   seed: RelatedVideoSeed,
   reason: ExperimentRealCandidateFailure['reason'],
 ): ExperimentRealCandidateFailure {
@@ -134,12 +445,169 @@ function toRelatedCandidate(
     title,
     authorName: cleanText(item.owner?.name) || '未知 UP',
     authorMid: positiveNumber(item.owner?.mid),
-    cover: cleanText(item.pic) || cleanText(item.cover43),
+    cover: normalizeImageUrl(item.pic || item.cover43),
     duration: positiveNumber(item.duration),
     pubtime: positiveNumber(item.pubdate) ?? positiveNumber(item.ctime),
     tagName: cleanText(item.tname),
     url: buildVideoUrl(bvid),
   };
+}
+
+function buildNoDirectionPool(records: WatchHistoryRecord[], nowMs: number): VarietyRegionCandidatePool {
+  const positiveRecords = records
+    .filter(record => toEpochMs(record.viewAt) >= nowMs - LONG_WINDOW_DAYS * DAY_MS)
+    .filter(isPositiveRecord);
+  const mappedSignalCount = positiveRecords
+    .flatMap(record => getRecordSignals(record))
+    .length;
+  const status: VarietyRegionCandidatePoolStatus = positiveRecords.length < MIN_LONG_POSITIVE_COUNT
+    ? 'insufficient_local_evidence'
+    : mappedSignalCount === 0
+      ? 'unmapped_interest'
+      : 'empty';
+
+  return {
+    status,
+    sourceLabel: REGION_SOURCE_LABEL,
+    directions: [],
+    candidates: [],
+    evidence: [
+      `近 ${LONG_WINDOW_DAYS} 天本地正向观看 ${positiveRecords.length} 条，换口味至少需要 ${MIN_LONG_POSITIVE_COUNT} 条可聚合兴趣证据。`,
+      status === 'unmapped_interest'
+        ? '本地长期兴趣还不能保守映射到 B 站公开分区，暂不硬凑真实候选。'
+        : '没有找到长期相关但近期低频的分区方向，避免从近期高频口味里抽。',
+    ],
+    checkedRegionCount: 0,
+    excludedRecentBvidCount: 0,
+    excludedInvalidCandidateCount: 0,
+  };
+}
+
+function buildDirectionEvidence(
+  direction: VarietyRegionDirection,
+  candidateCount: number,
+  excludedRecentBvidCount: number,
+): string[] {
+  const recentHigh = direction.recentHighLabels.length > 0
+    ? direction.recentHighLabels.join('、')
+    : '暂无明显高频口味';
+  return [
+    `长期 ${LONG_WINDOW_DAYS} 天里，「${direction.label}」有 ${direction.longWatchedCount} 条观看、${direction.longPositiveCount} 条正向观看。`,
+    `近期 ${RECENT_WINDOW_DAYS} 天里，这个方向正向观看 ${direction.recentPositiveCount} 条；按长期节奏预期约 ${formatCount(direction.expectedRecentPositive)} 条。`,
+    `最近高频口味是：${recentHigh}；本次只从冷却方向「${direction.regionName}」分区取新视频候选。`,
+    `真实候选池返回 ${candidateCount} 条可打开视频，已排除最近 ${RECENT_VIDEO_BLOCK_DAYS} 天本地看过的同 bvid ${excludedRecentBvidCount} 条。`,
+  ];
+}
+
+function getRecordSignals(record: WatchHistoryRecord): InterestSignal[] {
+  const signals = [
+    toInterestSignal('category', record.tagName),
+    ...(record.tags ?? []).map(tag => toInterestSignal('tag', tag)),
+  ].filter((signal): signal is InterestSignal => Boolean(signal));
+  const result: InterestSignal[] = [];
+  const seen = new Set<string>();
+  for (const signal of signals) {
+    if (seen.has(signal.key)) continue;
+    seen.add(signal.key);
+    result.push(signal);
+  }
+  return result;
+}
+
+function toInterestSignal(kind: VarietyRegionInterestKind, rawLabel: string | undefined): InterestSignal | null {
+  const label = cleanText(rawLabel);
+  if (!label) return null;
+  const region = resolveRegion(label);
+  if (!region) return null;
+  return {
+    key: `${kind}:${normalizeLabel(label)}:${region.rid}`,
+    kind,
+    label,
+    rid: region.rid,
+    regionName: region.regionName,
+  };
+}
+
+function resolveRegion(label: string): RegionMapping | null {
+  const normalized = normalizeLabel(label);
+  if (!normalized) return null;
+  for (const mapping of REGION_MAPPINGS) {
+    for (const candidate of mapping.labels.map(normalizeLabel)) {
+      if (normalized === candidate || normalized.includes(candidate) || candidate.includes(normalized)) {
+        return mapping;
+      }
+    }
+  }
+  return null;
+}
+
+function buildRecentHighLabels(records: WatchHistoryRecord[]): string[] {
+  const counts = new Map<string, { label: string; count: number }>();
+  for (const record of records.filter(isPositiveRecord)) {
+    const seenInRecord = new Set<string>();
+    for (const signal of getRecordSignals(record)) {
+      const key = normalizeLabel(signal.label);
+      if (!key || seenInRecord.has(key)) continue;
+      seenInRecord.add(key);
+      const existing = counts.get(key);
+      counts.set(key, {
+        label: existing?.label ?? signal.label,
+        count: (existing?.count ?? 0) + 1,
+      });
+    }
+  }
+
+  return [...counts.values()]
+    .filter(entry => entry.count >= 2)
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label, 'zh-CN'))
+    .slice(0, 3)
+    .map(entry => entry.label);
+}
+
+function getRegionArchives(data: BiliRegionResponse): BiliRegionArchive[] {
+  if (Array.isArray(data.archives)) return data.archives;
+  if (Array.isArray(data.items)) return data.items;
+  if (Array.isArray(data.list)) return data.list;
+  if (Array.isArray(data.result)) return data.result;
+  return [];
+}
+
+function toRegionVideoCandidate(
+  archive: BiliRegionArchive,
+  direction: VarietyRegionDirection,
+): ExperimentVideoCandidate | null {
+  const bvid = cleanText(archive.bvid);
+  if (!isLikelyBvid(bvid)) return null;
+  const title = stripHtml(cleanText(archive.title));
+  return {
+    bvid,
+    avid: positiveNumber(archive.aid),
+    cid: positiveNumber(archive.cid),
+    title: title || bvid,
+    authorName: cleanText(archive.owner?.name) || cleanText(archive.author) || '未知 UP',
+    authorMid: positiveNumber(archive.owner?.mid),
+    cover: normalizeImageUrl(archive.pic || archive.cover || archive.first_frame),
+    url: buildVideoUrl(bvid),
+    duration: positiveNumber(archive.duration),
+    pubtime: positiveNumber(archive.pubdate ?? archive.ctime),
+    publishedAt: positiveNumber(archive.pubdate ?? archive.ctime),
+    tagName: cleanText(archive.tname) || direction.label,
+    sourceKind: 'bili_region_dynamic',
+    sourceLabel: `${REGION_SOURCE_LABEL} / ${direction.regionName}`,
+    regionRid: direction.rid,
+    regionName: direction.regionName,
+    cooldownLabel: direction.label,
+  };
+}
+
+function recentWatchedBvids(records: WatchHistoryRecord[], nowMs: number): Set<string> {
+  const cutoffMs = nowMs - RECENT_VIDEO_BLOCK_DAYS * DAY_MS;
+  return new Set(
+    records
+      .filter(record => toEpochMs(record.viewAt) >= cutoffMs)
+      .map(record => cleanText(record.bvid))
+      .filter(Boolean),
+  );
 }
 
 function normalizeSeeds(seeds: RelatedVideoSeed[]): RelatedVideoSeed[] {
@@ -157,8 +625,24 @@ function normalizeSeeds(seeds: RelatedVideoSeed[]): RelatedVideoSeed[] {
   return normalized;
 }
 
+function isPositiveRecord(record: WatchHistoryRecord): boolean {
+  return record.actualCompletion >= POSITIVE_COMPLETION
+    || Math.max(0, record.progress) >= Math.min(Math.max(0, record.duration), 900);
+}
+
 function cleanText(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeLabel(value: unknown): string {
+  return cleanText(value)
+    .toLocaleLowerCase()
+    .replace(/[\s_\-·/｜|]+/g, '');
+}
+
+function toEpochMs(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return value > 1_000_000_000_000 ? value : value * 1000;
 }
 
 function positiveNumber(value: unknown): number | undefined {
@@ -172,10 +656,35 @@ function clampPositive(value: unknown, fallback: number): number {
   return Math.max(1, Math.floor(numeric));
 }
 
+function normalizeImageUrl(value: unknown): string {
+  const url = cleanText(value);
+  if (!url) return '';
+  if (url.startsWith('//')) return `https:${url}`;
+  return url;
+}
+
+function stripHtml(value: string): string {
+  return value.replace(/<[^>]*>/g, '').trim();
+}
+
 function isLikelyBvid(value: string): boolean {
   return /^BV[0-9A-Za-z]{8,}$/.test(value);
 }
 
 function buildVideoUrl(bvid: string): string {
   return `https://www.bilibili.com/video/${encodeURIComponent(bvid)}`;
+}
+
+function formatCount(value: number): string {
+  return String(Math.round(value * 10) / 10);
+}
+
+function readableCandidateError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
 }

--- a/src/shared/types/analytics.ts
+++ b/src/shared/types/analytics.ts
@@ -189,9 +189,15 @@ export interface ExperimentVideoCandidate {
   pubtime?: number;
   tagName?: string;
   url: string;
+  publishedAt?: number;
+  sourceKind?: 'local_history' | 'local_favorite' | 'bilibili_related' | 'bili_region_dynamic';
+  sourceLabel?: string;
+  regionRid?: number;
+  regionName?: string;
+  cooldownLabel?: string;
 }
 
-export type ExperimentRealCandidateSourceKind = 'bilibili_related';
+export type ExperimentRealCandidateSourceKind = 'bilibili_related' | 'bili_region_dynamic';
 
 export interface ExperimentRealVideoCandidate extends ExperimentVideoCandidate {
   sourceKind: ExperimentRealCandidateSourceKind;
@@ -222,6 +228,7 @@ export interface ExperimentBlindBox {
   reason: string;
   evidence: string[];
   state: ExperimentBlindBoxState;
+  statusLabel?: string;
   video?: ExperimentVideoCandidate;
   emptyTitle?: string;
   emptyDescription?: string;

--- a/tests/experiment-blind-boxes.test.ts
+++ b/tests/experiment-blind-boxes.test.ts
@@ -1,32 +1,26 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { buildExperimentData } from '../src/background/analytics/suggestions.ts';
+import {
+  buildVarietyRegionDirections,
+  type VarietyRegionCandidatePool,
+  type VarietyRegionDirection,
+} from '../src/background/api/video-blind-box-candidates.ts';
 import type { ExperimentRealCandidatePool } from '../src/shared/types/analytics';
 import type { FavoriteItem, SmartFavoriteIndex } from '../src/shared/types/favorite';
 import type { WatchHistoryRecord } from '../src/shared/types/watch-event';
 
 const NOW_MS = Date.UTC(2026, 5, 13, 12, 0, 0);
 
-test('builds blind boxes with a real random explore candidate source', () => {
-  const bannedGuessWord = `猜${'你喜欢'}`;
-  const records: WatchHistoryRecord[] = [
-    createRecord({ bvid: 'BVREC001', tagName: '游戏', daysAgo: 3, actualCompletion: 0.82, title: '最近游戏 1' }),
-    createRecord({ bvid: 'BVREC002', tagName: '游戏', daysAgo: 5, actualCompletion: 0.78, title: '最近游戏 2' }),
-    createRecord({ bvid: 'BVREC003', tagName: '游戏', daysAgo: 8, actualCompletion: 0.75, title: '最近游戏 3' }),
-    createRecord({ bvid: 'BVREC004', tagName: '游戏', daysAgo: 12, actualCompletion: 0.88, title: '最近游戏 4' }),
-    createRecord({ bvid: 'BVREC005', tagName: '游戏', daysAgo: 16, actualCompletion: 0.8, title: '最近游戏 5' }),
-    createRecord({ bvid: 'BVREC006', tagName: '游戏', daysAgo: 22, actualCompletion: 0.79, title: '最近游戏 6' }),
-    createRecord({ bvid: 'BVKNO001', tagName: '知识', daysAgo: 120, actualCompletion: 0.92, title: '旧兴趣 1' }),
-    createRecord({ bvid: 'BVKNO002', tagName: '知识', daysAgo: 145, actualCompletion: 0.94, title: '旧兴趣 2' }),
-    createRecord({ bvid: 'BVKNO003', tagName: '知识', daysAgo: 170, actualCompletion: 0.9, title: '旧兴趣 3' }),
-    createRecord({ bvid: 'BVKNO004', tagName: '知识', daysAgo: 210, actualCompletion: 0.89, title: '旧兴趣 4' }),
-  ];
+test('builds blind boxes with real random explore and real variety candidate sources', () => {
+  const bannedGuessWord = ['猜你', '喜欢'].join('');
+  const records = createMixedTasteRecords();
 
   const favorites: FavoriteItem[] = [
     createFavorite({
-      itemKey: 'variety',
+      itemKey: 'variety-local-only',
       bvid: 'BVFAVVAR1',
-      title: '编程收藏视频',
+      title: '本地收藏不应作为换口味候选',
       folderTitle: '技术夹',
       tagName: '科技',
       favDaysAgo: 240,
@@ -50,18 +44,15 @@ test('builds blind boxes with a real random explore candidate source', () => {
   ];
 
   const smartIndexByItemKey = new Map<string, SmartFavoriteIndex>([
-    ['variety', createSmartIndex('variety', ['科技', '编程'])],
+    ['variety-local-only', createSmartIndex('variety-local-only', ['科技', '编程'])],
     ['hidden', createSmartIndex('hidden', ['游戏', '攻略'])],
     ['random', createSmartIndex('random', ['生活', '旅行'])],
   ]);
 
-  const data = buildExperimentData(
-    records,
-    favorites,
-    smartIndexByItemKey,
-    NOW_MS,
-    createRelatedPool(),
-  );
+  const data = buildExperimentData(records, favorites, smartIndexByItemKey, NOW_MS, {
+    randomExplorePool: createRelatedPool(),
+    varietyRegionPool: createReadyRegionPool(),
+  });
 
   assert.deepEqual(data.blindBoxes.map(box => box.id), [
     'variety',
@@ -73,8 +64,15 @@ test('builds blind boxes with a real random explore candidate source', () => {
   const [variety, hiddenFavorite, reviveInterest, randomExplore] = data.blindBoxes;
 
   assert.equal(variety.state, 'ready');
-  assert.equal(variety.video?.bvid, 'BVFAVVAR1');
-  assert.match(variety.reason, /换口味|主口味|最近 45 天/);
+  assert.equal(variety.statusLabel, '真实候选');
+  assert.equal(variety.video?.bvid, 'BV1REAL139A');
+  assert.equal(variety.video?.sourceKind, 'bili_region_dynamic');
+  assert.notEqual(variety.video?.bvid, 'BVFAVVAR1');
+  assert.match(variety.source, /B 站分区新视频/);
+  assert.match(variety.reason, /长期看过「知识」/);
+  assert.match(variety.reason, /最近 30 天/);
+  assert.match(variety.reason, /游戏/);
+  assert.ok(variety.evidence.some(line => line.includes('本地历史和收藏只参与选择冷却方向与解释')));
 
   assert.equal(hiddenFavorite.state, 'ready');
   assert.equal(hiddenFavorite.video?.bvid, 'BVFAVHID1');
@@ -86,6 +84,7 @@ test('builds blind boxes with a real random explore candidate source', () => {
 
   assert.equal(randomExplore.state, 'ready');
   assert.equal(randomExplore.video?.bvid, 'BV1REALRND01');
+  assert.equal(randomExplore.video?.sourceKind, 'bilibili_related');
   assert.match(randomExplore.source, /相关视频候选/);
   assert.match(randomExplore.source, /种子视频/);
   assert.match(randomExplore.reason, /没有保留平台排序|随机抽取/);
@@ -105,10 +104,74 @@ test('builds blind boxes with a real random explore candidate source', () => {
   }
 });
 
+test('selects cooled long-term region directions instead of recent high-frequency interests', () => {
+  const directions = buildVarietyRegionDirections(createMixedTasteRecords(), { nowMs: NOW_MS });
+
+  assert.ok(directions.length > 0);
+  assert.equal(directions[0].regionName, '知识');
+  assert.equal(directions[0].label, '知识');
+  assert.equal(directions[0].recentPositiveCount, 0);
+  assert.ok(directions[0].recentHighLabels.includes('游戏'));
+  assert.equal(directions.some(direction => direction.regionName === '游戏'), false);
+});
+
+test('returns a clear downgrade when the real region candidate source fails', () => {
+  const data = buildExperimentData(
+    createMixedTasteRecords(),
+    [],
+    new Map(),
+    NOW_MS,
+    {
+      randomExplorePool: createRelatedPool(),
+      varietyRegionPool: {
+        status: 'source_failed',
+        sourceLabel: 'B 站分区新视频',
+        directions: [createKnowledgeDirection()],
+        candidates: [],
+        evidence: [
+          '长期 180 天里，「知识」有 4 条观看、4 条正向观看。',
+          '分区新视频候选源暂时不可用：RATE_LIMITED。',
+        ],
+        failureReason: 'RATE_LIMITED',
+        checkedRegionCount: 1,
+        excludedRecentBvidCount: 0,
+        excludedInvalidCandidateCount: 0,
+      },
+    },
+  );
+
+  const variety = data.blindBoxes[0];
+  assert.equal(variety.id, 'variety');
+  assert.equal(variety.state, 'empty');
+  assert.equal(variety.statusLabel, '候选源暂不可用');
+  assert.equal(variety.source, 'B 站分区新视频');
+  assert.match(variety.emptyTitle ?? '', /候选源暂不可用/);
+  assert.match(variety.emptyDescription ?? '', /不显示空视频/);
+  assert.equal(variety.video, undefined);
+});
+
 test('returns Chinese empty states instead of generic filler when local evidence is insufficient', () => {
-  const bannedGuessWord = `猜${'你喜欢'}`;
-  const bannedUnconsumedWord = `未${'消费'}`;
-  const data = buildExperimentData([], [], new Map(), NOW_MS);
+  const bannedGuessWord = ['猜你', '喜欢'].join('');
+  const bannedUnconsumedWord = ['未', '消费'].join('');
+  const data = buildExperimentData([], [], new Map(), NOW_MS, {
+    randomExplorePool: {
+      sourceKind: 'bilibili_related',
+      sourceLabel: '相关视频候选',
+      seedCount: 0,
+      candidates: [],
+      failures: [],
+    },
+    varietyRegionPool: {
+      status: 'insufficient_local_evidence',
+      sourceLabel: 'B 站分区新视频',
+      directions: [],
+      candidates: [],
+      evidence: ['近 180 天本地正向观看 0 条，换口味至少需要 2 条可聚合兴趣证据。'],
+      checkedRegionCount: 0,
+      excludedRecentBvidCount: 0,
+      excludedInvalidCandidateCount: 0,
+    },
+  });
 
   assert.equal(data.blindBoxes.length, 4);
   for (const box of data.blindBoxes) {
@@ -148,6 +211,78 @@ test('does not fall back to a local random video when related candidates fail', 
   assert.match(randomExplore.emptyDescription ?? '', /不会用本地库存视频冒充/);
   assert.ok(randomExplore.evidence.some(line => line.includes('请求失败')));
 });
+
+function createMixedTasteRecords(): WatchHistoryRecord[] {
+  return [
+    createRecord({ bvid: 'BVREC001', tagName: '游戏', daysAgo: 3, actualCompletion: 0.82, title: '最近游戏 1' }),
+    createRecord({ bvid: 'BVREC002', tagName: '游戏', daysAgo: 5, actualCompletion: 0.78, title: '最近游戏 2' }),
+    createRecord({ bvid: 'BVREC003', tagName: '游戏', daysAgo: 8, actualCompletion: 0.75, title: '最近游戏 3' }),
+    createRecord({ bvid: 'BVREC004', tagName: '游戏', daysAgo: 12, actualCompletion: 0.88, title: '最近游戏 4' }),
+    createRecord({ bvid: 'BVREC005', tagName: '游戏', daysAgo: 16, actualCompletion: 0.8, title: '最近游戏 5' }),
+    createRecord({ bvid: 'BVREC006', tagName: '游戏', daysAgo: 22, actualCompletion: 0.79, title: '最近游戏 6' }),
+    createRecord({ bvid: 'BVKNO001', tagName: '知识', daysAgo: 120, actualCompletion: 0.92, title: '旧兴趣 1' }),
+    createRecord({ bvid: 'BVKNO002', tagName: '知识', daysAgo: 145, actualCompletion: 0.94, title: '旧兴趣 2' }),
+    createRecord({ bvid: 'BVKNO003', tagName: '知识', daysAgo: 170, actualCompletion: 0.9, title: '旧兴趣 3' }),
+    createRecord({ bvid: 'BVKNO004', tagName: '知识', daysAgo: 175, actualCompletion: 0.89, title: '旧兴趣 4' }),
+  ];
+}
+
+function createReadyRegionPool(): VarietyRegionCandidatePool {
+  const direction = createKnowledgeDirection();
+  return {
+    status: 'ready',
+    sourceLabel: 'B 站分区新视频',
+    directions: [direction],
+    candidates: [
+      {
+        bvid: 'BV1REAL139A',
+        avid: 139001,
+        cid: 139002,
+        title: '真实分区新视频',
+        authorName: '公开知识 UP',
+        authorMid: 139003,
+        cover: 'https://example.com/real-region.jpg',
+        url: 'https://www.bilibili.com/video/BV1REAL139A',
+        duration: 900,
+        publishedAt: Math.floor(NOW_MS / 1000),
+        tagName: '知识',
+        sourceKind: 'bili_region_dynamic',
+        sourceLabel: 'B 站分区新视频 / 知识',
+        regionRid: 36,
+        regionName: '知识',
+        cooldownLabel: '知识',
+      },
+    ],
+    evidence: [
+      '长期 180 天里，「知识」有 4 条观看、4 条正向观看。',
+      '近期 30 天里，这个方向正向观看 0 条；按长期节奏预期约 0.7 条。',
+      '最近高频口味是：游戏；本次只从冷却方向「知识」分区取新视频候选。',
+      '真实候选池返回 1 条可打开视频，已排除最近 90 天本地看过的同 bvid 0 条。',
+    ],
+    checkedRegionCount: 1,
+    excludedRecentBvidCount: 0,
+    excludedInvalidCandidateCount: 0,
+  };
+}
+
+function createKnowledgeDirection(): VarietyRegionDirection {
+  return {
+    key: 'category:知识:36',
+    kind: 'category',
+    label: '知识',
+    rid: 36,
+    regionName: '知识',
+    longWatchedCount: 4,
+    longPositiveCount: 4,
+    recentWatchedCount: 0,
+    recentPositiveCount: 0,
+    expectedRecentPositive: 0.7,
+    cooldownRatio: 0,
+    daysSinceLastWatch: 120,
+    recentHighLabels: ['游戏'],
+    score: 100,
+  };
+}
 
 function createRecord(input: {
   bvid: string;


### PR DESCRIPTION
## Scope
- Implements Issue #139 "???" MVP with a real Bilibili candidate pool from `/x/web-interface/dynamic/region`.
- Uses local long-term interest and recent cooldown signals only to choose conservative region directions and explain the result.
- Keeps local history/favorites out of the variety candidate corpus; they are only used for direction selection, cooldown filtering, and evidence copy.
- Adds clear downgrade states for insufficient local evidence, unmapped interests, source failures, and empty filtered pools.
- Updates the experiments page copy/status labels so users can distinguish the real variety source from local-only boxes.

## Privacy and Safety
- No Cookie files, browser profiles, Bilibili login-state files, local key files, or `C:\Users\LittleNub\Desktop\Key.txt` were read.
- No full history, full favorites, full following list, or feedback is uploaded to AI or any new service.
- New Bilibili requests only send conservative region pagination params (`rid`, `pn`, `ps`) through the existing read-only `biliGet` client.
- No Bilibili relationship, favorite, comment, like, coin, or watch-state writeback is added.

## Validation
- `npm run test:experiments`
- `npm run typecheck`
- `npm run build`
- `git diff --check` (passes with existing CRLF working-copy warnings only)
- `rg -n "???|????" dashboard popup public src README.md tests` (no matches)
- Browser/mock QA via Playwright against local Vite: verified real variety card, source/reason copy, Bilibili video link open, and source-failure downgrade with no empty video link.

## Notes
- Build still reports the existing large `chunks/theme-*.js` warning.
- Vite notes the dynamic import of `api/client.ts` does not split a chunk because the client is already statically imported elsewhere; this is expected and keeps Node tests from loading the network client for pure direction tests.
