### PR TITLE
Fix 0.12.1-alpha feedback blockers

### DIFF
--- a/dashboard/modules/dynamic-bill/DynamicBillPage.tsx
+++ b/dashboard/modules/dynamic-bill/DynamicBillPage.tsx
@@ -38,14 +38,14 @@ const BILL_COLUMNS = [
   {
     key: "afk_update",
     title: "久违更新",
-    detail: "长期窗口有正反馈、近期冷却、最近 7 天有新投稿的已关注 UP。",
+    detail: "本地历史覆盖足够长时，才比较长期正反馈、近期冷却和最近 7 天新投稿。",
     accent: "pink",
     enabled: true,
   },
   {
     key: "variety",
-    title: "换换口味",
-    detail: "长期分区/标签强、近期明显下降，最近 7 天有已关注 UP 新投稿。",
+    title: "兴趣再平衡",
+    detail: "本地历史覆盖足够长时，才比较长期分区/标签和近期下降。",
     accent: "blue",
     enabled: true,
   },
@@ -356,13 +356,13 @@ export function DynamicBillPage() {
           <span className="dynamic-bill-kicker">消费前 / 已关注视频投稿</span>
           <h2>动态账单</h2>
           <p>
-            面向兴趣再平衡，久违更新、换换口味和被淹没的关注由本地规则入选和排序；AI 只生成解释展示，未启用、未配置或失败时继续显示本地证据结果。
+            面向兴趣再平衡，账单项由本地规则入选和排列；AI 只生成解释展示，未启用、未配置或失败时继续显示本地证据结果。
           </p>
         </div>
         <div className="dynamic-bill-scope">
           <strong>解释数据范围</strong>
           <span>
-            AI 只接收已入选账单项的新视频标题/简介、UP 名、分区/标签、发布时间、时长和紧凑证据事实；不发送完整历史、完整关注列表、Cookie、用户账号标识、个人资料或反馈记录。
+            AI 只接收已入选账单项的新视频标题/简介、UP 名、分区/标签、发布时间、时长和紧凑证据事实；不发送完整历史、完整关注列表、本地登录凭据、用户账号标识、个人资料或反馈记录。
           </span>
           <span>
             {dynamicBillAiSettingsCopy(isAiEnabled, isAiConfigured)}
@@ -426,7 +426,7 @@ export function DynamicBillPage() {
         <StatusMetric
           label="本地账单"
           value={String(items.length)}
-          detail={`久违更新 ${afkItems.length} / 换换口味 ${varietyItems.length} / 被淹没的关注 ${buriedFollowItems.length}`}
+          detail={`久违更新 ${afkItems.length} / 兴趣再平衡 ${varietyItems.length} / 被淹没的关注 ${buriedFollowItems.length}`}
         />
       </section>
 
@@ -866,7 +866,7 @@ function describeSyncResult(result: DynamicSyncResult): string {
 }
 
 function describeGenerateResult(result: DynamicBillGenerateResult): string {
-  return `本地账单生成 ${result.itemCount} 项：久违更新 ${result.columnItemCounts.afk_update} 项，换换口味 ${result.columnItemCounts.variety} 项，被淹没的关注 ${result.columnItemCounts.buried_follow} 项；扫描最近投稿 ${result.candidatesScanned} 条，排除近期已看同视频 ${result.excludedRecentSameVideoCount} 条，长期/关注记忆证据不足 ${result.excludedNoLongSignalCount} 个，近期仍活跃 ${result.excludedRecentActiveCount} 个，本地少提醒阈值排除 ${result.excludedByFeedbackCount} 个。`;
+  return `本地账单生成 ${result.itemCount} 项：久违更新 ${result.columnItemCounts.afk_update} 项，兴趣再平衡 ${result.columnItemCounts.variety} 项，被淹没的关注 ${result.columnItemCounts.buried_follow} 项；扫描最近投稿 ${result.candidatesScanned} 条，排除近期已看同视频 ${result.excludedRecentSameVideoCount} 条，长期/关注记忆证据不足 ${result.excludedNoLongSignalCount} 个，近期仍活跃 ${result.excludedRecentActiveCount} 个，本地少提醒阈值排除 ${result.excludedByFeedbackCount} 个。若本地观看历史覆盖不足最近 ${result.thresholds.recentWindowDays} 天，依赖长期/近期对比的栏目会保持为空，不当作长期洞察。`;
 }
 
 function describeExplanationResult(result: DynamicBillExplanationResult): string {
@@ -937,19 +937,19 @@ function getColumnEmptyCopy(
   }
   if (column.key === "variety") {
     return {
-      title: `暂无${statusLabel}换换口味`,
-      detail: "可能是长期分区/标签强度不足、近期没有明显下降，或最近新投稿没有命中下降兴趣。",
+      title: `暂无${statusLabel}兴趣再平衡项`,
+      detail: "可能是本地历史覆盖不足最近 30 天、长期分区/标签证据不足、近期没有明显下降，或最近新投稿没有命中下降兴趣。覆盖太短时不会当作长期洞察展示。",
     };
   }
   if (column.key === "buried_follow") {
     return {
       title: `暂无${statusLabel}被淹没的关注`,
-      detail: "可能是缺少长期关注、特别关注或近期窗口以前弱观看等关注记忆信号，或该 UP 最近 30 天仍在观看。",
+      detail: "可能是本地历史覆盖不足最近 30 天、缺少长期关注、特别关注或近期窗口以前弱观看等关注记忆信号，或该 UP 最近 30 天仍在观看。",
     };
   }
   return {
     title: `暂无${statusLabel}久违更新`,
-    detail: "可能是长期正反馈不足、近期仍在观看，或同一新视频已在近期观看历史中出现。",
+    detail: "可能是本地历史覆盖不足最近 30 天、长期正反馈不足、近期仍在观看，或同一新视频已在近期观看历史中出现。",
   };
 }
 
@@ -1012,7 +1012,7 @@ function localFallbackReason(item: DynamicBillItem): string {
 
 function localFallbackViewingAngle(item: DynamicBillItem): string {
   if (item.column === "variety" && item.evidence.interest) {
-    return `把它当作回到「${item.evidence.interest.label}」这个长期兴趣的一次口味切换。`;
+    return `把它当作回到「${item.evidence.interest.label}」这个长期兴趣的一次兴趣再平衡。`;
   }
   if (item.column === "buried_follow") {
     return "把它当作一次低压力回访，判断这个长期关注是否仍值得保留注意力。";

--- a/dashboard/modules/experiments/ExperimentsPage.tsx
+++ b/dashboard/modules/experiments/ExperimentsPage.tsx
@@ -30,7 +30,7 @@ export function ExperimentsPage() {
       setRevealed({});
       setOpened({});
     } catch (error) {
-      expError.value = (error as Error).message;
+      expError.value = formatExperimentLoadError(error);
     } finally {
       expLoading.value = false;
     }
@@ -225,6 +225,14 @@ export function ExperimentsPage() {
       </div>
     </ErrorBoundary>
   );
+}
+
+function formatExperimentLoadError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/document is not defined|window is not defined|ReferenceError/i.test(message)) {
+    return '盲盒候选源暂时不可用，请刷新后重试。';
+  }
+  return message || '盲盒数据读取失败，请稍后重试。';
 }
 
 function sourceMetaStyle(): Record<string, string> {

--- a/dashboard/modules/settings/SettingsPage.tsx
+++ b/dashboard/modules/settings/SettingsPage.tsx
@@ -8,12 +8,13 @@ import {
   formatLocalDataError,
   LOCAL_DATA_CLEAR_CONFIRMATION,
 } from '../../../src/shared/local-data-privacy';
-import type {
-  AiConfig,
-  AiConnectionTestResult,
-  AssistantConfig,
-  DynamicBillConfig,
-  UserConfig,
+import {
+  DEFAULT_CONFIG,
+  type AiConfig,
+  type AiConnectionTestResult,
+  type AssistantConfig,
+  type DynamicBillConfig,
+  type UserConfig,
 } from '../../../src/shared/types/config';
 import type {
   LocalDataOperationResult,
@@ -30,21 +31,14 @@ interface AiFormState {
 }
 
 const DEFAULT_AI_FORM: AiFormState = {
-  baseURL: 'https://api.deepseek.com',
-  chatModel: 'deepseek-v4-flash',
+  baseURL: DEFAULT_CONFIG.ai.baseURL,
+  chatModel: DEFAULT_CONFIG.ai.chatModel,
   apiKeyInput: '',
 };
 
-const DEFAULT_ASSISTANT: AssistantConfig = {
-  aiSummariesEnabled: false,
-  smartFavoritesQaAiEnabled: false,
-  currentVideoSegmentRerankAiEnabled: false,
-  currentVideoQaAiEnabled: false,
-};
+const DEFAULT_ASSISTANT: AssistantConfig = DEFAULT_CONFIG.assistant;
 
-const DEFAULT_DYNAMIC_BILL: DynamicBillConfig = {
-  aiExplanationsEnabled: false,
-};
+const DEFAULT_DYNAMIC_BILL: DynamicBillConfig = DEFAULT_CONFIG.dynamicBill;
 
 export function SettingsPage() {
   const [form, setForm] = useState<AiFormState>(DEFAULT_AI_FORM);
@@ -65,6 +59,25 @@ export function SettingsPage() {
   useEffect(() => {
     void refreshConfig();
     void refreshLocalData();
+  }, []);
+
+  useEffect(() => {
+    if (typeof chrome === 'undefined' || !chrome.storage?.onChanged) return undefined;
+
+    const handleStorageChange = (
+      changes: Record<string, chrome.storage.StorageChange>,
+      areaName: string,
+    ) => {
+      if (areaName !== 'local') return;
+      const change = changes.userConfig;
+      if (!change?.newValue) return;
+      applyConfig(change.newValue as Partial<UserConfig>);
+      setNotice('');
+      setLastTest(null);
+    };
+
+    chrome.storage.onChanged.addListener(handleStorageChange);
+    return () => chrome.storage.onChanged.removeListener(handleStorageChange);
   }, []);
 
   const effectiveAiConfig = useMemo<AiConfig>(() => ({
@@ -119,12 +132,13 @@ export function SettingsPage() {
     setNotice('');
     try {
       await ensureAiHostPermission(effectiveAiConfig.baseURL);
-      const nextConfig: UserConfig = {
-        ...(loadedConfig ?? await requestSW<UserConfig>('GET_CONFIG')),
+      const baseConfig = normalizeSettingsUserConfig(loadedConfig ?? await requestSW<UserConfig>('GET_CONFIG'));
+      const nextConfig = normalizeSettingsUserConfig({
+        ...baseConfig,
         ai: effectiveAiConfig,
         assistant,
         dynamicBill,
-      };
+      });
       await requestSW('UPDATE_CONFIG', {
         ai: nextConfig.ai,
         assistant: nextConfig.assistant,
@@ -217,16 +231,17 @@ export function SettingsPage() {
     }
   }
 
-  function applyConfig(config: UserConfig) {
-    setLoadedConfig(config);
+  function applyConfig(config: Partial<UserConfig>) {
+    const normalized = normalizeSettingsUserConfig(config);
+    setLoadedConfig(normalized);
     setForm({
-      baseURL: config.ai.baseURL,
-      chatModel: config.ai.chatModel,
+      baseURL: normalized.ai.baseURL,
+      chatModel: normalized.ai.chatModel,
       apiKeyInput: '',
     });
-    setSavedApiKey(config.ai.apiKey);
-    setAssistant(config.assistant);
-    setDynamicBill(config.dynamicBill);
+    setSavedApiKey(normalized.ai.apiKey);
+    setAssistant(normalized.assistant);
+    setDynamicBill(normalized.dynamicBill);
   }
 
   if (loading) {
@@ -333,31 +348,31 @@ export function SettingsPage() {
             title="当前视频摘要"
             detail="允许当前视频助手在有边界的元数据、简介或字幕证据上整理摘要。"
             checked={assistant.aiSummariesEnabled}
-            onChange={(checked) => setAssistant({ ...assistant, aiSummariesEnabled: checked })}
+            onChange={(checked) => setAssistant(current => ({ ...current, aiSummariesEnabled: checked }))}
           />
           <FeatureToggle
             title="当前视频片段排序辅助"
             detail="允许 AI 只在已检索出的本地候选片段中调整展示顺序和解释。"
             checked={assistant.currentVideoSegmentRerankAiEnabled}
-            onChange={(checked) => setAssistant({ ...assistant, currentVideoSegmentRerankAiEnabled: checked })}
+            onChange={(checked) => setAssistant(current => ({ ...current, currentVideoSegmentRerankAiEnabled: checked }))}
           />
           <FeatureToggle
             title="当前视频问答整理"
             detail="允许 AI 只基于当前视频 top-N 本地引用片段整理简短回答；时间点和引用仍来自本地候选。"
             checked={assistant.currentVideoQaAiEnabled}
-            onChange={(checked) => setAssistant({ ...assistant, currentVideoQaAiEnabled: checked })}
+            onChange={(checked) => setAssistant(current => ({ ...current, currentVideoQaAiEnabled: checked }))}
           />
           <FeatureToggle
             title="智能收藏问答"
             detail="允许 AI 基于已同步收藏的前置引用视频整理综合回答。"
             checked={assistant.smartFavoritesQaAiEnabled}
-            onChange={(checked) => setAssistant({ ...assistant, smartFavoritesQaAiEnabled: checked })}
+            onChange={(checked) => setAssistant(current => ({ ...current, smartFavoritesQaAiEnabled: checked }))}
           />
           <FeatureToggle
             title="动态账单解释"
             detail="允许 AI 为已入选的账单项生成解释；入选、排序和状态推进仍由本地规则决定。"
             checked={dynamicBill.aiExplanationsEnabled}
-            onChange={(checked) => setDynamicBill({ ...dynamicBill, aiExplanationsEnabled: checked })}
+            onChange={(checked) => setDynamicBill(current => ({ ...current, aiExplanationsEnabled: checked }))}
           />
         </div>
       </section>
@@ -483,7 +498,7 @@ export function SettingsPage() {
         <ul className="settings-privacy-list">
           <li>API Key 只保存在本地浏览器扩展存储中，不会提交到 Bili-Bill 服务端。</li>
           <li>AI 请求只发送当前功能需要的最小证据片段，不上传完整观看历史、完整收藏、完整关注或反馈记录。</li>
-          <li>Bili-Bill 不读取 Cookie 文件、浏览器用户资料目录、Bilibili 登录态文件或本地密钥文件。</li>
+          <li>Bili-Bill 不读取本地登录凭据文件、浏览器用户资料目录、B 站登录状态文件或本地密钥文件。</li>
           <li>动态账单、收藏和当前视频功能不会写回 B 站关注关系、收藏夹或视频数据。</li>
         </ul>
       </section>
@@ -511,8 +526,12 @@ function FeatureToggle({
   checked: boolean;
   onChange: (checked: boolean) => void;
 }) {
+  const stateText = checked ? '已启用' : '已关闭';
   return (
-    <label className="settings-toggle">
+    <label
+      className={`settings-toggle ${checked ? 'is-on' : 'is-off'}`}
+      data-state={checked ? 'on' : 'off'}
+    >
       <input
         type="checkbox"
         checked={checked}
@@ -520,11 +539,42 @@ function FeatureToggle({
       />
       <span className="settings-toggle-control" aria-hidden="true" />
       <span className="settings-toggle-copy">
-        <strong>{title}</strong>
+        <span className="settings-toggle-title-row">
+          <strong>{title}</strong>
+          <span className="settings-toggle-state">{stateText}</span>
+        </span>
         <small>{detail}</small>
       </span>
     </label>
   );
+}
+
+function normalizeSettingsUserConfig(config: Partial<UserConfig>): UserConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    ...config,
+    ai: {
+      ...DEFAULT_CONFIG.ai,
+      ...(config.ai ?? {}),
+    },
+    assistant: normalizeAssistantConfig(config.assistant),
+    dynamicBill: normalizeDynamicBillConfig(config.dynamicBill),
+  };
+}
+
+function normalizeAssistantConfig(config: Partial<AssistantConfig> | undefined): AssistantConfig {
+  return {
+    aiSummariesEnabled: config?.aiSummariesEnabled === true,
+    smartFavoritesQaAiEnabled: config?.smartFavoritesQaAiEnabled === true,
+    currentVideoSegmentRerankAiEnabled: config?.currentVideoSegmentRerankAiEnabled === true,
+    currentVideoQaAiEnabled: config?.currentVideoQaAiEnabled === true,
+  };
+}
+
+function normalizeDynamicBillConfig(config: Partial<DynamicBillConfig> | undefined): DynamicBillConfig {
+  return {
+    aiExplanationsEnabled: config?.aiExplanationsEnabled === true,
+  };
 }
 
 async function ensureAiHostPermission(baseURL: string): Promise<void> {

--- a/dashboard/styles/dashboard.css
+++ b/dashboard/styles/dashboard.css
@@ -481,6 +481,11 @@ button {
   cursor: pointer;
 }
 
+.settings-toggle.is-on {
+  border-color: rgba(20, 184, 166, 0.44);
+  background: rgba(20, 184, 166, 0.09);
+}
+
 .settings-toggle input {
   position: absolute;
   opacity: 0;
@@ -516,15 +521,49 @@ button {
   transform: translateX(18px);
 }
 
+.settings-toggle.is-on .settings-toggle-control {
+  background: var(--bb-mint);
+}
+
+.settings-toggle.is-on .settings-toggle-control::after {
+  transform: translateX(18px);
+}
+
 .settings-toggle-copy {
   display: grid;
   gap: 3px;
   min-width: 0;
 }
 
+.settings-toggle-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
 .settings-toggle-copy strong {
   color: #FFFFFF;
   font-size: 13px;
+}
+
+.settings-toggle-state {
+  flex: 0 0 auto;
+  min-height: 20px;
+  padding: 3px 7px;
+  border-radius: 999px;
+  color: #C8C8D8;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.settings-toggle.is-on .settings-toggle-state {
+  color: #A8FFF0;
+  background: rgba(20, 184, 166, 0.16);
 }
 
 .settings-privacy-list {

--- a/src/background/analytics/history-coverage.ts
+++ b/src/background/analytics/history-coverage.ts
@@ -1,0 +1,52 @@
+import type { WatchHistoryRecord } from '../../shared/types/watch-event';
+
+const DAY_MS = 86_400_000;
+
+export interface HistoryCoverageSpan {
+  recordCount: number;
+  oldestAt: number;
+  newestAt: number;
+  spanDays: number;
+  requiredDays: number;
+  hasEnoughForRecentComparison: boolean;
+}
+
+export function getHistoryCoverageSpan(
+  records: WatchHistoryRecord[],
+  nowMs = Date.now(),
+  requiredDays = 30,
+): HistoryCoverageSpan {
+  const timestamps = records
+    .map(record => toEpochMs(record.viewAt))
+    .filter(timestamp => timestamp > 0 && timestamp <= nowMs + DAY_MS);
+  const normalizedRequiredDays = Math.max(1, Math.floor(requiredDays));
+
+  if (timestamps.length === 0) {
+    return {
+      recordCount: 0,
+      oldestAt: 0,
+      newestAt: 0,
+      spanDays: 0,
+      requiredDays: normalizedRequiredDays,
+      hasEnoughForRecentComparison: false,
+    };
+  }
+
+  const oldestAt = Math.min(...timestamps);
+  const newestAt = Math.max(...timestamps);
+  const spanDays = Math.max(1, Math.floor((newestAt - oldestAt) / DAY_MS) + 1);
+
+  return {
+    recordCount: timestamps.length,
+    oldestAt,
+    newestAt,
+    spanDays,
+    requiredDays: normalizedRequiredDays,
+    hasEnoughForRecentComparison: spanDays >= normalizedRequiredDays,
+  };
+}
+
+function toEpochMs(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return value > 1_000_000_000_000 ? value : value * 1000;
+}

--- a/src/background/analytics/suggestions.ts
+++ b/src/background/analytics/suggestions.ts
@@ -8,6 +8,12 @@ import type {
 import type { FavoriteItem, SmartFavoriteIndex } from '../../shared/types/favorite';
 import type { WatchHistoryRecord } from '../../shared/types/watch-event';
 import { getHistoryCoverageSpan, type HistoryCoverageSpan } from './history-coverage.ts';
+import {
+  buildRelatedVideoSourceFailure,
+  buildVarietyRegionSourceFailure,
+  fetchRelatedVideoCandidates,
+  fetchVarietyRegionCandidatePool,
+} from '../api/video-blind-box-candidates.ts';
 import type {
   RelatedVideoSeed,
   VarietyRegionCandidatePool,
@@ -63,12 +69,6 @@ export async function getExperimentData(): Promise<ExperimentData> {
     getFavoriteItems(),
     getSmartFavoriteIndexMap(),
   ]);
-  const {
-    buildRelatedVideoSourceFailure,
-    fetchRelatedVideoCandidates,
-    fetchVarietyRegionCandidatePool,
-    buildVarietyRegionSourceFailure,
-  } = await import('../api/video-blind-box-candidates.ts');
   const relatedSeeds = selectRelatedVideoSeeds(records, nowMs);
 
   const [randomExplorePool, varietyRegionPool] = await Promise.all([

--- a/src/background/analytics/suggestions.ts
+++ b/src/background/analytics/suggestions.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../shared/types/analytics';
 import type { FavoriteItem, SmartFavoriteIndex } from '../../shared/types/favorite';
 import type { WatchHistoryRecord } from '../../shared/types/watch-event';
+import { getHistoryCoverageSpan, type HistoryCoverageSpan } from './history-coverage.ts';
 import type {
   RelatedVideoSeed,
   VarietyRegionCandidatePool,
@@ -63,16 +64,18 @@ export async function getExperimentData(): Promise<ExperimentData> {
     getSmartFavoriteIndexMap(),
   ]);
   const {
+    buildRelatedVideoSourceFailure,
     fetchRelatedVideoCandidates,
     fetchVarietyRegionCandidatePool,
     buildVarietyRegionSourceFailure,
   } = await import('../api/video-blind-box-candidates.ts');
+  const relatedSeeds = selectRelatedVideoSeeds(records, nowMs);
 
   const [randomExplorePool, varietyRegionPool] = await Promise.all([
     fetchRelatedVideoCandidates(
-      selectRelatedVideoSeeds(records, nowMs),
+      relatedSeeds,
       { seedLimit: RANDOM_RELATED_SEED_LIMIT },
-    ),
+    ).catch(error => buildRelatedVideoSourceFailure(relatedSeeds, error, { seedLimit: RANDOM_RELATED_SEED_LIMIT })),
     fetchVarietyRegionCandidatePool(records, { nowMs })
       .catch(error => buildVarietyRegionSourceFailure(records, nowMs, error)),
   ]);
@@ -168,9 +171,12 @@ function localHistoryReviewMeta(): BlindBoxBoundaryMeta {
 }
 
 function buildVarietyBox(ctx: BlindBoxContext): ExperimentBlindBox {
-  const title = '换口味';
-  const teaser = '从长期兴趣里找一条近期少看的真实 B 站新视频。';
   const pool = ctx.varietyRegionPool;
+  const hasShortHistoryCoverage = pool ? hasShortHistoryCoverageEvidence(pool.evidence) : false;
+  const title = hasShortHistoryCoverage ? '历史证据不足' : '换口味';
+  const teaser = hasShortHistoryCoverage
+    ? '本地历史覆盖太短，暂不判断长期口味冷却。'
+    : '从长期兴趣里找一条近期少看的真实 B 站新视频。';
 
   if (!pool) {
     return emptyBox(
@@ -287,6 +293,9 @@ function varietyEmptyTitle(status: VarietyRegionCandidatePool['status']): string
 function varietyEmptyDescription(pool: VarietyRegionCandidatePool): string {
   switch (pool.status) {
     case 'insufficient_local_evidence':
+      if (hasShortHistoryCoverageEvidence(pool.evidence)) {
+        return `${shortHistoryCoverageLine(pool.evidence)} 暂不生成换口味真实候选，避免把最近几天的记录说成长期兴趣或冷却方向。`;
+      }
       return '换口味需要先从本地长期历史里找出“长期相关、近期低频”的方向。当前证据不足时不会退回本地收藏夹凑数。';
     case 'unmapped_interest':
       return '本地长期兴趣还不能保守映射到 B 站公开分区，所以暂不请求不相关候选，也不从近期高频口味里抽。';
@@ -426,6 +435,23 @@ function buildHiddenFavoriteBox(ctx: BlindBoxContext): ExperimentBlindBox {
 function buildReviveInterestBox(ctx: BlindBoxContext): ExperimentBlindBox {
   const title = '本地兴趣回顾';
   const teaser = '只从本地历史里回看一条旧兴趣代表视频。';
+  const coverage = getHistoryCoverageSpan(ctx.records, ctx.nowMs, VARIETY_RECENT_WINDOW_DAYS);
+  if (!coverage.hasEnoughForRecentComparison) {
+    const coverageLine = formatShortHistoryCoverageForBlindBox(coverage);
+    return emptyBox(
+      'revive_interest',
+      '历史证据不足',
+      '本地历史覆盖太短，暂不回顾旧兴趣。',
+      [coverageLine],
+      '本地历史覆盖还不够长',
+      `${coverageLine} 不能把最近几天当作长期兴趣，也不会用本地库存视频冒充旧兴趣回顾。`,
+      '历史证据不足',
+      LOCAL_HISTORY_REVIEW_SOURCE,
+      '本地观看历史覆盖短于近期对比窗口，暂不判断旧兴趣。',
+      localHistoryReviewMeta(),
+    );
+  }
+
   if (ctx.records.length < MIN_INTEREST_RECORDS) {
     return emptyBox(
       'revive_interest',
@@ -645,6 +671,22 @@ function formatRelatedCandidateFailures(pool: ExperimentRealCandidatePool): stri
   ].filter(Boolean);
 
   return `相关视频候选暂不可用：${parts.join('，') || '未返回有效候选'}。`;
+}
+
+function hasShortHistoryCoverageEvidence(evidence: string[]): boolean {
+  return evidence.some(line => line.includes('本地观看历史目前只覆盖约'));
+}
+
+function shortHistoryCoverageLine(evidence: string[]): string {
+  return evidence.find(line => line.includes('本地观看历史目前只覆盖约'))
+    ?? '本地观看历史覆盖短于近期对比窗口。';
+}
+
+function formatShortHistoryCoverageForBlindBox(coverage: HistoryCoverageSpan): string {
+  if (coverage.recordCount === 0) {
+    return `本地观看历史目前还没有可用于长期/近期对比的记录，至少需要覆盖最近 ${coverage.requiredDays} 天。`;
+  }
+  return `本地观看历史目前只覆盖约 ${coverage.spanDays} 天，短于最近 ${coverage.requiredDays} 天对比窗口。`;
 }
 
 function emptyBox(

--- a/src/background/api/video-blind-box-candidates.ts
+++ b/src/background/api/video-blind-box-candidates.ts
@@ -5,6 +5,7 @@ import type {
   ExperimentVideoCandidate,
 } from '../../shared/types/analytics';
 import type { WatchHistoryRecord } from '../../shared/types/watch-event';
+import { getHistoryCoverageSpan, type HistoryCoverageSpan } from '../analytics/history-coverage.ts';
 
 const DAY_MS = 86_400_000;
 const RELATED_VIDEO_ENDPOINT = '/x/web-interface/archive/related';
@@ -218,6 +219,21 @@ export async function fetchRelatedVideoCandidates(
   };
 }
 
+export function buildRelatedVideoSourceFailure(
+  seeds: RelatedVideoSeed[],
+  _error: unknown,
+  options: RelatedVideoCandidateOptions = {},
+): ExperimentRealCandidatePool {
+  const selectedSeeds = normalizeSeeds(seeds).slice(0, clampPositive(options.seedLimit, DEFAULT_SEED_LIMIT));
+  return {
+    sourceKind: 'bilibili_related',
+    sourceLabel: '相关视频候选',
+    seedCount: selectedSeeds.length,
+    candidates: [],
+    failures: selectedSeeds.map(seed => toRelatedFailure(seed, 'request_failed')),
+  };
+}
+
 export async function fetchVarietyRegionCandidatePool(
   records: WatchHistoryRecord[],
   options: VarietyRegionCandidateOptions = {},
@@ -338,6 +354,9 @@ export function buildVarietyRegionDirections(
   options: { nowMs?: number; maxDirections?: number } = {},
 ): VarietyRegionDirection[] {
   const nowMs = options.nowMs ?? Date.now();
+  const coverage = getHistoryCoverageSpan(records, nowMs, RECENT_WINDOW_DAYS);
+  if (!coverage.hasEnoughForRecentComparison) return [];
+
   const longCutoffMs = nowMs - LONG_WINDOW_DAYS * DAY_MS;
   const recentCutoffMs = nowMs - RECENT_WINDOW_DAYS * DAY_MS;
   const longRecords = records.filter(record => toEpochMs(record.viewAt) >= longCutoffMs);
@@ -454,13 +473,15 @@ function toRelatedCandidate(
 }
 
 function buildNoDirectionPool(records: WatchHistoryRecord[], nowMs: number): VarietyRegionCandidatePool {
+  const coverage = getHistoryCoverageSpan(records, nowMs, RECENT_WINDOW_DAYS);
   const positiveRecords = records
     .filter(record => toEpochMs(record.viewAt) >= nowMs - LONG_WINDOW_DAYS * DAY_MS)
     .filter(isPositiveRecord);
   const mappedSignalCount = positiveRecords
     .flatMap(record => getRecordSignals(record))
     .length;
-  const status: VarietyRegionCandidatePoolStatus = positiveRecords.length < MIN_LONG_POSITIVE_COUNT
+  const hasShortHistoryCoverage = !coverage.hasEnoughForRecentComparison;
+  const status: VarietyRegionCandidatePoolStatus = hasShortHistoryCoverage || positiveRecords.length < MIN_LONG_POSITIVE_COUNT
     ? 'insufficient_local_evidence'
     : mappedSignalCount === 0
       ? 'unmapped_interest'
@@ -472,8 +493,12 @@ function buildNoDirectionPool(records: WatchHistoryRecord[], nowMs: number): Var
     directions: [],
     candidates: [],
     evidence: [
-      `近 ${LONG_WINDOW_DAYS} 天本地正向观看 ${positiveRecords.length} 条，换口味至少需要 ${MIN_LONG_POSITIVE_COUNT} 条可聚合兴趣证据。`,
-      status === 'unmapped_interest'
+      hasShortHistoryCoverage
+        ? formatShortHistoryCoverageEvidence(coverage)
+        : `近 ${LONG_WINDOW_DAYS} 天本地正向观看 ${positiveRecords.length} 条，换口味至少需要 ${MIN_LONG_POSITIVE_COUNT} 条可聚合兴趣证据。`,
+      hasShortHistoryCoverage
+        ? `本地历史覆盖短于最近 ${RECENT_WINDOW_DAYS} 天对比窗口，暂不把这些记录解释成长期兴趣或冷却方向。`
+        : status === 'unmapped_interest'
         ? '本地长期兴趣还不能保守映射到 B 站公开分区，暂不硬凑真实候选。'
         : '没有找到长期相关但近期低频的分区方向，避免从近期高频口味里抽。',
     ],
@@ -481,6 +506,13 @@ function buildNoDirectionPool(records: WatchHistoryRecord[], nowMs: number): Var
     excludedRecentBvidCount: 0,
     excludedInvalidCandidateCount: 0,
   };
+}
+
+function formatShortHistoryCoverageEvidence(coverage: HistoryCoverageSpan): string {
+  if (coverage.recordCount === 0) {
+    return `本地观看历史目前还没有可用于长期/近期对比的记录，至少需要覆盖最近 ${coverage.requiredDays} 天。`;
+  }
+  return `本地观看历史目前只覆盖约 ${coverage.spanDays} 天，短于最近 ${coverage.requiredDays} 天对比窗口。`;
 }
 
 function buildDirectionEvidence(
@@ -680,11 +712,30 @@ function formatCount(value: number): string {
 }
 
 function readableCandidateError(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  if (typeof error === 'string') return error;
+  if (error instanceof Error) return sanitizeCandidateError(error.message);
+  if (typeof error === 'string') return sanitizeCandidateError(error);
   try {
-    return JSON.stringify(error);
+    return sanitizeCandidateError(JSON.stringify(error));
   } catch {
-    return String(error);
+    return sanitizeCandidateError(String(error));
   }
+}
+
+function sanitizeCandidateError(message: string): string {
+  if (/document is not defined|window is not defined|ReferenceError/i.test(message)) {
+    return '运行环境暂不支持该候选源';
+  }
+  if (/RATE_LIMITED|HTTP 412|\b412\b/i.test(message)) {
+    return '请求频率受限';
+  }
+  if (/REQUEST_TIMEOUT|AbortError|timeout/i.test(message)) {
+    return '请求超时';
+  }
+  if (/NOT_LOGGED_IN/i.test(message)) {
+    return '登录状态不可用';
+  }
+  if (/API Error/i.test(message)) {
+    return 'B 站接口暂时不可用';
+  }
+  return '候选源请求失败';
 }

--- a/src/background/dynamic-bill/buried-follow.ts
+++ b/src/background/dynamic-bill/buried-follow.ts
@@ -17,6 +17,7 @@ import {
 } from '../storage/dynamic-bill-repo';
 import { applyDynamicBillFeedbackScore, evaluateDynamicBillFeedback } from './feedback';
 import { DYNAMIC_BILL_STRATEGY, getDynamicBillThresholdEvidence } from './strategy';
+import { getHistoryCoverageSpan } from '../analytics/history-coverage.ts';
 
 const SECONDS_PER_DAY = 86_400;
 const BURIED_FOLLOW_COLUMN = 'buried_follow';
@@ -79,6 +80,40 @@ export async function generateBuriedFollowBillItems(): Promise<DynamicBillGenera
     if (!existing || update.dynamicTime > existing.dynamicTime) {
       newestUnwatchedUpdateByCreator.set(update.authorMid, update);
     }
+  }
+
+  const historyCoverage = getHistoryCoverageSpan(
+    longRecords,
+    generatedAt,
+    DYNAMIC_BILL_STRATEGY.recentWindowDays,
+  );
+  if (!historyCoverage.hasEnoughForRecentComparison) {
+    const storedItems = await replaceDynamicBillItemsForColumn(BURIED_FOLLOW_COLUMN, []);
+    const overview = await getDynamicBillOverview(DYNAMIC_BILL_STRATEGY.updateWindowDays);
+
+    return {
+      generatedAt,
+      itemCount: storedItems.length,
+      candidatesScanned: updates.length,
+      eligibleCreatorCount: 0,
+      excludedNoLongSignalCount: newestUnwatchedUpdateByCreator.size,
+      excludedRecentActiveCount: 0,
+      excludedRecentSameVideoCount,
+      excludedByFeedbackCount: 0,
+      columnItemCounts: {
+        afk_update: 0,
+        variety: 0,
+        buried_follow: storedItems.length,
+      },
+      columnEligibleCounts: {
+        afk_update: 0,
+        variety: 0,
+        buried_follow: 0,
+      },
+      items: storedItems,
+      thresholds,
+      overview,
+    };
   }
 
   const candidates: Candidate[] = [];

--- a/src/background/dynamic-bill/rules.ts
+++ b/src/background/dynamic-bill/rules.ts
@@ -16,6 +16,7 @@ import {
 } from '../storage/dynamic-bill-repo';
 import { applyDynamicBillFeedbackScore, evaluateDynamicBillFeedback } from './feedback';
 import { DYNAMIC_BILL_STRATEGY, getDynamicBillThresholdEvidence } from './strategy';
+import { getHistoryCoverageSpan } from '../analytics/history-coverage.ts';
 
 const SECONDS_PER_DAY = 86_400;
 const AFK_UPDATE_COLUMN = 'afk_update';
@@ -37,6 +38,17 @@ interface Candidate {
 }
 
 type CandidateInput = Omit<Candidate, 'score' | 'feedbackFacts'>;
+
+export function hasSufficientLongTermHistoryCoverage(
+  records: WatchHistoryRecord[],
+  nowSeconds: number,
+): boolean {
+  return getHistoryCoverageSpan(
+    records,
+    nowSeconds * 1000,
+    DYNAMIC_BILL_STRATEGY.recentWindowDays,
+  ).hasEnoughForRecentComparison;
+}
 
 export async function generateAfkUpdateBillItems(): Promise<DynamicBillGenerateResult> {
   const generatedAt = Date.now();
@@ -75,6 +87,35 @@ export async function generateAfkUpdateBillItems(): Promise<DynamicBillGenerateR
     if (!existing || update.dynamicTime > existing.dynamicTime) {
       newestUnwatchedUpdateByCreator.set(update.authorMid, update);
     }
+  }
+
+  if (!hasSufficientLongTermHistoryCoverage(longRecords, nowSeconds)) {
+    const storedItems = await replaceDynamicBillItemsForColumn(AFK_UPDATE_COLUMN, []);
+    const overview = await getDynamicBillOverview(DYNAMIC_BILL_STRATEGY.updateWindowDays);
+
+    return {
+      generatedAt,
+      itemCount: storedItems.length,
+      candidatesScanned: updates.length,
+      eligibleCreatorCount: 0,
+      excludedNoLongSignalCount: newestUnwatchedUpdateByCreator.size,
+      excludedRecentActiveCount: 0,
+      excludedRecentSameVideoCount,
+      excludedByFeedbackCount: 0,
+      columnItemCounts: {
+        afk_update: storedItems.length,
+        variety: 0,
+        buried_follow: 0,
+      },
+      columnEligibleCounts: {
+        afk_update: 0,
+        variety: 0,
+        buried_follow: 0,
+      },
+      items: storedItems,
+      thresholds,
+      overview,
+    };
   }
 
   const candidates: Candidate[] = [];

--- a/src/background/dynamic-bill/variety.ts
+++ b/src/background/dynamic-bill/variety.ts
@@ -17,6 +17,7 @@ import {
 } from '../storage/dynamic-bill-repo';
 import { applyDynamicBillFeedbackScore, evaluateDynamicBillFeedback } from './feedback';
 import { DYNAMIC_BILL_STRATEGY, getDynamicBillThresholdEvidence } from './strategy';
+import { getHistoryCoverageSpan } from '../analytics/history-coverage.ts';
 
 const SECONDS_PER_DAY = 86_400;
 const VARIETY_COLUMN = 'variety';
@@ -96,6 +97,40 @@ export async function generateVarietyBillItems(): Promise<DynamicBillGenerateRes
       continue;
     }
     unwatchedUpdates.push(update);
+  }
+
+  const historyCoverage = getHistoryCoverageSpan(
+    longRecords,
+    generatedAt,
+    DYNAMIC_BILL_STRATEGY.recentWindowDays,
+  );
+  if (!historyCoverage.hasEnoughForRecentComparison) {
+    const storedItems = await replaceDynamicBillItemsForColumn(VARIETY_COLUMN, []);
+    const overview = await getDynamicBillOverview(DYNAMIC_BILL_STRATEGY.updateWindowDays);
+
+    return {
+      generatedAt,
+      itemCount: storedItems.length,
+      candidatesScanned: updates.length,
+      eligibleCreatorCount: 0,
+      excludedNoLongSignalCount: unwatchedUpdates.length,
+      excludedRecentActiveCount: 0,
+      excludedRecentSameVideoCount,
+      excludedByFeedbackCount: 0,
+      columnItemCounts: {
+        afk_update: 0,
+        variety: storedItems.length,
+        buried_follow: 0,
+      },
+      columnEligibleCounts: {
+        afk_update: 0,
+        variety: 0,
+        buried_follow: 0,
+      },
+      items: storedItems,
+      thresholds,
+      overview,
+    };
   }
 
   const recentRecords = longRecords.filter(record => record.viewAt >= recentCutoff);

--- a/tests/experiment-blind-boxes.test.ts
+++ b/tests/experiment-blind-boxes.test.ts
@@ -2,10 +2,14 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { buildExperimentData } from '../src/background/analytics/suggestions.ts';
 import {
+  buildRelatedVideoSourceFailure,
+  buildVarietyRegionSourceFailure,
   buildVarietyRegionDirections,
+  fetchVarietyRegionCandidatePool,
   type VarietyRegionCandidatePool,
   type VarietyRegionDirection,
 } from '../src/background/api/video-blind-box-candidates.ts';
+import { getHistoryCoverageSpan } from '../src/background/analytics/history-coverage.ts';
 import type { ExperimentRealCandidatePool } from '../src/shared/types/analytics';
 import type { FavoriteItem, SmartFavoriteIndex } from '../src/shared/types/favorite';
 import type { WatchHistoryRecord } from '../src/shared/types/watch-event';
@@ -175,6 +179,25 @@ test('returns a clear downgrade when the real region candidate source fails', ()
   assert.equal(variety.video, undefined);
 });
 
+test('sanitizes raw runtime errors from region candidate source failures', () => {
+  const failedPool = buildVarietyRegionSourceFailure(
+    createMixedTasteRecords(),
+    NOW_MS,
+    new ReferenceError('document is not defined'),
+  );
+  const data = buildExperimentData(createMixedTasteRecords(), [], new Map(), NOW_MS, {
+    randomExplorePool: createRelatedPool(),
+    varietyRegionPool: failedPool,
+  });
+  const variety = data.blindBoxes.find(box => box.id === 'variety');
+
+  assert.ok(variety);
+  assert.equal(variety.state, 'empty');
+  assert.match(variety.emptyDescription ?? '', /候选源|运行环境|暂时不可用/);
+  assert.equal(JSON.stringify(variety).includes('document is not defined'), false);
+  assert.equal(JSON.stringify(variety).includes('ReferenceError'), false);
+});
+
 test('returns Chinese empty states instead of generic filler when local evidence is insufficient', () => {
   const bannedGuessWord = ['猜你', '喜欢'].join('');
   const bannedUnconsumedWord = ['未', '消费'].join('');
@@ -218,17 +241,10 @@ test('does not fall back to a local random video when related candidates fail', 
     createRecord({ bvid: 'BV1LOCAL001', tagName: '游戏', daysAgo: 3, actualCompletion: 0.92, title: '本地种子视频' }),
     createRecord({ bvid: 'BV1LOCAL002', tagName: '游戏', daysAgo: 40, actualCompletion: 0.91, title: '本地备用视频' }),
   ];
-  const failedPool: ExperimentRealCandidatePool = {
-    sourceKind: 'bilibili_related',
-    sourceLabel: '相关视频候选',
-    seedCount: 1,
-    candidates: [],
-    failures: [{
-      seedBvid: 'BV1LOCAL001',
-      seedTitle: '本地种子视频',
-      reason: 'request_failed',
-    }],
-  };
+  const failedPool = buildRelatedVideoSourceFailure(
+    [{ bvid: 'BV1LOCAL001', title: '本地种子视频' }],
+    new ReferenceError('document is not defined'),
+  );
 
   const data = buildExperimentData(records, [], new Map(), NOW_MS, failedPool);
   const randomExplore = data.blindBoxes.find(box => box.id === 'random_explore');
@@ -242,6 +258,45 @@ test('does not fall back to a local random video when related candidates fail', 
   assert.match(randomExplore.source, /相关视频候选/);
   assert.match(randomExplore.emptyDescription ?? '', /不会用本地库存视频冒充/);
   assert.ok(randomExplore.evidence.some(line => line.includes('请求失败')));
+  assert.equal(JSON.stringify(randomExplore).includes('document is not defined'), false);
+});
+
+test('downgrades blind-box long-term surfaces when local history only spans about a week', async () => {
+  const records = createShortCoverageRecords();
+  const coverage = getHistoryCoverageSpan(records, NOW_MS);
+  assert.equal(coverage.spanDays, 7);
+  assert.equal(coverage.hasEnoughForRecentComparison, false);
+
+  assert.deepEqual(buildVarietyRegionDirections(records, { nowMs: NOW_MS }), []);
+  const regionPool = await fetchVarietyRegionCandidatePool(records, { nowMs: NOW_MS });
+  assert.equal(regionPool.status, 'insufficient_local_evidence');
+  assert.ok(regionPool.evidence.some(line => line.includes('本地观看历史目前只覆盖约 7 天')));
+
+  const data = buildExperimentData(records, [], new Map(), NOW_MS, {
+    randomExplorePool: createRelatedPool(),
+    varietyRegionPool: regionPool,
+  });
+  const variety = data.blindBoxes.find(box => box.id === 'variety');
+  const reviveInterest = data.blindBoxes.find(box => box.id === 'revive_interest');
+
+  assert.ok(variety);
+  assert.equal(variety.state, 'empty');
+  assert.match(variety.emptyDescription ?? '', /本地观看历史目前只覆盖约 7 天/);
+  assert.equal(variety.title.includes('换口味'), false);
+  assert.ok(reviveInterest);
+  assert.equal(reviveInterest.state, 'empty');
+  assert.match(reviveInterest.emptyDescription ?? '', /不能把最近几天当作长期兴趣/);
+});
+
+test('dynamic bill long-term columns require local history to span the recent comparison window', () => {
+  assert.equal(
+    getHistoryCoverageSpan(createShortCoverageRecords(), NOW_MS).hasEnoughForRecentComparison,
+    false,
+  );
+  assert.equal(
+    getHistoryCoverageSpan(createMixedTasteRecords(), NOW_MS).hasEnoughForRecentComparison,
+    true,
+  );
 });
 
 function createMixedTasteRecords(): WatchHistoryRecord[] {
@@ -256,6 +311,16 @@ function createMixedTasteRecords(): WatchHistoryRecord[] {
     createRecord({ bvid: 'BVKNO002', tagName: '知识', daysAgo: 145, actualCompletion: 0.94, title: '旧兴趣 2' }),
     createRecord({ bvid: 'BVKNO003', tagName: '知识', daysAgo: 170, actualCompletion: 0.9, title: '旧兴趣 3' }),
     createRecord({ bvid: 'BVKNO004', tagName: '知识', daysAgo: 175, actualCompletion: 0.89, title: '旧兴趣 4' }),
+  ];
+}
+
+function createShortCoverageRecords(): WatchHistoryRecord[] {
+  return [
+    createRecord({ bvid: 'BVSHORT001', tagName: '知识', daysAgo: 0, actualCompletion: 0.92, title: '短历史知识 1' }),
+    createRecord({ bvid: 'BVSHORT002', tagName: '知识', daysAgo: 1, actualCompletion: 0.9, title: '短历史知识 2' }),
+    createRecord({ bvid: 'BVSHORT003', tagName: '知识', daysAgo: 2, actualCompletion: 0.88, title: '短历史知识 3' }),
+    createRecord({ bvid: 'BVSHORT004', tagName: '知识', daysAgo: 4, actualCompletion: 0.91, title: '短历史知识 4' }),
+    createRecord({ bvid: 'BVSHORT005', tagName: '知识', daysAgo: 6, actualCompletion: 0.89, title: '短历史知识 5' }),
   ];
 }
 

--- a/tests/experiment-blind-boxes.test.ts
+++ b/tests/experiment-blind-boxes.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 import { buildExperimentData } from '../src/background/analytics/suggestions.ts';
 import {
@@ -297,6 +298,13 @@ test('dynamic bill long-term columns require local history to span the recent co
     getHistoryCoverageSpan(createMixedTasteRecords(), NOW_MS).hasEnoughForRecentComparison,
     true,
   );
+});
+
+test('keeps blind-box candidate helpers out of service-worker dynamic preload', () => {
+  const source = readFileSync(new URL('../src/background/analytics/suggestions.ts', import.meta.url), 'utf8');
+
+  assert.equal(source.includes("await import('../api/video-blind-box-candidates.ts')"), false);
+  assert.match(source, /from ['"]\.\.\/api\/video-blind-box-candidates\.ts['"]/);
 });
 
 function createMixedTasteRecords(): WatchHistoryRecord[] {


### PR DESCRIPTION
Refs #165.

Scope:
- Keep AI feature switches in Settings aligned with stored config after reload/navigation by normalizing config and listening for config storage changes.
- Degrade blind-box real candidate source failures instead of surfacing raw runtime errors, including related-video failures.
- Gate long-term blind-box and Dynamic Bill surfaces when local history coverage is shorter than the recent comparison window.
- Remove user-visible Cookie wording from touched privacy copy and keep Dynamic Bill framed as interest rebalancing.

Validation:
- npm.cmd run test:experiments
- npm.cmd run typecheck
- npm.cmd run build
- git diff --check
- copy scan: 未消费|猜你喜欢
- raw-field scan on changed UI/background/test surfaces
- Browser/mock QA for Settings switches, four blind-box cards, source labels, short-history downgrade, Dynamic Bill copy

Notes:
- No release/tag/package/dist changes.
- Did not process #82/#83 or #166.