### PR TITLE
[codex] Consolidate blind box source boundaries

### DIFF
--- a/dashboard/modules/experiments/ExperimentsPage.tsx
+++ b/dashboard/modules/experiments/ExperimentsPage.tsx
@@ -60,7 +60,7 @@ export function ExperimentsPage() {
         }}>
           <div style={{ color: '#FFFFFF', fontSize: '18px', fontWeight: 700, marginBottom: '8px' }}>视频盲盒</div>
           <div style={{ color: '#D4D8E8', fontSize: '13px', lineHeight: 1.7 }}>
-            随机探索会从真实 B 站相关视频候选池里随机抽取；换口味会先用本地长期兴趣和近期冷却选择方向，再从 B 站公开分区新视频候选池抽取。冷门收藏和久未观看兴趣仍按本地证据工作；这里不做推荐排序，也不会写回 B 站。
+            随机探索从真实 B 站相关视频候选池里随机抽取；换口味先用本地长期兴趣和近期低频方向，再从 B 站公开分区新视频候选池抽取。冷门收藏只回访本地收藏；本地兴趣回顾只看本地历史，动态账单继续负责兴趣再平衡。这里不按点击偏好排队，也不会写回 B 站。
           </div>
           <div style={{ color: '#8F97B5', fontSize: '12px', marginTop: '8px' }}>
             最近生成时间：{new Date(data.generatedAt).toLocaleString('zh-CN')}
@@ -77,7 +77,7 @@ export function ExperimentsPage() {
             const isReady = box.state === 'ready';
             const accent = CARD_ACCENT[box.id];
             const statusLabel = box.statusLabel ?? (isReady ? '可揭晓' : '本地证据不足');
-            const usesRealCandidateSource = box.id === 'random_explore' || box.id === 'variety';
+            const dependsOnRealCandidateSource = box.candidateSource.includes('B 站');
             return (
               <article
                 key={box.id}
@@ -125,10 +125,14 @@ export function ExperimentsPage() {
                   }}>
                     <div style={{ color: '#DCE2F8', fontSize: '13px', lineHeight: 1.7 }}>
                       {isReady
-                        ? '这盒里是一个可以直接打开的具体视频。揭晓后会显示标题、UP 主、来源、理由和证据。'
-                        : usesRealCandidateSource
+                        ? '这盒里是一个可以直接打开的具体视频。揭晓后会显示标题、UP 主、候选来源、真实候选状态、理由和证据。'
+                        : dependsOnRealCandidateSource
                           ? '这盒不会显示空卡，也不会用本地库存冒充真实候选。揭晓后会说明候选源或冷却方向为什么暂时不可用。'
                           : '这盒不会拿泛泛建议充数。揭晓后只会告诉你为什么本地证据还不够。'}
+                    </div>
+                    <div style={sourceMetaStyle()}>
+                      <div>候选来源：{box.candidateSource}</div>
+                      <div>真实 B 站候选：{box.realCandidateLabel}</div>
                     </div>
                     <button
                       type="button"
@@ -141,7 +145,11 @@ export function ExperimentsPage() {
                   </div>
                 ) : (
                   <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', flex: 1 }}>
-                    <div style={{ color: accent, fontSize: '12px', fontWeight: 600 }}>来源：{box.source}</div>
+                    <div style={sourceMetaStyle()}>
+                      <div>候选来源：{box.candidateSource}</div>
+                      <div>真实 B 站候选：{box.realCandidateLabel}</div>
+                      <div style={{ color: accent, fontWeight: 600 }}>来源：{box.source}</div>
+                    </div>
                     <div style={{
                       background: 'rgba(255,255,255,0.03)',
                       borderRadius: '12px',
@@ -211,12 +219,27 @@ export function ExperimentsPage() {
         }}>
           <div style={{ color: '#FFFFFF', fontSize: '13px', fontWeight: 600, marginBottom: '8px' }}>说明</div>
           <div style={{ color: '#A8B0CE', fontSize: '12px', lineHeight: 1.7 }}>
-            随机探索只使用少量本地 BV 号作为种子，请求公开相关视频候选后在本地随机抽取；换口味只把本地历史用于选择冷却方向和解释，候选视频来自 B 站公开分区新视频池；冷门收藏和久未观看兴趣仍使用本地历史或收藏。打开动作只会新开一个 B 站视频页，不会回写收藏、关注或观看状态。
+            随机探索只使用少量本地 BV 号作为种子，请求公开相关视频候选后在本地随机抽取；换口味只把本地历史用于选择冷却方向和解释，候选视频来自 B 站公开分区新视频池；冷门收藏的来源是本地收藏；本地兴趣回顾的来源是本地观看历史。打开动作只会新开一个 B 站视频页，不会回写收藏、关注或观看状态。
           </div>
         </section>
       </div>
     </ErrorBoundary>
   );
+}
+
+function sourceMetaStyle(): Record<string, string> {
+  return {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+    color: '#A8B0CE',
+    fontSize: '12px',
+    lineHeight: '1.5',
+    background: 'rgba(255,255,255,0.025)',
+    border: '1px solid rgba(255,255,255,0.06)',
+    borderRadius: '10px',
+    padding: '9px 10px',
+  };
 }
 
 function primaryButtonStyle(accent: string): Record<string, string> {

--- a/src/background/analytics/suggestions.ts
+++ b/src/background/analytics/suggestions.ts
@@ -24,6 +24,10 @@ const VARIETY_RECENT_WINDOW_DAYS = 30;
 const MIN_INTEREST_RECORDS = 4;
 const MIN_INTEREST_POSITIVE_RECORDS = 2;
 const POSITIVE_COMPLETION = 0.75;
+const RELATED_CANDIDATE_SOURCE = 'B 站公开视频的相关视频候选池';
+const REGION_CANDIDATE_SOURCE = 'B 站公开分区新视频候选池';
+const LOCAL_FAVORITE_SOURCE = '本地收藏';
+const LOCAL_HISTORY_REVIEW_SOURCE = '本地观看历史';
 
 interface BlindBoxContext {
   nowMs: number;
@@ -45,6 +49,11 @@ interface ExperimentBuildOptions {
   randomExplorePool?: ExperimentRealCandidatePool;
   varietyRegionPool?: VarietyRegionCandidatePool;
 }
+
+type BlindBoxBoundaryMeta = Pick<
+  ExperimentBlindBox,
+  'candidateSource' | 'realCandidateLabel' | 'usesRealBilibiliCandidates'
+>;
 
 export async function getExperimentData(): Promise<ExperimentData> {
   const nowMs = Date.now();
@@ -126,6 +135,38 @@ function normalizeExperimentBuildOptions(
   return value;
 }
 
+function realCandidateUsedMeta(candidateSource: string): BlindBoxBoundaryMeta {
+  return {
+    candidateSource,
+    realCandidateLabel: '已使用真实 B 站候选',
+    usesRealBilibiliCandidates: true,
+  };
+}
+
+function realCandidateUnavailableMeta(candidateSource: string, reason: string): BlindBoxBoundaryMeta {
+  return {
+    candidateSource,
+    realCandidateLabel: `未使用真实 B 站候选：${reason}`,
+    usesRealBilibiliCandidates: false,
+  };
+}
+
+function localFavoriteMeta(): BlindBoxBoundaryMeta {
+  return {
+    candidateSource: LOCAL_FAVORITE_SOURCE,
+    realCandidateLabel: '未使用真实 B 站候选：这是本地收藏回访。',
+    usesRealBilibiliCandidates: false,
+  };
+}
+
+function localHistoryReviewMeta(): BlindBoxBoundaryMeta {
+  return {
+    candidateSource: LOCAL_HISTORY_REVIEW_SOURCE,
+    realCandidateLabel: '未使用真实 B 站候选：这是本地历史回顾。',
+    usesRealBilibiliCandidates: false,
+  };
+}
+
 function buildVarietyBox(ctx: BlindBoxContext): ExperimentBlindBox {
   const title = '换口味';
   const teaser = '从长期兴趣里找一条近期少看的真实 B 站新视频。';
@@ -142,6 +183,7 @@ function buildVarietyBox(ctx: BlindBoxContext): ExperimentBlindBox {
       '候选源未返回',
       'B 站分区新视频',
       '真实候选源尚未返回，换口味不会退回本地收藏夹凑数。',
+      realCandidateUnavailableMeta(REGION_CANDIDATE_SOURCE, '候选源尚未返回。'),
     );
   }
 
@@ -156,6 +198,7 @@ function buildVarietyBox(ctx: BlindBoxContext): ExperimentBlindBox {
       varietyEmptyStatusLabel(pool.status),
       pool.sourceLabel,
       varietyEmptyReason(pool),
+      realCandidateUnavailableMeta(REGION_CANDIDATE_SOURCE, varietyRealCandidateUnavailableReason(pool)),
     );
   }
 
@@ -174,6 +217,7 @@ function buildVarietyBox(ctx: BlindBoxContext): ExperimentBlindBox {
       '候选已冷却过滤',
       pool.sourceLabel,
       '真实候选池有结果，但经过近期观看和本页占用过滤后没有剩余视频。',
+      realCandidateUnavailableMeta(REGION_CANDIDATE_SOURCE, '候选经过近期过滤后没有剩余视频。'),
     );
   }
 
@@ -185,6 +229,7 @@ function buildVarietyBox(ctx: BlindBoxContext): ExperimentBlindBox {
     id: 'variety',
     title,
     teaser,
+    ...realCandidateUsedMeta(REGION_CANDIDATE_SOURCE),
     source: pick.sourceLabel ?? `${pool.sourceLabel} / ${direction.regionName}`,
     reason: buildVarietyReason(direction, pick),
     evidence: [
@@ -269,6 +314,21 @@ function varietyEmptyReason(pool: VarietyRegionCandidatePool): string {
   }
 }
 
+function varietyRealCandidateUnavailableReason(pool: VarietyRegionCandidatePool): string {
+  switch (pool.status) {
+    case 'insufficient_local_evidence':
+      return '本地长期兴趣和近期低频方向还不够明确。';
+    case 'unmapped_interest':
+      return '本地长期兴趣暂时不能映射到 B 站公开分区。';
+    case 'source_failed':
+      return 'B 站分区新视频候选源暂不可用。';
+    case 'empty':
+      return '候选源本轮没有返回可打开视频。';
+    case 'ready':
+      return '候选列表为空。';
+  }
+}
+
 function varietyEmptyStatusLabel(status: VarietyRegionCandidatePool['status']): string {
   switch (status) {
     case 'source_failed':
@@ -291,7 +351,11 @@ function buildHiddenFavoriteBox(ctx: BlindBoxContext): ExperimentBlindBox {
       '从本地收藏里翻出被你压箱底的一条。',
       ['本地收藏 0 条，暂时没有可以翻出来的冷门收藏。'],
       '先同步收藏',
-      '这盒只看本地收藏，不会去猜外部推荐。先把收藏同步进来，再让我帮你翻压箱底。',
+      '这盒只看本地收藏，不会拿外部候选凑数。先把收藏同步进来，再让我帮你翻压箱底。',
+      '本地收藏未同步',
+      LOCAL_FAVORITE_SOURCE,
+      '本地收藏还没有可回访的视频。',
+      localFavoriteMeta(),
     );
   }
 
@@ -328,6 +392,10 @@ function buildHiddenFavoriteBox(ctx: BlindBoxContext): ExperimentBlindBox {
       [`本地收藏 ${ctx.favorites.length} 条，但最近 ${RECENT_VIDEO_BLOCK_DAYS} 天都还比较活跃。`],
       '压箱底的视频还没攒出来',
       '当前收藏里最近都还在看，或者收藏时间太新，暂时没有那种“你留过但快忘了”的冷门收藏。',
+      '本地收藏暂不符合',
+      LOCAL_FAVORITE_SOURCE,
+      '本地收藏里暂时没有足够冷门的回访候选。',
+      localFavoriteMeta(),
     );
   }
 
@@ -338,6 +406,7 @@ function buildHiddenFavoriteBox(ctx: BlindBoxContext): ExperimentBlindBox {
     id: 'hidden_favorite',
     title: '冷门收藏',
     teaser: '从本地收藏里翻出被你压箱底的一条。',
+    ...localFavoriteMeta(),
     source: `本地收藏 / 收藏夹「${pick.item.folderTitle}」`,
     reason: pick.watchCount === 0
       ? '你把它收进本地收藏后，还没有留下再次观看记录。'
@@ -355,14 +424,20 @@ function buildHiddenFavoriteBox(ctx: BlindBoxContext): ExperimentBlindBox {
 }
 
 function buildReviveInterestBox(ctx: BlindBoxContext): ExperimentBlindBox {
+  const title = '本地兴趣回顾';
+  const teaser = '只从本地历史里回看一条旧兴趣代表视频。';
   if (ctx.records.length < MIN_INTEREST_RECORDS) {
     return emptyBox(
       'revive_interest',
-      '久未观看兴趣',
-      '把曾经常看的兴趣，重新翻回你面前。',
+      title,
+      teaser,
       [`本地历史只有 ${ctx.records.length} 条，暂时还看不出长期兴趣。`],
       '先多积累一点历史',
-      '这盒要判断“以前常看、最近冷下来”的兴趣，需要更长一点的本地历史样本。',
+      '这盒只做本地历史回顾，不读取关注新投稿，也不替代动态账单的兴趣再平衡；它需要更长一点的本地历史样本。',
+      '本地历史不足',
+      LOCAL_HISTORY_REVIEW_SOURCE,
+      '本地历史样本不足，暂不回看旧兴趣。',
+      localHistoryReviewMeta(),
     );
   }
 
@@ -416,11 +491,15 @@ function buildReviveInterestBox(ctx: BlindBoxContext): ExperimentBlindBox {
   if (candidates.length === 0) {
     return emptyBox(
       'revive_interest',
-      '久未观看兴趣',
-      '把曾经常看的兴趣，重新翻回你面前。',
+      title,
+      teaser,
       [`在 ${ctx.records.length} 条本地历史里，还没有找到“以前常看、最近明显降温”的主题。`],
       '近期口味还没出现明显冷却',
-      '这盒只会在本地证据足够明确时开出来，不会硬塞一条泛泛建议。',
+      '这盒只会在本地证据足够明确时回看旧兴趣，不读取关注新投稿，也不会硬塞一条泛泛建议。',
+      '本地历史暂不符合',
+      LOCAL_HISTORY_REVIEW_SOURCE,
+      '本地历史里暂时没有明确冷却的旧兴趣。',
+      localHistoryReviewMeta(),
     );
   }
 
@@ -429,11 +508,15 @@ function buildReviveInterestBox(ctx: BlindBoxContext): ExperimentBlindBox {
   if (!video) {
     return emptyBox(
       'revive_interest',
-      '久未观看兴趣',
-      '把曾经常看的兴趣，重新翻回你面前。',
+      title,
+      teaser,
       ['本地找到了兴趣下降信号，但缺少可打开的视频链接。'],
       '证据够了，链接不够',
-      '这个兴趣确实冷下来了，但目前本地没有留下能直接打开的代表视频。',
+      '这个兴趣确实冷下来了，但目前本地没有留下能直接打开的代表视频；不会改用动态账单或外部候选补位。',
+      '本地历史链接不足',
+      LOCAL_HISTORY_REVIEW_SOURCE,
+      '本地历史缺少可打开的代表视频。',
+      localHistoryReviewMeta(),
     );
   }
 
@@ -441,14 +524,15 @@ function buildReviveInterestBox(ctx: BlindBoxContext): ExperimentBlindBox {
 
   return {
     id: 'revive_interest',
-    title: '久未观看兴趣',
-    teaser: '把曾经常看的兴趣，重新翻回你面前。',
+    title,
+    teaser,
+    ...localHistoryReviewMeta(),
     source: `本地历史 / 标签「${pick.label}」`,
-    reason: `你对「${pick.label}」长期有稳定正反馈，但最近已经 ${pick.daysSinceLastWatch} 天没碰它，这条是本地历史里的代表视频。`,
+    reason: `你对「${pick.label}」长期有稳定正反馈，但最近已经 ${pick.daysSinceLastWatch} 天没碰它；这不是动态账单的兴趣再平衡，也不使用关注新投稿，只回看本地历史里的一条代表视频。`,
     evidence: [
       `长期累计 ${pick.records.length} 条相关历史，其中高完成度记录 ${pick.positiveRecords.length} 条，平均完成度 ${formatPercent(pick.averageCompletion)}。`,
       `最近 ${RECENT_ACTIVITY_DAYS} 天相关记录 ${pick.recentRecords.length} 条，上次观看距今 ${pick.daysSinceLastWatch} 天。`,
-      '代表视频优先从这个兴趣里完成度更高、且最近没有重复打开过的本地历史里挑选。',
+      '代表视频只从这个兴趣里完成度更高、且最近没有重复打开过的本地历史里挑选。',
     ],
     state: 'ready',
     video,
@@ -457,17 +541,19 @@ function buildReviveInterestBox(ctx: BlindBoxContext): ExperimentBlindBox {
 
 function buildRandomExploreBox(ctx: BlindBoxContext): ExperimentBlindBox {
   const sourceLabel = '来自相关视频候选';
+  const teaser = '只从真实 B 站候选池里随机抽一条，不从本地库存补位。';
   if (!ctx.randomExplorePool || ctx.randomExplorePool.seedCount === 0) {
     return emptyBox(
       'random_explore',
       '随机探索',
-      '不做推荐排序，只从真实候选池里随机抽一条。',
+      teaser,
       ['本地还没有可作为公开相关视频候选种子的 BV 号。'],
       '真实候选源还没有可用种子',
       '随机探索现在需要先用最近少量本地历史作为种子，请求 B 站公开视频的相关视频候选池。等本地有可用 BV 号后，它才会开出真实候选。',
       '候选源未准备好',
       sourceLabel,
       '没有可请求的种子，未生成空白视频卡。',
+      realCandidateUnavailableMeta(RELATED_CANDIDATE_SOURCE, '缺少可请求的本地 BV 种子。'),
     );
   }
 
@@ -480,7 +566,7 @@ function buildRandomExploreBox(ctx: BlindBoxContext): ExperimentBlindBox {
     return emptyBox(
       'random_explore',
       '随机探索',
-      '不做推荐排序，只从真实候选池里随机抽一条。',
+      teaser,
       [
         `已尝试 ${ctx.randomExplorePool.seedCount} 个种子视频的相关视频候选。`,
         failureSummary,
@@ -491,6 +577,7 @@ function buildRandomExploreBox(ctx: BlindBoxContext): ExperimentBlindBox {
       '候选源暂不可用',
       sourceLabel,
       '真实候选源失败或为空，未生成空白视频卡。',
+      realCandidateUnavailableMeta(RELATED_CANDIDATE_SOURCE, '候选源失败、为空或过滤后无可打开视频。'),
     );
   }
 
@@ -501,9 +588,10 @@ function buildRandomExploreBox(ctx: BlindBoxContext): ExperimentBlindBox {
   return {
     id: 'random_explore',
     title: '随机探索',
-    teaser: '不做推荐排序，只从真实候选池里随机抽一条。',
+    teaser,
+    ...realCandidateUsedMeta(RELATED_CANDIDATE_SOURCE),
     source: `${sourceLabel} / 种子视频「${pick.seedTitle || pick.seedBvid}」`,
-    reason: `Bili-Bill 没有保留平台排序，只是在 ${pool.length} 条公开相关视频候选里随机抽取一条。`,
+    reason: `Bili-Bill 只保留可打开的公开相关视频候选，并在 ${pool.length} 条候选里随机抽取一条；不会从本地历史或收藏库存补位。`,
     evidence: [
       `候选来自 B 站公开视频的相关视频候选池，使用 ${ctx.randomExplorePool.seedCount} 个本地种子视频逐个请求。`,
       `抽取前已排除最近 ${RECENT_VIDEO_BLOCK_DAYS} 天看过的视频，以及其它盲盒已经占用的候选。`,
@@ -569,11 +657,13 @@ function emptyBox(
   statusLabel?: string,
   source?: string,
   reason?: string,
+  boundaryMeta: BlindBoxBoundaryMeta = localHistoryReviewMeta(),
 ): ExperimentBlindBox {
   return {
     id,
     title,
     teaser,
+    ...boundaryMeta,
     source: source ?? '仅使用本地历史 / 本地收藏',
     reason: reason ?? '这盒没有足够的本地证据，不会拿泛泛建议来凑数。',
     evidence,
@@ -593,6 +683,7 @@ function toHistoryVideo(record: WatchHistoryRecord): ExperimentVideoCandidate | 
     authorName: cleanText(record.authorName) || '未知 UP',
     cover: cleanText(record.cover),
     url: buildVideoUrl(record.bvid, record.avid),
+    sourceKind: 'local_history',
   };
 }
 
@@ -605,6 +696,7 @@ function toFavoriteVideo(item: FavoriteItem): ExperimentVideoCandidate | null {
     authorName: cleanText(item.authorName) || '未知 UP',
     cover: cleanText(item.cover),
     url: buildVideoUrl(item.bvid, item.avid),
+    sourceKind: 'local_favorite',
   };
 }
 

--- a/src/shared/types/analytics.ts
+++ b/src/shared/types/analytics.ts
@@ -224,6 +224,9 @@ export interface ExperimentBlindBox {
   id: ExperimentBlindBoxId;
   title: string;
   teaser: string;
+  candidateSource: string;
+  realCandidateLabel: string;
+  usesRealBilibiliCandidates: boolean;
   source: string;
   reason: string;
   evidence: string[];

--- a/tests/experiment-blind-boxes.test.ts
+++ b/tests/experiment-blind-boxes.test.ts
@@ -14,6 +14,7 @@ const NOW_MS = Date.UTC(2026, 5, 13, 12, 0, 0);
 
 test('builds blind boxes with real random explore and real variety candidate sources', () => {
   const bannedGuessWord = ['猜你', '喜欢'].join('');
+  const bannedRankingWord = ['推荐', '排序'].join('');
   const records = createMixedTasteRecords();
 
   const favorites: FavoriteItem[] = [
@@ -65,6 +66,9 @@ test('builds blind boxes with real random explore and real variety candidate sou
 
   assert.equal(variety.state, 'ready');
   assert.equal(variety.statusLabel, '真实候选');
+  assert.equal(variety.candidateSource, 'B 站公开分区新视频候选池');
+  assert.equal(variety.realCandidateLabel, '已使用真实 B 站候选');
+  assert.equal(variety.usesRealBilibiliCandidates, true);
   assert.equal(variety.video?.bvid, 'BV1REAL139A');
   assert.equal(variety.video?.sourceKind, 'bili_region_dynamic');
   assert.notEqual(variety.video?.bvid, 'BVFAVVAR1');
@@ -75,25 +79,43 @@ test('builds blind boxes with real random explore and real variety candidate sou
   assert.ok(variety.evidence.some(line => line.includes('本地历史和收藏只参与选择冷却方向与解释')));
 
   assert.equal(hiddenFavorite.state, 'ready');
+  assert.equal(hiddenFavorite.candidateSource, '本地收藏');
+  assert.equal(hiddenFavorite.realCandidateLabel, '未使用真实 B 站候选：这是本地收藏回访。');
+  assert.equal(hiddenFavorite.usesRealBilibiliCandidates, false);
+  assert.match(hiddenFavorite.source, /^本地收藏/);
   assert.equal(hiddenFavorite.video?.bvid, 'BVFAVHID1');
+  assert.equal(hiddenFavorite.video?.sourceKind, 'local_favorite');
   assert.match(hiddenFavorite.reason, /收藏|本地/);
 
   assert.equal(reviveInterest.state, 'ready');
+  assert.equal(reviveInterest.title, '本地兴趣回顾');
+  assert.equal(reviveInterest.candidateSource, '本地观看历史');
+  assert.equal(reviveInterest.realCandidateLabel, '未使用真实 B 站候选：这是本地历史回顾。');
+  assert.equal(reviveInterest.usesRealBilibiliCandidates, false);
   assert.equal(reviveInterest.video?.bvid, 'BVKNO002');
+  assert.equal(reviveInterest.video?.sourceKind, 'local_history');
   assert.match(reviveInterest.source, /本地历史/);
+  assert.match(reviveInterest.reason, /不是动态账单的兴趣再平衡/);
+  assert.match(reviveInterest.reason, /不使用关注新投稿/);
 
   assert.equal(randomExplore.state, 'ready');
+  assert.equal(randomExplore.candidateSource, 'B 站公开视频的相关视频候选池');
+  assert.equal(randomExplore.realCandidateLabel, '已使用真实 B 站候选');
+  assert.equal(randomExplore.usesRealBilibiliCandidates, true);
   assert.equal(randomExplore.video?.bvid, 'BV1REALRND01');
   assert.equal(randomExplore.video?.sourceKind, 'bilibili_related');
   assert.match(randomExplore.source, /相关视频候选/);
   assert.match(randomExplore.source, /种子视频/);
-  assert.match(randomExplore.reason, /没有保留平台排序|随机抽取/);
+  assert.match(randomExplore.reason, /公开相关视频候选|随机抽取/);
   assert.notEqual(randomExplore.video?.bvid, variety.video?.bvid);
   assert.notEqual(randomExplore.video?.bvid, hiddenFavorite.video?.bvid);
   assert.notEqual(randomExplore.video?.bvid, reviveInterest.video?.bvid);
 
   for (const box of data.blindBoxes) {
     assert.equal(box.reason.includes(bannedGuessWord), false);
+    assert.equal(box.reason.includes(bannedRankingWord), false);
+    assert.ok(box.candidateSource.length > 0);
+    assert.ok(box.realCandidateLabel.length > 0);
     assert.ok(box.evidence.length > 0);
     if (box.state === 'ready') {
       assert.ok(box.video);
@@ -144,6 +166,9 @@ test('returns a clear downgrade when the real region candidate source fails', ()
   assert.equal(variety.id, 'variety');
   assert.equal(variety.state, 'empty');
   assert.equal(variety.statusLabel, '候选源暂不可用');
+  assert.equal(variety.candidateSource, 'B 站公开分区新视频候选池');
+  assert.match(variety.realCandidateLabel, /未使用真实 B 站候选/);
+  assert.equal(variety.usesRealBilibiliCandidates, false);
   assert.equal(variety.source, 'B 站分区新视频');
   assert.match(variety.emptyTitle ?? '', /候选源暂不可用/);
   assert.match(variety.emptyDescription ?? '', /不显示空视频/);
@@ -153,6 +178,7 @@ test('returns a clear downgrade when the real region candidate source fails', ()
 test('returns Chinese empty states instead of generic filler when local evidence is insufficient', () => {
   const bannedGuessWord = ['猜你', '喜欢'].join('');
   const bannedUnconsumedWord = ['未', '消费'].join('');
+  const bannedRankingWord = ['推荐', '排序'].join('');
   const data = buildExperimentData([], [], new Map(), NOW_MS, {
     randomExplorePool: {
       sourceKind: 'bilibili_related',
@@ -178,9 +204,12 @@ test('returns Chinese empty states instead of generic filler when local evidence
     assert.equal(box.state, 'empty');
     assert.ok(box.emptyTitle);
     assert.ok(box.emptyDescription);
+    assert.ok(box.candidateSource);
+    assert.ok(box.realCandidateLabel);
     assert.ok(box.evidence.length > 0);
     assert.equal(box.reason.includes(bannedGuessWord), false);
     assert.equal(box.reason.includes(bannedUnconsumedWord), false);
+    assert.equal(box.reason.includes(bannedRankingWord), false);
   }
 });
 
@@ -207,6 +236,9 @@ test('does not fall back to a local random video when related candidates fail', 
   assert.ok(randomExplore);
   assert.equal(randomExplore.state, 'empty');
   assert.equal(randomExplore.video, undefined);
+  assert.equal(randomExplore.candidateSource, 'B 站公开视频的相关视频候选池');
+  assert.match(randomExplore.realCandidateLabel, /未使用真实 B 站候选/);
+  assert.equal(randomExplore.usesRealBilibiliCandidates, false);
   assert.match(randomExplore.source, /相关视频候选/);
   assert.match(randomExplore.emptyDescription ?? '', /不会用本地库存视频冒充/);
   assert.ok(randomExplore.evidence.some(line => line.includes('请求失败')));


### PR DESCRIPTION
﻿## Scope

Issue: #140

- Adds explicit candidate-source and real-Bilibili-candidate status fields to every video blind-box card.
- Updates the Dashboard blind-box copy so users can distinguish random explore, variety, hidden favorites, and local interest review.
- Keeps random explore and variety tied to real Bilibili candidate pools when available.
- Keeps hidden favorites as a local favorites revisit surface with visible `来源：本地收藏` copy.
- Renames the overlapping local-history card to `本地兴趣回顾` and states that Dynamic Bill remains responsible for `兴趣再平衡`.
- Removes recommendation-ranking style copy from the touched blind-box UI/runtime surfaces.

## Validation

- `npm run test:experiments` (5 passed)
- `npm run typecheck` (passed)
- `npm run build` (passed; existing Vite dynamic-import and large `theme` chunk warnings only)
- `git diff --check` (passed; Windows line-ending warnings only)
- `git diff --cached --check` (passed)
- `rg -n "未消费|猜你喜欢" dashboard popup public src README.md tests` (no matches)
- `rg -n "fallback|transcript|confidence|sourceHash|segmentId|subtitle_url|candidateId|nodeId|token|Cookie|profile|Key\.txt" dashboard popup public src README.md tests` (hits are existing README privacy notes, assistant payload audit guards, current-video/runtime types, and tests; touched blind-box files have no hits)
- `rg -n "推荐" dashboard\modules\experiments\ExperimentsPage.tsx src\background\analytics\suggestions.ts tests\experiment-blind-boxes.test.ts` (hits only in test guard strings)

## Browser / Mock QA

- In-app Browser against local Vite + in-memory mock extension runtime.
- Ready scenario: verified all four blind-box card types, candidate-source lines, real-candidate labels, reveal interactions, Bilibili video links, and no console warn/error logs.
- Degraded/no-candidate scenario: verified all four card types show source explanations, no open-video links, real-candidate unavailable/local labels, and regenerate actions; no console warn/error logs.
- Visible DOM leak scan in Browser found no `fallback`, `transcript`, `confidence`, `sourceHash`, `segmentId`, `subtitle_url`, `candidateId`, `nodeId`, `token`, `Cookie`, `profile`, `Key.txt`, `未消费`, `猜你喜欢`, or `推荐排序` text.

## Privacy

- Privacy-sensitive files read: false.
- Full local datasets read/exported: false.
- No Cookie files, browser profiles, Bilibili login-state files, key files, or `C:\Users\LittleNub\Desktop\Key.txt` were read.
- No Bilibili writeback was added.
- AI payload audit: not applicable; this PR does not add or change AI payloads.

## State

Draft PR only. Not ready for review, not merged, and issue #140 remains open for main-agent review.
