### PR TITLE
[0.13][SET-013-A] 配置迁移与持久状态

### DIFF
--- a/dashboard/modules/favorites/SmartFavoritesPage.tsx
+++ b/dashboard/modules/favorites/SmartFavoritesPage.tsx
@@ -27,10 +27,8 @@ const CARD = {
 export function SmartFavoritesPage() {
   const [overview, setOverview] = useState<SmartFavoriteOverview | null>(null);
   const [assistantConfig, setAssistantConfig] = useState<AssistantConfig>({
-    aiSummariesEnabled: false,
+    currentVideoAiAssistantEnabled: false,
     smartFavoritesQaAiEnabled: false,
-    currentVideoSegmentRerankAiEnabled: false,
-    currentVideoQaAiEnabled: false,
   });
   const [aiStatus, setAiStatus] = useState({ hasApiKey: false, model: '' });
   const [query, setQuery] = useState('');
@@ -316,7 +314,7 @@ export function SmartFavoritesPage() {
           <Badge text={aiStatus.hasApiKey ? 'AI 服务：已配置' : 'AI 服务：未配置'} color={aiStatus.hasApiKey ? '#00D4AA' : '#FFB347'} />
           <Badge text={`模型：${aiStatus.model || '未设置'}`} color="#9090A0" />
           <Badge text={assistantConfig.smartFavoritesQaAiEnabled ? '收藏问答：已启用' : '收藏问答：未启用'} color={assistantConfig.smartFavoritesQaAiEnabled ? '#00D4AA' : '#9090A0'} />
-          <Badge text={assistantConfig.currentVideoSegmentRerankAiEnabled ? '当前视频片段排序：已启用' : '当前视频片段排序：未启用'} color={assistantConfig.currentVideoSegmentRerankAiEnabled ? '#00D4AA' : '#9090A0'} />
+          <Badge text={assistantConfig.currentVideoAiAssistantEnabled ? '当前视频助手：已启用' : '当前视频助手：未启用'} color={assistantConfig.currentVideoAiAssistantEnabled ? '#00D4AA' : '#9090A0'} />
         </div>
       </section>
 

--- a/dashboard/modules/settings/SettingsPage.tsx
+++ b/dashboard/modules/settings/SettingsPage.tsx
@@ -21,6 +21,11 @@ import type {
   LocalDataPrivacySummary,
   SmartFavoriteIndexRebuildResult,
 } from '../../../src/shared/types/local-data-privacy';
+import {
+  formatSettingsError,
+  normalizeSettingsUserConfig,
+  saveSettingsDraft,
+} from './settings-save-state';
 
 type BusyState = '' | 'save' | 'test' | 'local-refresh' | 'subtitle-clear' | 'index-rebuild' | 'clear-all';
 
@@ -129,20 +134,35 @@ export function SettingsPage() {
     setError('');
     setNotice('');
     try {
-      await ensureAiHostPermission(effectiveAiConfig.baseURL);
       const baseConfig = normalizeSettingsUserConfig(loadedConfig ?? await requestSW<UserConfig>('GET_CONFIG'));
-      const nextConfig = normalizeSettingsUserConfig({
-        ...baseConfig,
-        ai: effectiveAiConfig,
-        assistant,
-        dynamicBill,
-      });
-      await requestSW('UPDATE_CONFIG', {
-        ai: nextConfig.ai,
-        assistant: nextConfig.assistant,
-        dynamicBill: nextConfig.dynamicBill,
-      });
-      applyConfig(nextConfig);
+      const result = await saveSettingsDraft(
+        {
+          persistedConfig: baseConfig,
+          draft: {
+            ai: {
+              ...form,
+              savedApiKey,
+            },
+            assistant,
+            dynamicBill,
+          },
+        },
+        {
+          persist: async nextConfig => {
+            await ensureAiHostPermission(nextConfig.ai.baseURL);
+            await requestSW('UPDATE_CONFIG', {
+              ai: nextConfig.ai,
+              assistant: nextConfig.assistant,
+              dynamicBill: nextConfig.dynamicBill,
+            });
+          },
+          applyPersistedConfig: applyConfig,
+        },
+      );
+      if (result.status === 'failure') {
+        setError(result.error);
+        return;
+      }
       setNotice('设置已保存。后续 AI 功能会从这里读取同一套服务配置和开关。');
     } catch (err) {
       setError(formatSettingsError(err));
@@ -535,32 +555,6 @@ function FeatureToggle({
   );
 }
 
-function normalizeSettingsUserConfig(config: Partial<UserConfig>): UserConfig {
-  return {
-    ...DEFAULT_CONFIG,
-    ...config,
-    ai: {
-      ...DEFAULT_CONFIG.ai,
-      ...(config.ai ?? {}),
-    },
-    assistant: normalizeAssistantConfig(config.assistant),
-    dynamicBill: normalizeDynamicBillConfig(config.dynamicBill),
-  };
-}
-
-function normalizeAssistantConfig(config: Partial<AssistantConfig> | undefined): AssistantConfig {
-  return {
-    currentVideoAiAssistantEnabled: config?.currentVideoAiAssistantEnabled === true,
-    smartFavoritesQaAiEnabled: config?.smartFavoritesQaAiEnabled === true,
-  };
-}
-
-function normalizeDynamicBillConfig(config: Partial<DynamicBillConfig> | undefined): DynamicBillConfig {
-  return {
-    aiExplanationsEnabled: config?.aiExplanationsEnabled === true,
-  };
-}
-
 async function ensureAiHostPermission(baseURL: string): Promise<void> {
   const pattern = getOriginPattern(baseURL);
   const granted = await new Promise<boolean>(resolve => {
@@ -597,16 +591,6 @@ function getOriginPattern(baseURL: string): string {
 
 function isLocalHttpHost(hostname: string): boolean {
   return hostname === 'localhost' || hostname === '127.0.0.1';
-}
-
-function formatSettingsError(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
-  const retained = '设置未保存，当前输入已保留。';
-  if (message === 'AI_BASE_URL_INVALID') return `${retained} AI 服务地址格式不正确。`;
-  if (message === 'AI_BASE_URL_UNSUPPORTED') return `${retained} AI 服务地址只支持 http 或 https。`;
-  if (message === 'AI_HTTP_HOST_UNSUPPORTED') return `${retained} HTTP 服务地址仅限本机调试地址。`;
-  if (message === 'AI_PERMISSION_DENIED') return `${retained} 没有获得该 AI 服务地址的访问权限。`;
-  return `${retained} 请检查服务地址、模型名和浏览器授权后重试。`;
 }
 
 function formatConnectionError(error: unknown): string {

--- a/dashboard/modules/settings/SettingsPage.tsx
+++ b/dashboard/modules/settings/SettingsPage.tsx
@@ -92,10 +92,8 @@ export function SettingsPage() {
     return form.baseURL.trim() !== loadedConfig.ai.baseURL
       || form.chatModel.trim() !== loadedConfig.ai.chatModel
       || form.apiKeyInput.trim().length > 0
-      || assistant.aiSummariesEnabled !== loadedConfig.assistant.aiSummariesEnabled
+      || assistant.currentVideoAiAssistantEnabled !== loadedConfig.assistant.currentVideoAiAssistantEnabled
       || assistant.smartFavoritesQaAiEnabled !== loadedConfig.assistant.smartFavoritesQaAiEnabled
-      || assistant.currentVideoSegmentRerankAiEnabled !== loadedConfig.assistant.currentVideoSegmentRerankAiEnabled
-      || assistant.currentVideoQaAiEnabled !== loadedConfig.assistant.currentVideoQaAiEnabled
       || dynamicBill.aiExplanationsEnabled !== loadedConfig.dynamicBill.aiExplanationsEnabled;
   }, [assistant, dynamicBill, form, loadedConfig]);
   const localDataCards = localData ? buildLocalDataSummaryCards(localData) : [];
@@ -147,6 +145,7 @@ export function SettingsPage() {
       applyConfig(nextConfig);
       setNotice('设置已保存。后续 AI 功能会从这里读取同一套服务配置和开关。');
     } catch (err) {
+      await refreshConfig();
       setError(formatSettingsError(err));
     } finally {
       setBusy('');
@@ -345,22 +344,10 @@ export function SettingsPage() {
 
         <div className="settings-toggle-grid">
           <FeatureToggle
-            title="当前视频摘要"
-            detail="允许当前视频助手在有边界的元数据、简介或字幕证据上整理摘要。"
-            checked={assistant.aiSummariesEnabled}
-            onChange={(checked) => setAssistant(current => ({ ...current, aiSummariesEnabled: checked }))}
-          />
-          <FeatureToggle
-            title="当前视频片段排序辅助"
-            detail="允许 AI 只在已检索出的本地候选片段中调整展示顺序和解释。"
-            checked={assistant.currentVideoSegmentRerankAiEnabled}
-            onChange={(checked) => setAssistant(current => ({ ...current, currentVideoSegmentRerankAiEnabled: checked }))}
-          />
-          <FeatureToggle
-            title="当前视频问答整理"
-            detail="允许 AI 只基于当前视频 top-N 本地引用片段整理简短回答；时间点和引用仍来自本地候选。"
-            checked={assistant.currentVideoQaAiEnabled}
-            onChange={(checked) => setAssistant(current => ({ ...current, currentVideoQaAiEnabled: checked }))}
+            title="当前视频 AI 助手"
+            detail="允许用户主动触发摘要、亮点和问答时，把当前分 P 的主要文本发送给已配置的聊天服务；开启开关本身不会发送请求。"
+            checked={assistant.currentVideoAiAssistantEnabled}
+            onChange={(checked) => setAssistant(current => ({ ...current, currentVideoAiAssistantEnabled: checked }))}
           />
           <FeatureToggle
             title="智能收藏问答"
@@ -564,10 +551,8 @@ function normalizeSettingsUserConfig(config: Partial<UserConfig>): UserConfig {
 
 function normalizeAssistantConfig(config: Partial<AssistantConfig> | undefined): AssistantConfig {
   return {
-    aiSummariesEnabled: config?.aiSummariesEnabled === true,
+    currentVideoAiAssistantEnabled: config?.currentVideoAiAssistantEnabled === true,
     smartFavoritesQaAiEnabled: config?.smartFavoritesQaAiEnabled === true,
-    currentVideoSegmentRerankAiEnabled: config?.currentVideoSegmentRerankAiEnabled === true,
-    currentVideoQaAiEnabled: config?.currentVideoQaAiEnabled === true,
   };
 }
 

--- a/dashboard/modules/settings/SettingsPage.tsx
+++ b/dashboard/modules/settings/SettingsPage.tsx
@@ -145,7 +145,6 @@ export function SettingsPage() {
       applyConfig(nextConfig);
       setNotice('设置已保存。后续 AI 功能会从这里读取同一套服务配置和开关。');
     } catch (err) {
-      await refreshConfig();
       setError(formatSettingsError(err));
     } finally {
       setBusy('');
@@ -602,11 +601,12 @@ function isLocalHttpHost(hostname: string): boolean {
 
 function formatSettingsError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
-  if (message === 'AI_BASE_URL_INVALID') return 'AI 服务地址格式不正确。';
-  if (message === 'AI_BASE_URL_UNSUPPORTED') return 'AI 服务地址只支持 http 或 https。';
-  if (message === 'AI_HTTP_HOST_UNSUPPORTED') return 'HTTP 服务地址仅限本机调试地址。';
-  if (message === 'AI_PERMISSION_DENIED') return '没有获得该 AI 服务地址的访问权限，设置尚未保存。';
-  return '设置保存失败，请检查服务地址、模型名和浏览器授权后重试。';
+  const retained = '设置未保存，当前输入已保留。';
+  if (message === 'AI_BASE_URL_INVALID') return `${retained} AI 服务地址格式不正确。`;
+  if (message === 'AI_BASE_URL_UNSUPPORTED') return `${retained} AI 服务地址只支持 http 或 https。`;
+  if (message === 'AI_HTTP_HOST_UNSUPPORTED') return `${retained} HTTP 服务地址仅限本机调试地址。`;
+  if (message === 'AI_PERMISSION_DENIED') return `${retained} 没有获得该 AI 服务地址的访问权限。`;
+  return `${retained} 请检查服务地址、模型名和浏览器授权后重试。`;
 }
 
 function formatConnectionError(error: unknown): string {

--- a/dashboard/modules/settings/settings-save-state.ts
+++ b/dashboard/modules/settings/settings-save-state.ts
@@ -1,0 +1,126 @@
+import {
+  DEFAULT_CONFIG,
+  type AssistantConfig,
+  type DynamicBillConfig,
+  type UserConfig,
+} from '../../../src/shared/types/config.ts';
+
+export interface SettingsDraft {
+  ai: {
+    baseURL: string;
+    chatModel: string;
+    apiKeyInput: string;
+    savedApiKey: string;
+  };
+  assistant: AssistantConfig;
+  dynamicBill: DynamicBillConfig;
+}
+
+export interface SaveSettingsDraftInput {
+  persistedConfig: UserConfig;
+  draft: SettingsDraft;
+}
+
+export interface SaveSettingsDraftDependencies {
+  persist: (config: UserConfig) => Promise<void>;
+  applyPersistedConfig: (config: UserConfig) => void;
+}
+
+export type SaveSettingsDraftResult =
+  | {
+    status: 'success';
+    draft: SettingsDraft;
+    persistedConfig: UserConfig;
+    error: '';
+  }
+  | {
+    status: 'failure';
+    draft: SettingsDraft;
+    persistedConfig: UserConfig;
+    error: string;
+  };
+
+export async function saveSettingsDraft(
+  input: SaveSettingsDraftInput,
+  dependencies: SaveSettingsDraftDependencies,
+): Promise<SaveSettingsDraftResult> {
+  const persistedConfig = normalizeSettingsUserConfig(input.persistedConfig);
+  const nextConfig = normalizeSettingsUserConfig({
+    ...persistedConfig,
+    ai: {
+      baseURL: input.draft.ai.baseURL.trim(),
+      chatModel: input.draft.ai.chatModel.trim(),
+      apiKey: input.draft.ai.apiKeyInput.trim() || input.draft.ai.savedApiKey,
+    },
+    assistant: input.draft.assistant,
+    dynamicBill: input.draft.dynamicBill,
+  });
+
+  try {
+    await dependencies.persist(nextConfig);
+  } catch (error) {
+    return {
+      status: 'failure',
+      draft: input.draft,
+      persistedConfig,
+      error: formatSettingsError(error),
+    };
+  }
+
+  dependencies.applyPersistedConfig(nextConfig);
+  return {
+    status: 'success',
+    draft: draftFromPersistedConfig(nextConfig),
+    persistedConfig: nextConfig,
+    error: '',
+  };
+}
+
+export function normalizeSettingsUserConfig(config: Partial<UserConfig>): UserConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    ...config,
+    ai: {
+      ...DEFAULT_CONFIG.ai,
+      ...(config.ai ?? {}),
+    },
+    assistant: normalizeAssistantConfig(config.assistant),
+    dynamicBill: normalizeDynamicBillConfig(config.dynamicBill),
+  };
+}
+
+export function formatSettingsError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const retained = '设置未保存，当前输入已保留。';
+  if (message === 'AI_BASE_URL_INVALID') return `${retained} AI 服务地址格式不正确。`;
+  if (message === 'AI_BASE_URL_UNSUPPORTED') return `${retained} AI 服务地址只支持 http 或 https。`;
+  if (message === 'AI_HTTP_HOST_UNSUPPORTED') return `${retained} HTTP 服务地址仅限本机调试地址。`;
+  if (message === 'AI_PERMISSION_DENIED') return `${retained} 没有获得该 AI 服务地址的访问权限。`;
+  return `${retained} 请检查服务地址、模型名和浏览器授权后重试。`;
+}
+
+function draftFromPersistedConfig(config: UserConfig): SettingsDraft {
+  return {
+    ai: {
+      baseURL: config.ai.baseURL,
+      chatModel: config.ai.chatModel,
+      apiKeyInput: '',
+      savedApiKey: config.ai.apiKey,
+    },
+    assistant: config.assistant,
+    dynamicBill: config.dynamicBill,
+  };
+}
+
+function normalizeAssistantConfig(config: Partial<AssistantConfig> | undefined): AssistantConfig {
+  return {
+    currentVideoAiAssistantEnabled: config?.currentVideoAiAssistantEnabled === true,
+    smartFavoritesQaAiEnabled: config?.smartFavoritesQaAiEnabled === true,
+  };
+}
+
+function normalizeDynamicBillConfig(config: Partial<DynamicBillConfig> | undefined): DynamicBillConfig {
+  return {
+    aiExplanationsEnabled: config?.aiExplanationsEnabled === true,
+  };
+}

--- a/src/background/current-video-summary.ts
+++ b/src/background/current-video-summary.ts
@@ -34,7 +34,7 @@ export async function generateCurrentVideoSummary(
   const local = buildLocalCurrentVideoSummary(context, {
     aiStatus: 'disabled',
     aiModel: config.ai.chatModel,
-    aiNote: 'AI 摘要未在设置中启用，当前显示本地证据结果。',
+    aiNote: '当前视频 AI 助手未在设置中开启，当前显示本地证据结果。',
     transcriptSegments: options.transcriptSegments,
     now,
   });
@@ -49,7 +49,7 @@ export async function generateCurrentVideoSummary(
     });
   }
 
-  if (!config.assistant.aiSummariesEnabled) {
+  if (!config.assistant.currentVideoAiAssistantEnabled) {
     return local;
   }
 
@@ -57,7 +57,7 @@ export async function generateCurrentVideoSummary(
     return buildLocalCurrentVideoSummary(context, {
       aiStatus: 'not_configured',
       aiModel: config.ai.chatModel,
-      aiNote: 'AI 摘要已启用但尚未在设置中配置 API Key，当前显示本地证据结果。',
+      aiNote: '当前视频 AI 助手已开启但尚未配置 API Key，当前显示本地证据结果。',
       transcriptSegments: options.transcriptSegments,
       now,
     });

--- a/src/background/current-video-summary.ts
+++ b/src/background/current-video-summary.ts
@@ -2,9 +2,7 @@ import type { AiConfig, UserConfig } from '../shared/types/config.ts';
 import type { CurrentVideoContextResult } from '../shared/types/current-video-context.ts';
 import type { CurrentVideoSummaryResult } from '../shared/types/current-video-summary.ts';
 import {
-  buildCurrentVideoSummaryAiPayload,
   buildLocalCurrentVideoSummary,
-  validateCurrentVideoSummaryAiOutput,
 } from '../shared/current-video-summary.ts';
 import type { CurrentVideoTranscriptSegment } from '../shared/types/current-video-transcript.ts';
 import { chatJson } from './ai/openai-compatible.ts';
@@ -23,8 +21,6 @@ export interface GenerateCurrentVideoSummaryOptions {
   now?: number;
 }
 
-const LOW_AI_CONFIDENCE_THRESHOLD = 0.45;
-
 export async function generateCurrentVideoSummary(
   context: CurrentVideoContextResult,
   options: GenerateCurrentVideoSummaryOptions = {},
@@ -34,7 +30,7 @@ export async function generateCurrentVideoSummary(
   const local = buildLocalCurrentVideoSummary(context, {
     aiStatus: 'disabled',
     aiModel: config.ai.chatModel,
-    aiNote: '当前视频 AI 助手未在设置中开启，当前显示本地证据结果。',
+    aiNote: '当前只显示本地证据结果，本次没有向聊天服务发送视频内容。',
     transcriptSegments: options.transcriptSegments,
     now,
   });
@@ -49,105 +45,5 @@ export async function generateCurrentVideoSummary(
     });
   }
 
-  if (!config.assistant.currentVideoAiAssistantEnabled) {
-    return local;
-  }
-
-  if (!config.ai.apiKey.trim()) {
-    return buildLocalCurrentVideoSummary(context, {
-      aiStatus: 'not_configured',
-      aiModel: config.ai.chatModel,
-      aiNote: '当前视频 AI 助手已开启但尚未配置 API Key，当前显示本地证据结果。',
-      transcriptSegments: options.transcriptSegments,
-      now,
-    });
-  }
-
-  try {
-    const payload = buildCurrentVideoSummaryAiPayload(context, {
-      transcriptSegments: options.transcriptSegments,
-    });
-    const transcriptPayload = payload.intent === 'current_video_transcript_summary_v1';
-    const ai = await (options.chat ?? chatJson)(config.ai, [
-      {
-        role: 'system',
-        content: buildSystemPrompt(transcriptPayload),
-      },
-      {
-        role: 'user',
-        content: JSON.stringify(payload),
-      },
-    ]);
-
-    const validated = validateCurrentVideoSummaryAiOutput(ai, payload, local);
-    if (!validated.ok) {
-      return buildLocalCurrentVideoSummary(context, {
-        aiStatus: 'invalid_output',
-        aiModel: config.ai.chatModel,
-        aiError: validated.error,
-        aiNote: 'AI 返回内容引用了本次证据范围之外的片段或时间，当前显示本地字幕正文证据结果。',
-        transcriptSegments: options.transcriptSegments,
-        now,
-      });
-    }
-    if (validated.confidence < LOW_AI_CONFIDENCE_THRESHOLD) {
-      return buildLocalCurrentVideoSummary(context, {
-        aiStatus: 'low_confidence',
-        aiModel: config.ai.chatModel,
-        aiNote: `AI 返回置信度 ${validated.confidence.toFixed(2)}，低于本地证据结果阈值；当前显示本地证据结果。`,
-        transcriptSegments: options.transcriptSegments,
-        now,
-      });
-    }
-
-    return {
-      ...local,
-      generationMode: 'ai',
-      summary: validated.summary,
-      bullets: validated.bullets,
-      ai: {
-        status: 'generated',
-        model: config.ai.chatModel,
-        error: null,
-        note: transcriptPayload
-          ? 'AI 只基于当前视频元数据和有边界的字幕正文证据片段生成。'
-          : 'AI 只基于有边界的当前视频元数据和简介 payload 生成。',
-      },
-      generatedAt: now,
-    };
-  } catch (error) {
-    return buildLocalCurrentVideoSummary(context, {
-      aiStatus: 'failed',
-      aiModel: config.ai.chatModel,
-      aiError: errorMessage(error),
-      aiNote: 'AI 生成失败，当前显示本地证据结果。',
-      transcriptSegments: options.transcriptSegments,
-      now,
-    });
-  }
-}
-
-function buildSystemPrompt(transcriptPayload: boolean): string {
-  const common = [
-    'You are Bili-Bill current video assistant. Return JSON only.',
-    'Keep the source tier exactly aligned with the payload sourceTier.',
-    'JSON fields: summary string, bullets string[], confidence number from 0 to 1.',
-  ];
-  if (transcriptPayload) {
-    return [
-      ...common,
-      'Summarize only the provided current-video metadata and transcript chunks.',
-      'Do not cite segment IDs or timestamps that are not in the payload.',
-      'Do not claim access to audio, visuals, comments, danmaku, local ledgers, or any unprovided data.',
-    ].join('\n');
-  }
-  return [
-    ...common,
-    'You may summarize only the provided metadata and description payload.',
-    'Do not claim a full video summary, full understanding, transcript coverage, audio analysis, comments, danmaku, or visual analysis.',
-  ].join('\n');
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  return local;
 }

--- a/src/background/storage/config-store.ts
+++ b/src/background/storage/config-store.ts
@@ -9,29 +9,18 @@ const HISTORY_SYNC_LOCK_TIMEOUT_MS = 30 * 60 * 1000;
 export async function loadConfig(): Promise<UserConfig> {
   const result = await chrome.storage.local.get(CONFIG_KEY);
   if (result[CONFIG_KEY]) {
-    return {
-      ...DEFAULT_CONFIG,
-      ...result[CONFIG_KEY],
-      ai: {
-        ...DEFAULT_CONFIG.ai,
-        ...(result[CONFIG_KEY].ai ?? {}),
-      },
-      assistant: {
-        ...DEFAULT_CONFIG.assistant,
-        ...(result[CONFIG_KEY].assistant ?? {}),
-      },
-      dynamicBill: {
-        ...DEFAULT_CONFIG.dynamicBill,
-        ...(result[CONFIG_KEY].dynamicBill ?? {}),
-      },
-    };
+    const normalized = normalizeUserConfig(result[CONFIG_KEY]);
+    if (shouldPersistNormalizedConfig(result[CONFIG_KEY], normalized)) {
+      await chrome.storage.local.set({ [CONFIG_KEY]: normalized });
+    }
+    return normalized;
   }
   return DEFAULT_CONFIG;
 }
 
 export async function saveConfig(config: Partial<UserConfig>): Promise<void> {
   const current = await loadConfig();
-  const updated = {
+  const updated = normalizeUserConfig({
     ...current,
     ...config,
     ai: {
@@ -46,8 +35,64 @@ export async function saveConfig(config: Partial<UserConfig>): Promise<void> {
       ...current.dynamicBill,
       ...(config.dynamicBill ?? {}),
     },
-  };
+  });
   await chrome.storage.local.set({ [CONFIG_KEY]: updated });
+}
+
+export function normalizeUserConfig(value: unknown): UserConfig {
+  const raw = isRecord(value) ? value : {};
+  return {
+    dailyWatchGoal: finiteNumber(raw.dailyWatchGoal, DEFAULT_CONFIG.dailyWatchGoal),
+    weeklyWatchGoal: finiteNumber(raw.weeklyWatchGoal, DEFAULT_CONFIG.weeklyWatchGoal),
+    overDependencyThreshold: finiteNumber(raw.overDependencyThreshold, DEFAULT_CONFIG.overDependencyThreshold),
+    syncIntervalMinutes: finiteNumber(raw.syncIntervalMinutes, DEFAULT_CONFIG.syncIntervalMinutes),
+    retentionDays: finiteNumber(raw.retentionDays, DEFAULT_CONFIG.retentionDays),
+    showSidebar: typeof raw.showSidebar === 'boolean' ? raw.showSidebar : DEFAULT_CONFIG.showSidebar,
+    theme: raw.theme === 'light' || raw.theme === 'dark' ? raw.theme : DEFAULT_CONFIG.theme,
+    ai: normalizeAiConfig(raw.ai),
+    assistant: normalizeAssistantConfig(raw.assistant),
+    dynamicBill: normalizeDynamicBillConfig(raw.dynamicBill),
+  };
+}
+
+function normalizeAiConfig(value: unknown): UserConfig['ai'] {
+  const raw = isRecord(value) ? value : {};
+  return {
+    baseURL: stringValue(raw.baseURL, DEFAULT_CONFIG.ai.baseURL),
+    apiKey: stringValue(raw.apiKey, DEFAULT_CONFIG.ai.apiKey),
+    chatModel: stringValue(raw.chatModel, DEFAULT_CONFIG.ai.chatModel),
+  };
+}
+
+function normalizeAssistantConfig(value: unknown): UserConfig['assistant'] {
+  const raw = isRecord(value) ? value : {};
+  return {
+    currentVideoAiAssistantEnabled: raw.currentVideoAiAssistantEnabled === true,
+    smartFavoritesQaAiEnabled: raw.smartFavoritesQaAiEnabled === true,
+  };
+}
+
+function normalizeDynamicBillConfig(value: unknown): UserConfig['dynamicBill'] {
+  const raw = isRecord(value) ? value : {};
+  return {
+    aiExplanationsEnabled: raw.aiExplanationsEnabled === true,
+  };
+}
+
+function shouldPersistNormalizedConfig(original: unknown, normalized: UserConfig): boolean {
+  return JSON.stringify(original) !== JSON.stringify(normalized);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stringValue(value: unknown, fallback: string): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function finiteNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
 }
 
 export async function getLastSyncTime(): Promise<number> {

--- a/src/background/storage/local-data-category-registry.ts
+++ b/src/background/storage/local-data-category-registry.ts
@@ -1,11 +1,11 @@
 import type { Table } from 'dexie';
 import type {
-  LocalDataCategoryId,
+  LocalDataCategoryClearResult,
   LocalDataCategoryReadback,
   LocalDataCategoryRegistration,
   LocalDataCategoryUsage,
+  LocalDataClearedCounts,
 } from '../../shared/local-data-category-contract.ts';
-import type { LocalDataOperationResult } from '../../shared/types/local-data-privacy.ts';
 import { db } from './db.ts';
 
 type AnyTable = Table<any, any, any>;
@@ -30,45 +30,106 @@ const LOCAL_SETTING_STORAGE_KEYS = [
   'floatingPopupWindowId',
 ];
 
+export type LocalDataCategoryTableName =
+  | 'watchHistory'
+  | 'playerEvents'
+  | 'dailyAggregates'
+  | 'favoriteFolders'
+  | 'favoriteItems'
+  | 'smartFavoriteIndex'
+  | 'currentVideoTranscriptSources'
+  | 'currentVideoTranscriptSegments'
+  | 'followedCreators'
+  | 'followedVideoUpdates'
+  | 'dynamicBillItems'
+  | 'dynamicBillExplanations'
+  | 'dynamicBillFeedback';
+
+export interface LocalDataCategoryTable {
+  count: () => Promise<number>;
+  toArray: () => Promise<unknown[]>;
+  clear: () => Promise<void>;
+}
+
+export interface LocalDataCategoryStorage {
+  get: (keys: string[]) => Promise<Record<string, unknown>>;
+  remove: (keys: string[]) => Promise<void>;
+}
+
+export interface LocalDataCategoryRegistryDependencies {
+  tables: Record<LocalDataCategoryTableName, LocalDataCategoryTable>;
+  storage: LocalDataCategoryStorage;
+  transaction: (
+    tables: LocalDataCategoryTable[],
+    operation: () => Promise<void>,
+  ) => Promise<void>;
+}
+
 interface CategoryTableGroup {
-  tables: AnyTable[];
+  tables: LocalDataCategoryTable[];
   storageKeys?: string[];
 }
 
-interface CategoryCounts {
-  cleared: LocalDataOperationResult['cleared'];
+export function getRegisteredLocalDataCategories(): LocalDataCategoryRegistration[] {
+  return createRegisteredLocalDataCategories({
+    tables: {
+      watchHistory: db.watchHistory,
+      playerEvents: db.playerEvents,
+      dailyAggregates: db.dailyAggregates,
+      favoriteFolders: db.favoriteFolders,
+      favoriteItems: db.favoriteItems,
+      smartFavoriteIndex: db.smartFavoriteIndex,
+      currentVideoTranscriptSources: db.currentVideoTranscriptSources,
+      currentVideoTranscriptSegments: db.currentVideoTranscriptSegments,
+      followedCreators: db.followedCreators,
+      followedVideoUpdates: db.followedVideoUpdates,
+      dynamicBillItems: db.dynamicBillItems,
+      dynamicBillExplanations: db.dynamicBillExplanations,
+      dynamicBillFeedback: db.dynamicBillFeedback,
+    },
+    storage: {
+      get: keys => chrome.storage.local.get(keys),
+      remove: keys => chrome.storage.local.remove(keys),
+    },
+    transaction: async (tables, operation) => {
+      await db.transaction('rw', tables as unknown as AnyTable[], operation);
+    },
+  });
 }
 
-export function getRegisteredLocalDataCategories(): LocalDataCategoryRegistration[] {
+export function createRegisteredLocalDataCategories(
+  dependencies: LocalDataCategoryRegistryDependencies,
+): LocalDataCategoryRegistration[] {
+  const tables = dependencies.tables;
   return [
-    tableCategory('history', '观看历史', {
-      tables: [db.watchHistory, db.playerEvents, db.dailyAggregates],
+    tableCategory(dependencies, 'history', '观看历史', {
+      tables: [tables.watchHistory, tables.playerEvents, tables.dailyAggregates],
       storageKeys: HISTORY_STORAGE_KEYS,
     }, counts => ({
       historyRecords: counts[0] ?? 0,
       playerEvents: counts[1] ?? 0,
       dailyAggregates: counts[2] ?? 0,
     })),
-    tableCategory('favorites', '收藏与智能索引', {
-      tables: [db.favoriteFolders, db.favoriteItems, db.smartFavoriteIndex],
+    tableCategory(dependencies, 'favorites', '收藏与智能索引', {
+      tables: [tables.favoriteFolders, tables.favoriteItems, tables.smartFavoriteIndex],
     }, counts => ({
       favoriteFolders: counts[0] ?? 0,
       favoriteItems: counts[1] ?? 0,
       smartFavoriteIndexes: counts[2] ?? 0,
     })),
-    tableCategory('currentVideoSubtitles', '当前视频字幕缓存', {
-      tables: [db.currentVideoTranscriptSources, db.currentVideoTranscriptSegments],
+    tableCategory(dependencies, 'currentVideoSubtitles', '当前视频字幕缓存', {
+      tables: [tables.currentVideoTranscriptSources, tables.currentVideoTranscriptSegments],
     }, counts => ({
       currentVideoSubtitleSources: counts[0] ?? 0,
       currentVideoSubtitleSegments: counts[1] ?? 0,
     })),
-    tableCategory('dynamicBill', '动态账单', {
+    tableCategory(dependencies, 'dynamicBill', '动态账单', {
       tables: [
-        db.followedCreators,
-        db.followedVideoUpdates,
-        db.dynamicBillItems,
-        db.dynamicBillExplanations,
-        db.dynamicBillFeedback,
+        tables.followedCreators,
+        tables.followedVideoUpdates,
+        tables.dynamicBillItems,
+        tables.dynamicBillExplanations,
+        tables.dynamicBillFeedback,
       ],
       storageKeys: DYNAMIC_BILL_STORAGE_KEYS,
     }, counts => ({
@@ -78,102 +139,54 @@ export function getRegisteredLocalDataCategories(): LocalDataCategoryRegistratio
       dynamicBillExplanations: counts[3] ?? 0,
       dynamicBillFeedback: counts[4] ?? 0,
     })),
-    storageCategory('localSettings', '本地 AI 设置', LOCAL_SETTING_STORAGE_KEYS),
+    storageCategory(dependencies, 'localSettings', '本地 AI 设置', LOCAL_SETTING_STORAGE_KEYS),
   ];
 }
 
-export async function clearRegisteredLocalDataCategories(): Promise<{
-  cleared: LocalDataOperationResult['cleared'];
-  categories: NonNullable<LocalDataOperationResult['categories']>;
-}> {
-  const cleared: LocalDataOperationResult['cleared'] = {};
-  const categories: NonNullable<LocalDataOperationResult['categories']> = [];
-
-  for (const category of getRegisteredLocalDataCategories().filter(item => item.includeInClearAll)) {
-    const before = await category.collectUsage();
-    const result = await category.clear() as CategoryCounts;
-    Object.assign(cleared, result.cleared);
-    const after = await category.readAfterClear();
-    categories.push({
-      id: category.id,
-      label: category.label,
-      before,
-      after,
-    });
-  }
-
-  return { cleared, categories };
-}
-
-export async function clearRegisteredLocalDataCategory(
-  id: LocalDataCategoryId,
-): Promise<{
-  cleared: LocalDataOperationResult['cleared'];
-  category: NonNullable<LocalDataOperationResult['categories']>[number];
-}> {
-  const category = getRegisteredLocalDataCategories().find(item => item.id === id);
-  if (!category) throw new Error('LOCAL_DATA_CATEGORY_NOT_REGISTERED');
-  const before = await category.collectUsage();
-  const result = await category.clear() as CategoryCounts;
-  const after = await category.readAfterClear();
-  return {
-    cleared: result.cleared,
-    category: {
-      id: category.id,
-      label: category.label,
-      before,
-      after,
-    },
-  };
-}
-
 function tableCategory(
+  dependencies: LocalDataCategoryRegistryDependencies,
   id: LocalDataCategoryRegistration['id'],
   label: string,
   group: CategoryTableGroup,
-  toClearedCounts: (counts: number[]) => LocalDataOperationResult['cleared'],
+  toClearedCounts: (counts: number[]) => LocalDataClearedCounts,
 ): LocalDataCategoryRegistration {
   return {
     id,
     label,
     includeInClearAll: true,
-    collectUsage: () => collectTableUsage(group),
+    collectUsage: () => collectTableUsage(dependencies.storage, group),
     clear: async () => {
       const counts = await countTables(group.tables);
-      await db.transaction('rw', group.tables, async () => {
+      await dependencies.transaction(group.tables, async () => {
         for (const table of group.tables) {
           await table.clear();
         }
       });
-      await removeStorageKeys(group.storageKeys);
-      return { cleared: toClearedCounts(counts) } satisfies CategoryCounts;
+      await removeStorageKeys(dependencies.storage, group.storageKeys);
+      return { cleared: toClearedCounts(counts) };
     },
-    readAfterClear: () => readbackTableUsage(group),
+    readAfterClear: () => readbackTableUsage(dependencies.storage, group),
   };
 }
 
 function storageCategory(
+  dependencies: LocalDataCategoryRegistryDependencies,
   id: LocalDataCategoryRegistration['id'],
   label: string,
   storageKeys: string[],
 ): LocalDataCategoryRegistration {
+  const collectUsage = () => collectStorageUsage(dependencies.storage, storageKeys);
   return {
     id,
     label,
     includeInClearAll: true,
-    collectUsage: async () => {
-      const stored = await chrome.storage.local.get(storageKeys);
-      return {
-        count: Object.values(stored).filter(value => value !== undefined).length,
-        usageBytes: serializedSize(stored),
-      };
-    },
-    clear: async () => {
-      await removeStorageKeys(storageKeys);
-      return { cleared: { localSettings: true } } satisfies CategoryCounts;
+    collectUsage,
+    clear: async (): Promise<LocalDataCategoryClearResult> => {
+      await removeStorageKeys(dependencies.storage, storageKeys);
+      return { cleared: { localSettings: true } };
     },
     readAfterClear: async () => {
-      const usage = await storageCategory(id, label, storageKeys).collectUsage();
+      const usage = await collectUsage();
       return {
         ...usage,
         empty: usage.count === 0,
@@ -182,40 +195,63 @@ function storageCategory(
   };
 }
 
-async function collectTableUsage(group: CategoryTableGroup): Promise<LocalDataCategoryUsage> {
+async function collectTableUsage(
+  storage: LocalDataCategoryStorage,
+  group: CategoryTableGroup,
+): Promise<LocalDataCategoryUsage> {
   const [counts, bytes] = await Promise.all([
     countTables(group.tables),
     estimateTablesUsageBytes(group.tables),
   ]);
-  const storageBytes = group.storageKeys
-    ? serializedSize(await chrome.storage.local.get(group.storageKeys))
-    : 0;
+  const storageUsage = group.storageKeys
+    ? await collectStorageUsage(storage, group.storageKeys)
+    : { count: 0, usageBytes: 0 };
   return {
     count: counts.reduce((sum, count) => sum + count, 0),
-    usageBytes: bytes + storageBytes,
+    usageBytes: bytes + storageUsage.usageBytes,
   };
 }
 
-async function readbackTableUsage(group: CategoryTableGroup): Promise<LocalDataCategoryReadback> {
-  const usage = await collectTableUsage(group);
+async function collectStorageUsage(
+  storage: LocalDataCategoryStorage,
+  storageKeys: string[],
+): Promise<LocalDataCategoryUsage> {
+  const stored = await storage.get(storageKeys);
+  const present = Object.fromEntries(
+    Object.entries(stored).filter(([, value]) => value !== undefined),
+  );
+  return {
+    count: Object.keys(present).length,
+    usageBytes: Object.keys(present).length > 0 ? serializedSize(present) : 0,
+  };
+}
+
+async function readbackTableUsage(
+  storage: LocalDataCategoryStorage,
+  group: CategoryTableGroup,
+): Promise<LocalDataCategoryReadback> {
+  const usage = await collectTableUsage(storage, group);
   return {
     ...usage,
     empty: usage.count === 0,
   };
 }
 
-async function countTables(tables: AnyTable[]): Promise<number[]> {
+async function countTables(tables: LocalDataCategoryTable[]): Promise<number[]> {
   return await Promise.all(tables.map(table => table.count()));
 }
 
-async function estimateTablesUsageBytes(tables: AnyTable[]): Promise<number> {
+async function estimateTablesUsageBytes(tables: LocalDataCategoryTable[]): Promise<number> {
   const rows = await Promise.all(tables.map(table => table.toArray()));
-  return serializedSize(rows);
+  return rows.some(tableRows => tableRows.length > 0) ? serializedSize(rows) : 0;
 }
 
-async function removeStorageKeys(keys: string[] | undefined): Promise<void> {
+async function removeStorageKeys(
+  storage: LocalDataCategoryStorage,
+  keys: string[] | undefined,
+): Promise<void> {
   if (!keys?.length) return;
-  await chrome.storage.local.remove(keys);
+  await storage.remove(keys);
 }
 
 function serializedSize(value: unknown): number {

--- a/src/background/storage/local-data-category-registry.ts
+++ b/src/background/storage/local-data-category-registry.ts
@@ -1,0 +1,227 @@
+import type { Table } from 'dexie';
+import type {
+  LocalDataCategoryId,
+  LocalDataCategoryReadback,
+  LocalDataCategoryRegistration,
+  LocalDataCategoryUsage,
+} from '../../shared/local-data-category-contract.ts';
+import type { LocalDataOperationResult } from '../../shared/types/local-data-privacy.ts';
+import { db } from './db.ts';
+
+type AnyTable = Table<any, any, any>;
+
+const HISTORY_STORAGE_KEYS = [
+  'lastSyncTime',
+  'historySyncing',
+  'historySyncStartedAt',
+  'historySyncProgress',
+  'historySyncCancelRequested',
+  'backfillComplete',
+  'deviceTypeMigrationComplete',
+];
+
+const DYNAMIC_BILL_STORAGE_KEYS = [
+  'dynamicBillSyncState',
+  'dynamicBillFilterPreference',
+];
+
+const LOCAL_SETTING_STORAGE_KEYS = [
+  'userConfig',
+  'floatingPopupWindowId',
+];
+
+interface CategoryTableGroup {
+  tables: AnyTable[];
+  storageKeys?: string[];
+}
+
+interface CategoryCounts {
+  cleared: LocalDataOperationResult['cleared'];
+}
+
+export function getRegisteredLocalDataCategories(): LocalDataCategoryRegistration[] {
+  return [
+    tableCategory('history', '观看历史', {
+      tables: [db.watchHistory, db.playerEvents, db.dailyAggregates],
+      storageKeys: HISTORY_STORAGE_KEYS,
+    }, counts => ({
+      historyRecords: counts[0] ?? 0,
+      playerEvents: counts[1] ?? 0,
+      dailyAggregates: counts[2] ?? 0,
+    })),
+    tableCategory('favorites', '收藏与智能索引', {
+      tables: [db.favoriteFolders, db.favoriteItems, db.smartFavoriteIndex],
+    }, counts => ({
+      favoriteFolders: counts[0] ?? 0,
+      favoriteItems: counts[1] ?? 0,
+      smartFavoriteIndexes: counts[2] ?? 0,
+    })),
+    tableCategory('currentVideoSubtitles', '当前视频字幕缓存', {
+      tables: [db.currentVideoTranscriptSources, db.currentVideoTranscriptSegments],
+    }, counts => ({
+      currentVideoSubtitleSources: counts[0] ?? 0,
+      currentVideoSubtitleSegments: counts[1] ?? 0,
+    })),
+    tableCategory('dynamicBill', '动态账单', {
+      tables: [
+        db.followedCreators,
+        db.followedVideoUpdates,
+        db.dynamicBillItems,
+        db.dynamicBillExplanations,
+        db.dynamicBillFeedback,
+      ],
+      storageKeys: DYNAMIC_BILL_STORAGE_KEYS,
+    }, counts => ({
+      followedCreators: counts[0] ?? 0,
+      followedVideoUpdates: counts[1] ?? 0,
+      dynamicBillItems: counts[2] ?? 0,
+      dynamicBillExplanations: counts[3] ?? 0,
+      dynamicBillFeedback: counts[4] ?? 0,
+    })),
+    storageCategory('localSettings', '本地 AI 设置', LOCAL_SETTING_STORAGE_KEYS),
+  ];
+}
+
+export async function clearRegisteredLocalDataCategories(): Promise<{
+  cleared: LocalDataOperationResult['cleared'];
+  categories: NonNullable<LocalDataOperationResult['categories']>;
+}> {
+  const cleared: LocalDataOperationResult['cleared'] = {};
+  const categories: NonNullable<LocalDataOperationResult['categories']> = [];
+
+  for (const category of getRegisteredLocalDataCategories().filter(item => item.includeInClearAll)) {
+    const before = await category.collectUsage();
+    const result = await category.clear() as CategoryCounts;
+    Object.assign(cleared, result.cleared);
+    const after = await category.readAfterClear();
+    categories.push({
+      id: category.id,
+      label: category.label,
+      before,
+      after,
+    });
+  }
+
+  return { cleared, categories };
+}
+
+export async function clearRegisteredLocalDataCategory(
+  id: LocalDataCategoryId,
+): Promise<{
+  cleared: LocalDataOperationResult['cleared'];
+  category: NonNullable<LocalDataOperationResult['categories']>[number];
+}> {
+  const category = getRegisteredLocalDataCategories().find(item => item.id === id);
+  if (!category) throw new Error('LOCAL_DATA_CATEGORY_NOT_REGISTERED');
+  const before = await category.collectUsage();
+  const result = await category.clear() as CategoryCounts;
+  const after = await category.readAfterClear();
+  return {
+    cleared: result.cleared,
+    category: {
+      id: category.id,
+      label: category.label,
+      before,
+      after,
+    },
+  };
+}
+
+function tableCategory(
+  id: LocalDataCategoryRegistration['id'],
+  label: string,
+  group: CategoryTableGroup,
+  toClearedCounts: (counts: number[]) => LocalDataOperationResult['cleared'],
+): LocalDataCategoryRegistration {
+  return {
+    id,
+    label,
+    includeInClearAll: true,
+    collectUsage: () => collectTableUsage(group),
+    clear: async () => {
+      const counts = await countTables(group.tables);
+      await db.transaction('rw', group.tables, async () => {
+        for (const table of group.tables) {
+          await table.clear();
+        }
+      });
+      await removeStorageKeys(group.storageKeys);
+      return { cleared: toClearedCounts(counts) } satisfies CategoryCounts;
+    },
+    readAfterClear: () => readbackTableUsage(group),
+  };
+}
+
+function storageCategory(
+  id: LocalDataCategoryRegistration['id'],
+  label: string,
+  storageKeys: string[],
+): LocalDataCategoryRegistration {
+  return {
+    id,
+    label,
+    includeInClearAll: true,
+    collectUsage: async () => {
+      const stored = await chrome.storage.local.get(storageKeys);
+      return {
+        count: Object.values(stored).filter(value => value !== undefined).length,
+        usageBytes: serializedSize(stored),
+      };
+    },
+    clear: async () => {
+      await removeStorageKeys(storageKeys);
+      return { cleared: { localSettings: true } } satisfies CategoryCounts;
+    },
+    readAfterClear: async () => {
+      const usage = await storageCategory(id, label, storageKeys).collectUsage();
+      return {
+        ...usage,
+        empty: usage.count === 0,
+      };
+    },
+  };
+}
+
+async function collectTableUsage(group: CategoryTableGroup): Promise<LocalDataCategoryUsage> {
+  const [counts, bytes] = await Promise.all([
+    countTables(group.tables),
+    estimateTablesUsageBytes(group.tables),
+  ]);
+  const storageBytes = group.storageKeys
+    ? serializedSize(await chrome.storage.local.get(group.storageKeys))
+    : 0;
+  return {
+    count: counts.reduce((sum, count) => sum + count, 0),
+    usageBytes: bytes + storageBytes,
+  };
+}
+
+async function readbackTableUsage(group: CategoryTableGroup): Promise<LocalDataCategoryReadback> {
+  const usage = await collectTableUsage(group);
+  return {
+    ...usage,
+    empty: usage.count === 0,
+  };
+}
+
+async function countTables(tables: AnyTable[]): Promise<number[]> {
+  return await Promise.all(tables.map(table => table.count()));
+}
+
+async function estimateTablesUsageBytes(tables: AnyTable[]): Promise<number> {
+  const rows = await Promise.all(tables.map(table => table.toArray()));
+  return serializedSize(rows);
+}
+
+async function removeStorageKeys(keys: string[] | undefined): Promise<void> {
+  if (!keys?.length) return;
+  await chrome.storage.local.remove(keys);
+}
+
+function serializedSize(value: unknown): number {
+  const text = JSON.stringify(value ?? null);
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(text).byteLength;
+  }
+  return text.length;
+}

--- a/src/background/storage/local-data-privacy-repo.ts
+++ b/src/background/storage/local-data-privacy-repo.ts
@@ -10,10 +10,6 @@ import {
   getHistorySyncing,
   getLastSyncTime,
 } from './config-store.ts';
-import {
-  clearRegisteredLocalDataCategories,
-  clearRegisteredLocalDataCategory,
-} from './local-data-category-registry.ts';
 
 export async function getLocalDataPrivacySummary(): Promise<LocalDataPrivacySummary> {
   const [
@@ -38,12 +34,28 @@ export async function getLocalDataPrivacySummary(): Promise<LocalDataPrivacySumm
 }
 
 export async function clearCurrentVideoSubtitleCache(): Promise<LocalDataOperationResult> {
-  const result = await clearRegisteredLocalDataCategory('currentVideoSubtitles');
+  const [sourceCount, segmentCount] = await Promise.all([
+    db.currentVideoTranscriptSources.count(),
+    db.currentVideoTranscriptSegments.count(),
+  ]);
+
+  await db.transaction(
+    'rw',
+    db.currentVideoTranscriptSources,
+    db.currentVideoTranscriptSegments,
+    async () => {
+      await db.currentVideoTranscriptSources.clear();
+      await db.currentVideoTranscriptSegments.clear();
+    },
+  );
+
   return {
     operation: 'clear_current_video_subtitle_cache',
     completedAt: Date.now(),
-    cleared: result.cleared,
-    categories: [result.category],
+    cleared: {
+      currentVideoSubtitleSources: sourceCount,
+      currentVideoSubtitleSegments: segmentCount,
+    },
   };
 }
 
@@ -55,16 +67,21 @@ export async function clearAllLocalData(confirmation: unknown): Promise<LocalDat
     throw new Error('HISTORY_SYNC_IN_PROGRESS');
   }
 
-  const result = await clearRegisteredLocalDataCategories();
+  const counts = await collectClearCounts();
+  await db.transaction('rw', db.tables, async () => {
+    for (const table of db.tables) {
+      await table.clear();
+    }
+  });
+  await chrome.storage.local.clear();
 
   return {
     operation: 'clear_all_local_data',
     completedAt: Date.now(),
     cleared: {
-      ...result.cleared,
+      ...counts,
       localSettings: true,
     },
-    categories: result.categories,
   };
 }
 
@@ -172,6 +189,54 @@ async function summarizeDynamicBill(): Promise<LocalDataPrivacySummary['dynamicB
     lastGeneratedAt: normalizeNullableTimestamp(lastGeneratedAt),
     lastSyncedAt: normalizeNullableTimestamp(syncState.lastSuccessAt),
     syncStatus: syncState.status,
+  };
+}
+
+async function collectClearCounts(): Promise<Required<Omit<LocalDataOperationResult['cleared'], 'localSettings'>>> {
+  const [
+    historyRecords,
+    playerEvents,
+    dailyAggregates,
+    favoriteFolders,
+    favoriteItems,
+    smartFavoriteIndexes,
+    followedCreators,
+    followedVideoUpdates,
+    dynamicBillItems,
+    dynamicBillExplanations,
+    dynamicBillFeedback,
+    currentVideoSubtitleSources,
+    currentVideoSubtitleSegments,
+  ] = await Promise.all([
+    db.watchHistory.count(),
+    db.playerEvents.count(),
+    db.dailyAggregates.count(),
+    db.favoriteFolders.count(),
+    db.favoriteItems.count(),
+    db.smartFavoriteIndex.count(),
+    db.followedCreators.count(),
+    db.followedVideoUpdates.count(),
+    db.dynamicBillItems.count(),
+    db.dynamicBillExplanations.count(),
+    db.dynamicBillFeedback.count(),
+    db.currentVideoTranscriptSources.count(),
+    db.currentVideoTranscriptSegments.count(),
+  ]);
+
+  return {
+    historyRecords,
+    playerEvents,
+    dailyAggregates,
+    favoriteFolders,
+    favoriteItems,
+    smartFavoriteIndexes,
+    followedCreators,
+    followedVideoUpdates,
+    dynamicBillItems,
+    dynamicBillExplanations,
+    dynamicBillFeedback,
+    currentVideoSubtitleSources,
+    currentVideoSubtitleSegments,
   };
 }
 

--- a/src/background/storage/local-data-privacy-repo.ts
+++ b/src/background/storage/local-data-privacy-repo.ts
@@ -10,6 +10,10 @@ import {
   getHistorySyncing,
   getLastSyncTime,
 } from './config-store.ts';
+import {
+  clearRegisteredLocalDataCategories,
+  clearRegisteredLocalDataCategory,
+} from './local-data-category-registry.ts';
 
 export async function getLocalDataPrivacySummary(): Promise<LocalDataPrivacySummary> {
   const [
@@ -34,28 +38,12 @@ export async function getLocalDataPrivacySummary(): Promise<LocalDataPrivacySumm
 }
 
 export async function clearCurrentVideoSubtitleCache(): Promise<LocalDataOperationResult> {
-  const [sourceCount, segmentCount] = await Promise.all([
-    db.currentVideoTranscriptSources.count(),
-    db.currentVideoTranscriptSegments.count(),
-  ]);
-
-  await db.transaction(
-    'rw',
-    db.currentVideoTranscriptSources,
-    db.currentVideoTranscriptSegments,
-    async () => {
-      await db.currentVideoTranscriptSources.clear();
-      await db.currentVideoTranscriptSegments.clear();
-    },
-  );
-
+  const result = await clearRegisteredLocalDataCategory('currentVideoSubtitles');
   return {
     operation: 'clear_current_video_subtitle_cache',
     completedAt: Date.now(),
-    cleared: {
-      currentVideoSubtitleSources: sourceCount,
-      currentVideoSubtitleSegments: segmentCount,
-    },
+    cleared: result.cleared,
+    categories: [result.category],
   };
 }
 
@@ -67,21 +55,16 @@ export async function clearAllLocalData(confirmation: unknown): Promise<LocalDat
     throw new Error('HISTORY_SYNC_IN_PROGRESS');
   }
 
-  const counts = await collectClearCounts();
-  await db.transaction('rw', db.tables, async () => {
-    for (const table of db.tables) {
-      await table.clear();
-    }
-  });
-  await chrome.storage.local.clear();
+  const result = await clearRegisteredLocalDataCategories();
 
   return {
     operation: 'clear_all_local_data',
     completedAt: Date.now(),
     cleared: {
-      ...counts,
+      ...result.cleared,
       localSettings: true,
     },
+    categories: result.categories,
   };
 }
 
@@ -189,54 +172,6 @@ async function summarizeDynamicBill(): Promise<LocalDataPrivacySummary['dynamicB
     lastGeneratedAt: normalizeNullableTimestamp(lastGeneratedAt),
     lastSyncedAt: normalizeNullableTimestamp(syncState.lastSuccessAt),
     syncStatus: syncState.status,
-  };
-}
-
-async function collectClearCounts(): Promise<Required<Omit<LocalDataOperationResult['cleared'], 'localSettings'>>> {
-  const [
-    historyRecords,
-    playerEvents,
-    dailyAggregates,
-    favoriteFolders,
-    favoriteItems,
-    smartFavoriteIndexes,
-    followedCreators,
-    followedVideoUpdates,
-    dynamicBillItems,
-    dynamicBillExplanations,
-    dynamicBillFeedback,
-    currentVideoSubtitleSources,
-    currentVideoSubtitleSegments,
-  ] = await Promise.all([
-    db.watchHistory.count(),
-    db.playerEvents.count(),
-    db.dailyAggregates.count(),
-    db.favoriteFolders.count(),
-    db.favoriteItems.count(),
-    db.smartFavoriteIndex.count(),
-    db.followedCreators.count(),
-    db.followedVideoUpdates.count(),
-    db.dynamicBillItems.count(),
-    db.dynamicBillExplanations.count(),
-    db.dynamicBillFeedback.count(),
-    db.currentVideoTranscriptSources.count(),
-    db.currentVideoTranscriptSegments.count(),
-  ]);
-
-  return {
-    historyRecords,
-    playerEvents,
-    dailyAggregates,
-    favoriteFolders,
-    favoriteItems,
-    smartFavoriteIndexes,
-    followedCreators,
-    followedVideoUpdates,
-    dynamicBillItems,
-    dynamicBillExplanations,
-    dynamicBillFeedback,
-    currentVideoSubtitleSources,
-    currentVideoSubtitleSegments,
   };
 }
 

--- a/src/shared/current-video-qa.ts
+++ b/src/shared/current-video-qa.ts
@@ -10,10 +10,6 @@ import type {
   CurrentVideoSegmentRetrievalConfidenceLabel,
   CurrentVideoSegmentRetrievalResult,
 } from './types/current-video-segment-retrieval.ts';
-import {
-  assertAssistantPayloadAudit,
-  currentVideoQaPayloadContract,
-} from './assistant-payload-audit.ts';
 
 const DEFAULT_QA_CANDIDATE_LIMIT = 5;
 const PAYLOAD_QUESTION_LIMIT = 180;
@@ -185,95 +181,15 @@ export async function answerCurrentVideoQuestion(
     });
   }
 
-  if (!options.config.assistant.currentVideoAiAssistantEnabled) {
-    return withQa(local, {
-      ...localQa,
-      aiState: aiState({
-        status: 'disabled',
-        model,
-        note: '当前视频 AI 助手未在设置中开启，因此显示本地证据回答。',
-        now,
-      }),
-    });
-  }
-
-  if (!options.config.ai.apiKey.trim()) {
-    return withQa(local, {
-      ...localQa,
-      aiState: aiState({
-        status: 'not_configured',
-        model,
-        note: '当前视频 AI 助手已开启但尚未配置 API Key，因此显示本地证据回答。',
-        now,
-      }),
-    });
-  }
-
-  try {
-    const built = buildCurrentVideoQaAiPayload(context, local, {
-      candidateLimit: options.candidateLimit,
-    });
-    (options.auditPayload ?? defaultAuditPayload)(built.payload);
-    const ai = await options.chat(options.config.ai, buildCurrentVideoQaAiMessages(built.payload));
-    const guarded = guardCurrentVideoQaAiOutput(ai, built.payload);
-    if (!guarded.ok) {
-      const status = guarded.reason === 'AI_LOW_CONFIDENCE' ? 'low_confidence' : 'rejected';
-      return withQa(local, {
-        ...localQa,
-        aiState: aiState({
-          status,
-          model,
-          note: status === 'low_confidence'
-            ? 'AI 回答置信度较低，因此显示本地证据回答。'
-            : 'AI 回答没有通过引用边界检查，因此显示本地证据回答。',
-          error: guarded.error,
-          now,
-          payloadCandidateCount: built.payload.candidates.length,
-        }),
-      });
-    }
-
-    const localIdByPayloadId = new Map(built.refs.map(ref => [ref.payloadCandidateId, ref.localCandidateId]));
-    const citedLocalIds = guarded.citedPayloadCandidateIds
-      .map(id => localIdByPayloadId.get(id) ?? null)
-      .filter((id): id is string => Boolean(id));
-    const citedByLocalId = new Map(localQa.citedSegments.map(segment => [segment.candidateId, segment]));
-    const citedSegments = citedLocalIds
-      .map(id => citedByLocalId.get(id) ?? null)
-      .filter((segment): segment is CurrentVideoQaCitedSegment => Boolean(segment));
-
-    return withQa(local, {
-      ...localQa,
-      status: guarded.status,
-      answer: guarded.answer,
-      confidence: guarded.confidence,
-      confidenceLabel: confidenceLabel(guarded.confidence),
-      citedSegments,
-      aiState: aiState({
-        status: 'generated',
-        model,
-        note: 'AI 只基于本次 top-N 本地引用片段整理回答；时间点和跳转入口仍来自本地候选。',
-        now,
-        payloadCandidateCount: built.payload.candidates.length,
-        citedCandidateIds: citedLocalIds,
-      }),
-      limitations: uniqueText([
-        ...localQa.limitations,
-        'AI 只整理本次提供的当前视频引用片段，不会生成新的时间点、证据或外部来源。',
-      ]),
-    });
-  } catch (error) {
-    return withQa(local, {
-      ...localQa,
-      aiState: aiState({
-        status: 'failed',
-        model,
-        note: 'AI 回答请求失败，因此显示本地证据回答。',
-        error: errorMessage(error),
-        now,
-      }),
-    });
-  }
+  return withQa(local, {
+    ...localQa,
+    aiState: aiState({
+      status: 'disabled',
+      model,
+      note: '当前只显示本地证据回答，本次没有向聊天服务发送视频内容。',
+      now,
+    }),
+  });
 }
 
 export function buildCurrentVideoQaAiPayload(
@@ -667,10 +583,6 @@ function rejected(reason: string, error: string): QaGuardResult {
     reason,
     error,
   };
-}
-
-function defaultAuditPayload(payload: CurrentVideoQaAiPayload): void {
-  assertAssistantPayloadAudit(payload, currentVideoQaPayloadContract);
 }
 
 function isCitableCandidate(candidate: CurrentVideoSegmentRetrievalCandidate): boolean {

--- a/src/shared/current-video-qa.ts
+++ b/src/shared/current-video-qa.ts
@@ -185,13 +185,13 @@ export async function answerCurrentVideoQuestion(
     });
   }
 
-  if (!options.config.assistant.currentVideoQaAiEnabled) {
+  if (!options.config.assistant.currentVideoAiAssistantEnabled) {
     return withQa(local, {
       ...localQa,
       aiState: aiState({
         status: 'disabled',
         model,
-        note: '当前视频问答 AI 未在设置中启用，因此显示本地证据回答。',
+        note: '当前视频 AI 助手未在设置中开启，因此显示本地证据回答。',
         now,
       }),
     });
@@ -203,7 +203,7 @@ export async function answerCurrentVideoQuestion(
       aiState: aiState({
         status: 'not_configured',
         model,
-        note: '当前视频问答 AI 已启用但尚未配置 API Key，因此显示本地证据回答。',
+        note: '当前视频 AI 助手已开启但尚未配置 API Key，因此显示本地证据回答。',
         now,
       }),
     });

--- a/src/shared/current-video-segment-rerank.ts
+++ b/src/shared/current-video-segment-rerank.ts
@@ -6,10 +6,6 @@ import type {
   CurrentVideoSegmentRetrievalCandidate,
   CurrentVideoSegmentRetrievalResult,
 } from './types/current-video-segment-retrieval.ts';
-import {
-  assertAssistantPayloadAudit,
-  currentVideoSegmentRerankPayloadContract,
-} from './assistant-payload-audit.ts';
 
 const DEFAULT_RERANK_CANDIDATE_LIMIT = 5;
 const PAYLOAD_QUERY_LIMIT = 160;
@@ -138,56 +134,12 @@ export async function rerankCurrentVideoSegmentCandidates(
     }));
   }
 
-  if (!options.config.assistant.currentVideoAiAssistantEnabled) {
-    return withAiRerank(local, aiState({
-      status: 'disabled',
-      model,
-      note: '当前视频 AI 助手未在设置中开启，当前显示本地候选顺序。',
-      now,
-    }));
-  }
-
-  if (!options.config.ai.apiKey.trim()) {
-    return withAiRerank(local, aiState({
-      status: 'not_configured',
-      model,
-      note: '当前视频 AI 助手已开启但尚未配置 API Key，当前显示本地候选顺序。',
-      now,
-    }));
-  }
-
-  try {
-    const built = buildCurrentVideoSegmentRerankAiPayload(context, local, {
-      candidateLimit: options.candidateLimit,
-    });
-    (options.auditPayload ?? defaultAuditPayload)(built.payload);
-    const ai = await options.chat(options.config.ai, buildCurrentVideoSegmentRerankAiMessages(built.payload));
-    const guarded = guardCurrentVideoSegmentRerankAiOutput(ai, built.payload);
-    if (!guarded.ok) {
-      const status = guarded.reason === 'AI_LOW_CONFIDENCE' ? 'low_confidence' : 'rejected';
-      const note = status === 'low_confidence'
-        ? 'AI 返回置信度较低，当前显示本地候选顺序。'
-        : 'AI 结果未采用，当前显示本地候选顺序。';
-      return withAiRerank(local, aiState({
-        status,
-        model,
-        note,
-        error: guarded.error,
-        now,
-        payloadCandidateCount: built.payload.candidates.length,
-      }));
-    }
-
-    return applyGuardedRerank(local, built, guarded, model, now);
-  } catch (error) {
-    return withAiRerank(local, aiState({
-      status: 'failed',
-      model,
-      note: 'AI 重排请求失败，当前显示本地候选顺序。',
-      error: errorMessage(error),
-      now,
-    }));
-  }
+  return withAiRerank(local, aiState({
+    status: 'disabled',
+    model,
+    note: '片段排序保持本地处理，本次没有请求 AI，候选顺序不变。',
+    now,
+  }));
 }
 
 export function buildCurrentVideoSegmentRerankAiPayload(
@@ -553,10 +505,6 @@ function rejected(reason: string, error: string): RerankGuardResult {
     reason,
     error,
   };
-}
-
-function defaultAuditPayload(payload: CurrentVideoSegmentRerankAiPayload): void {
-  assertAssistantPayloadAudit(payload, currentVideoSegmentRerankPayloadContract);
 }
 
 function collectStrings(value: unknown): string[] {

--- a/src/shared/current-video-segment-rerank.ts
+++ b/src/shared/current-video-segment-rerank.ts
@@ -138,11 +138,11 @@ export async function rerankCurrentVideoSegmentCandidates(
     }));
   }
 
-  if (!options.config.assistant.currentVideoSegmentRerankAiEnabled) {
+  if (!options.config.assistant.currentVideoAiAssistantEnabled) {
     return withAiRerank(local, aiState({
       status: 'disabled',
       model,
-      note: 'AI 重排未在设置中启用，当前显示本地候选顺序。',
+      note: '当前视频 AI 助手未在设置中开启，当前显示本地候选顺序。',
       now,
     }));
   }
@@ -151,7 +151,7 @@ export async function rerankCurrentVideoSegmentCandidates(
     return withAiRerank(local, aiState({
       status: 'not_configured',
       model,
-      note: 'AI 重排已启用但尚未在设置中配置 API Key，当前显示本地候选顺序。',
+      note: '当前视频 AI 助手已开启但尚未配置 API Key，当前显示本地候选顺序。',
       now,
     }));
   }

--- a/src/shared/local-data-category-contract.ts
+++ b/src/shared/local-data-category-contract.ts
@@ -1,0 +1,39 @@
+export type LocalDataCategoryId =
+  | 'history'
+  | 'favorites'
+  | 'currentVideoSubtitles'
+  | 'dynamicBill'
+  | 'localSettings';
+
+export interface LocalDataCategoryUsage {
+  count: number;
+  usageBytes: number;
+}
+
+export interface LocalDataCategoryReadback {
+  count: number;
+  usageBytes: number;
+  empty: boolean;
+}
+
+export interface LocalDataCategoryRegistration {
+  id: LocalDataCategoryId;
+  label: string;
+  includeInClearAll: boolean;
+  collectUsage: () => Promise<LocalDataCategoryUsage>;
+  clear: () => Promise<unknown>;
+  readAfterClear: () => Promise<LocalDataCategoryReadback>;
+}
+
+export function validateLocalDataCategoryRegistration(
+  registration: LocalDataCategoryRegistration,
+): string[] {
+  const issues: string[] = [];
+  if (!registration.id) issues.push('missing_id');
+  if (!registration.label.trim()) issues.push('missing_label');
+  if (typeof registration.collectUsage !== 'function') issues.push('missing_collect_usage');
+  if (typeof registration.clear !== 'function') issues.push('missing_clear');
+  if (typeof registration.readAfterClear !== 'function') issues.push('missing_readback');
+  if (typeof registration.includeInClearAll !== 'boolean') issues.push('missing_clear_all_hook');
+  return issues;
+}

--- a/src/shared/local-data-category-contract.ts
+++ b/src/shared/local-data-category-contract.ts
@@ -5,14 +5,33 @@ export type LocalDataCategoryId =
   | 'dynamicBill'
   | 'localSettings';
 
+export interface LocalDataClearedCounts {
+  historyRecords?: number;
+  playerEvents?: number;
+  dailyAggregates?: number;
+  favoriteFolders?: number;
+  favoriteItems?: number;
+  smartFavoriteIndexes?: number;
+  followedCreators?: number;
+  followedVideoUpdates?: number;
+  dynamicBillItems?: number;
+  dynamicBillExplanations?: number;
+  dynamicBillFeedback?: number;
+  currentVideoSubtitleSources?: number;
+  currentVideoSubtitleSegments?: number;
+  localSettings?: boolean;
+}
+
 export interface LocalDataCategoryUsage {
   count: number;
   usageBytes: number;
 }
 
-export interface LocalDataCategoryReadback {
-  count: number;
-  usageBytes: number;
+export interface LocalDataCategoryClearResult {
+  cleared: LocalDataClearedCounts;
+}
+
+export interface LocalDataCategoryReadback extends LocalDataCategoryUsage {
   empty: boolean;
 }
 
@@ -21,8 +40,76 @@ export interface LocalDataCategoryRegistration {
   label: string;
   includeInClearAll: boolean;
   collectUsage: () => Promise<LocalDataCategoryUsage>;
-  clear: () => Promise<unknown>;
+  clear: () => Promise<LocalDataCategoryClearResult>;
   readAfterClear: () => Promise<LocalDataCategoryReadback>;
+}
+
+export type LocalDataCategoryFailureStage = 'collect_usage' | 'clear' | 'readback';
+
+export interface LocalDataCategoryLifecycleSuccess {
+  status: 'success';
+  id: LocalDataCategoryId;
+  label: string;
+  before: LocalDataCategoryUsage;
+  clearResult: LocalDataCategoryClearResult;
+  after: LocalDataCategoryReadback;
+}
+
+export interface LocalDataCategoryLifecycleFailure {
+  status: 'failure';
+  id: LocalDataCategoryId;
+  label: string;
+  failedStage: LocalDataCategoryFailureStage;
+  message: string;
+  before: LocalDataCategoryUsage | null;
+  clearResult: LocalDataCategoryClearResult | null;
+  after: null;
+}
+
+export type LocalDataCategoryLifecycleResult =
+  | LocalDataCategoryLifecycleSuccess
+  | LocalDataCategoryLifecycleFailure;
+
+export async function runLocalDataCategoryLifecycle(
+  registration: LocalDataCategoryRegistration,
+): Promise<LocalDataCategoryLifecycleResult> {
+  let before: LocalDataCategoryUsage;
+  try {
+    before = await registration.collectUsage();
+  } catch {
+    return lifecycleFailure(registration, 'collect_usage', null, null);
+  }
+
+  let clearResult: LocalDataCategoryClearResult;
+  try {
+    clearResult = await registration.clear();
+  } catch {
+    return lifecycleFailure(registration, 'clear', before, null);
+  }
+
+  try {
+    const after = await registration.readAfterClear();
+    return {
+      status: 'success',
+      id: registration.id,
+      label: registration.label,
+      before,
+      clearResult,
+      after,
+    };
+  } catch {
+    return lifecycleFailure(registration, 'readback', before, clearResult);
+  }
+}
+
+export async function runLocalDataCategoryLifecycles(
+  registrations: LocalDataCategoryRegistration[],
+): Promise<LocalDataCategoryLifecycleResult[]> {
+  const results: LocalDataCategoryLifecycleResult[] = [];
+  for (const registration of registrations) {
+    results.push(await runLocalDataCategoryLifecycle(registration));
+  }
+  return results;
 }
 
 export function validateLocalDataCategoryRegistration(
@@ -36,4 +123,28 @@ export function validateLocalDataCategoryRegistration(
   if (typeof registration.readAfterClear !== 'function') issues.push('missing_readback');
   if (typeof registration.includeInClearAll !== 'boolean') issues.push('missing_clear_all_hook');
   return issues;
+}
+
+function lifecycleFailure(
+  registration: LocalDataCategoryRegistration,
+  failedStage: LocalDataCategoryFailureStage,
+  before: LocalDataCategoryUsage | null,
+  clearResult: LocalDataCategoryClearResult | null,
+): LocalDataCategoryLifecycleFailure {
+  return {
+    status: 'failure',
+    id: registration.id,
+    label: registration.label,
+    failedStage,
+    message: lifecycleFailureMessage(registration.label, failedStage),
+    before,
+    clearResult,
+    after: null,
+  };
+}
+
+function lifecycleFailureMessage(label: string, stage: LocalDataCategoryFailureStage): string {
+  if (stage === 'collect_usage') return `${label}的数据统计失败，暂时无法开始清理。`;
+  if (stage === 'readback') return `${label}已执行清理，但结果回读失败，请刷新后核对。`;
+  return `${label}清理失败，已完成的其他类别不会受影响。`;
 }

--- a/src/shared/local-data-category-contract.ts
+++ b/src/shared/local-data-category-contract.ts
@@ -46,6 +46,12 @@ export interface LocalDataCategoryRegistration {
 
 export type LocalDataCategoryFailureStage = 'collect_usage' | 'clear' | 'readback';
 
+export type LocalDataCategoryFailureReason =
+  | 'usage_unavailable'
+  | 'clear_failed'
+  | 'readback_unavailable'
+  | 'data_remaining';
+
 export interface LocalDataCategoryLifecycleSuccess {
   status: 'success';
   id: LocalDataCategoryId;
@@ -60,10 +66,11 @@ export interface LocalDataCategoryLifecycleFailure {
   id: LocalDataCategoryId;
   label: string;
   failedStage: LocalDataCategoryFailureStage;
+  failureReason: LocalDataCategoryFailureReason;
   message: string;
   before: LocalDataCategoryUsage | null;
   clearResult: LocalDataCategoryClearResult | null;
-  after: null;
+  after: LocalDataCategoryReadback | null;
 }
 
 export type LocalDataCategoryLifecycleResult =
@@ -77,18 +84,28 @@ export async function runLocalDataCategoryLifecycle(
   try {
     before = await registration.collectUsage();
   } catch {
-    return lifecycleFailure(registration, 'collect_usage', null, null);
+    return lifecycleFailure(registration, 'collect_usage', 'usage_unavailable', null, null, null);
   }
 
   let clearResult: LocalDataCategoryClearResult;
   try {
     clearResult = await registration.clear();
   } catch {
-    return lifecycleFailure(registration, 'clear', before, null);
+    return lifecycleFailure(registration, 'clear', 'clear_failed', before, null, null);
   }
 
   try {
     const after = await registration.readAfterClear();
+    if (!after.empty || after.count !== 0 || after.usageBytes !== 0) {
+      return lifecycleFailure(
+        registration,
+        'readback',
+        'data_remaining',
+        before,
+        clearResult,
+        after,
+      );
+    }
     return {
       status: 'success',
       id: registration.id,
@@ -98,7 +115,14 @@ export async function runLocalDataCategoryLifecycle(
       after,
     };
   } catch {
-    return lifecycleFailure(registration, 'readback', before, clearResult);
+    return lifecycleFailure(
+      registration,
+      'readback',
+      'readback_unavailable',
+      before,
+      clearResult,
+      null,
+    );
   }
 }
 
@@ -128,23 +152,27 @@ export function validateLocalDataCategoryRegistration(
 function lifecycleFailure(
   registration: LocalDataCategoryRegistration,
   failedStage: LocalDataCategoryFailureStage,
+  failureReason: LocalDataCategoryFailureReason,
   before: LocalDataCategoryUsage | null,
   clearResult: LocalDataCategoryClearResult | null,
+  after: LocalDataCategoryReadback | null,
 ): LocalDataCategoryLifecycleFailure {
   return {
     status: 'failure',
     id: registration.id,
     label: registration.label,
     failedStage,
-    message: lifecycleFailureMessage(registration.label, failedStage),
+    failureReason,
+    message: lifecycleFailureMessage(registration.label, failureReason),
     before,
     clearResult,
-    after: null,
+    after,
   };
 }
 
-function lifecycleFailureMessage(label: string, stage: LocalDataCategoryFailureStage): string {
-  if (stage === 'collect_usage') return `${label}的数据统计失败，暂时无法开始清理。`;
-  if (stage === 'readback') return `${label}已执行清理，但结果回读失败，请刷新后核对。`;
+function lifecycleFailureMessage(label: string, reason: LocalDataCategoryFailureReason): string {
+  if (reason === 'usage_unavailable') return `${label}的数据统计失败，暂时无法开始清理。`;
+  if (reason === 'readback_unavailable') return `${label}已执行清理，但结果回读失败，请刷新后核对。`;
+  if (reason === 'data_remaining') return `${label}已执行清理，但回读后仍有本地数据，请重试。`;
   return `${label}清理失败，已完成的其他类别不会受影响。`;
 }

--- a/src/shared/types/config.ts
+++ b/src/shared/types/config.ts
@@ -25,10 +25,8 @@ export interface AiConnectionTestResult {
 }
 
 export interface AssistantConfig {
-  aiSummariesEnabled: boolean;
+  currentVideoAiAssistantEnabled: boolean;
   smartFavoritesQaAiEnabled: boolean;
-  currentVideoSegmentRerankAiEnabled: boolean;
-  currentVideoQaAiEnabled: boolean;
 }
 
 export interface DynamicBillConfig {
@@ -49,10 +47,8 @@ export const DEFAULT_CONFIG: UserConfig = {
     chatModel: 'deepseek-v4-flash',
   },
   assistant: {
-    aiSummariesEnabled: false,
+    currentVideoAiAssistantEnabled: false,
     smartFavoritesQaAiEnabled: false,
-    currentVideoSegmentRerankAiEnabled: false,
-    currentVideoQaAiEnabled: false,
   },
   dynamicBill: {
     aiExplanationsEnabled: false,

--- a/src/shared/types/local-data-privacy.ts
+++ b/src/shared/types/local-data-privacy.ts
@@ -1,5 +1,5 @@
 import type { DynamicSyncStatus } from './dynamic-bill';
-import type { LocalDataCategoryId } from '../local-data-category-contract';
+import type { LocalDataClearedCounts } from '../local-data-category-contract';
 
 export interface LocalDataPrivacySummary {
   checkedAt: number;
@@ -53,37 +53,7 @@ export type LocalDataOperationKind =
 export interface LocalDataOperationResult {
   operation: LocalDataOperationKind;
   completedAt: number;
-  cleared: {
-    historyRecords?: number;
-    playerEvents?: number;
-    dailyAggregates?: number;
-    favoriteFolders?: number;
-    favoriteItems?: number;
-    smartFavoriteIndexes?: number;
-    followedCreators?: number;
-    followedVideoUpdates?: number;
-    dynamicBillItems?: number;
-    dynamicBillExplanations?: number;
-    dynamicBillFeedback?: number;
-    currentVideoSubtitleSources?: number;
-    currentVideoSubtitleSegments?: number;
-    localSettings?: boolean;
-  };
-  categories?: LocalDataCategoryOperationResult[];
-}
-
-export interface LocalDataCategoryOperationResult {
-  id: LocalDataCategoryId;
-  label: string;
-  before: {
-    count: number;
-    usageBytes: number;
-  };
-  after: {
-    count: number;
-    usageBytes: number;
-    empty: boolean;
-  };
+  cleared: LocalDataClearedCounts;
 }
 
 export interface SmartFavoriteIndexRebuildResult {

--- a/src/shared/types/local-data-privacy.ts
+++ b/src/shared/types/local-data-privacy.ts
@@ -1,4 +1,5 @@
 import type { DynamicSyncStatus } from './dynamic-bill';
+import type { LocalDataCategoryId } from '../local-data-category-contract';
 
 export interface LocalDataPrivacySummary {
   checkedAt: number;
@@ -67,6 +68,21 @@ export interface LocalDataOperationResult {
     currentVideoSubtitleSources?: number;
     currentVideoSubtitleSegments?: number;
     localSettings?: boolean;
+  };
+  categories?: LocalDataCategoryOperationResult[];
+}
+
+export interface LocalDataCategoryOperationResult {
+  id: LocalDataCategoryId;
+  label: string;
+  before: {
+    count: number;
+    usageBytes: number;
+  };
+  after: {
+    count: number;
+    usageBytes: number;
+    empty: boolean;
   };
 }
 

--- a/tests/current-video-qa.test.ts
+++ b/tests/current-video-qa.test.ts
@@ -67,115 +67,32 @@ test('does not generate a full answer without subtitle body or local nodes', () 
   assert.ok(result.qa.limitations.some(item => item.includes('不能生成完整视频回答')));
 });
 
-test('generates AI answer only from top-N local cited candidates', async () => {
+test('new current-video authorization does not call the legacy cited-fragment QA chat path', async () => {
   const context = withTranscriptEvidence(videoContext());
   const local = localQaResult(context);
   const localOrder = local.candidates.map(candidate => candidate.id);
+  let chatCalls = 0;
 
   const result = await answerCurrentVideoQuestion(context, local, {
     config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
-    chat: async (_config, messages) => {
-      const payload = JSON.parse(messages[1].content);
-      const rawPayload = JSON.stringify(payload);
-      assert.equal(payload.intent, 'current_video_qa_v1');
-      assert.equal(payload.candidates[0].candidateId, 'candidate-1');
-      assert.doesNotMatch(rawPayload, /sourceHash|segmentId|authorMid|watchHistory|favorites|following|Cookie|Key\.txt/i);
-      assert.equal(rawPayload.includes(local.candidates[0].id), false);
+    chat: async () => {
+      chatCalls += 1;
       return {
-        answer: '有。当前引用片段说明了子代理如何拆分任务并协作。',
+        answer: 'legacy response',
         status: 'answered',
-        confidence: 0.86,
+        confidence: 0.9,
         citedCandidateIds: ['candidate-1'],
       };
     },
     now: 5000,
   });
 
-  assert.equal(result.qa.aiState.status, 'generated');
-  assert.equal(result.qa.status, 'answered');
-  assert.match(result.qa.answer, /^有。/);
-  assert.deepEqual(result.qa.aiState.citedCandidateIds, [localOrder[0]]);
-  assert.equal(result.qa.citedSegments[0].candidateId, localOrder[0]);
+  assert.equal(chatCalls, 0);
+  assert.equal(result.qa.aiState.status, 'disabled');
+  assert.match(result.qa.aiState.note, /没有向聊天服务发送视频内容/);
+  assert.equal(result.qa.answer, local.qa.answer);
+  assert.deepEqual(result.qa.citedSegments, local.qa.citedSegments);
   assert.deepEqual(result.candidates.map(candidate => candidate.id), localOrder);
-  assert.deepEqual(result.candidates[0].jumpPreview, local.candidates[0].jumpPreview);
-});
-
-test('AI disabled, not configured, failed, and low-confidence states keep local evidence answer', async () => {
-  const context = withTranscriptEvidence(videoContext());
-  const local = localQaResult(context);
-  const disabled = await answerCurrentVideoQuestion(context, local, {
-    config: userConfig({ currentVideoAiAssistantEnabled: false, apiKey: 'test-key' }),
-    chat: async () => {
-      throw new Error('should not call chat');
-    },
-    now: 5000,
-  });
-  const notConfigured = await answerCurrentVideoQuestion(context, local, {
-    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: '' }),
-    chat: async () => {
-      throw new Error('should not call chat');
-    },
-    now: 5000,
-  });
-  const failed = await answerCurrentVideoQuestion(context, local, {
-    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
-    chat: async () => {
-      throw new Error('AI_TEST_FAILURE');
-    },
-    now: 5000,
-  });
-  const lowConfidence = await answerCurrentVideoQuestion(context, local, {
-    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
-    chat: async () => ({
-      answer: '有。可能相关。',
-      status: 'answered',
-      confidence: 0.2,
-      citedCandidateIds: ['candidate-1'],
-    }),
-    now: 5000,
-  });
-
-  assert.equal(disabled.qa.aiState.status, 'disabled');
-  assert.equal(notConfigured.qa.aiState.status, 'not_configured');
-  assert.equal(failed.qa.aiState.status, 'failed');
-  assert.match(failed.qa.aiState.error ?? '', /AI_TEST_FAILURE/);
-  assert.equal(lowConfidence.qa.aiState.status, 'low_confidence');
-  for (const result of [disabled, notConfigured, failed, lowConfidence]) {
-    assert.equal(result.qa.answer, local.qa.answer);
-    assert.equal(result.qa.citedSegments.length, local.qa.citedSegments.length);
-  }
-});
-
-test('rejects AI unknown candidate references and invented timestamps', async () => {
-  const context = withTranscriptEvidence(videoContext());
-  const local = localQaResult(context);
-  const unknown = await answerCurrentVideoQuestion(context, local, {
-    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
-    chat: async () => ({
-      answer: '有。当前证据可以回答。',
-      status: 'answered',
-      confidence: 0.9,
-      citedCandidateIds: ['candidate-99'],
-    }),
-    now: 5000,
-  });
-  const inventedTime = await answerCurrentVideoQuestion(context, local, {
-    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
-    chat: async () => ({
-      answer: '有。建议直接看 0:42 的解释。',
-      status: 'answered',
-      confidence: 0.9,
-      citedCandidateIds: ['candidate-1'],
-    }),
-    now: 5000,
-  });
-
-  assert.equal(unknown.qa.aiState.status, 'rejected');
-  assert.match(unknown.qa.aiState.error ?? '', /AI_UNKNOWN_CANDIDATE_ID/);
-  assert.equal(inventedTime.qa.aiState.status, 'rejected');
-  assert.match(inventedTime.qa.aiState.error ?? '', /AI_TIMESTAMP_OUT_OF_SCHEMA/);
-  assert.equal(unknown.qa.answer, local.qa.answer);
-  assert.equal(inventedTime.qa.answer, local.qa.answer);
 });
 
 test('audits current-video QA AI payload allowlist and rejects sensitive fields', () => {

--- a/tests/current-video-qa.test.ts
+++ b/tests/current-video-qa.test.ts
@@ -73,7 +73,7 @@ test('generates AI answer only from top-N local cited candidates', async () => {
   const localOrder = local.candidates.map(candidate => candidate.id);
 
   const result = await answerCurrentVideoQuestion(context, local, {
-    config: userConfig({ currentVideoQaAiEnabled: true, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     chat: async (_config, messages) => {
       const payload = JSON.parse(messages[1].content);
       const rawPayload = JSON.stringify(payload);
@@ -104,28 +104,28 @@ test('AI disabled, not configured, failed, and low-confidence states keep local 
   const context = withTranscriptEvidence(videoContext());
   const local = localQaResult(context);
   const disabled = await answerCurrentVideoQuestion(context, local, {
-    config: userConfig({ currentVideoQaAiEnabled: false, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: false, apiKey: 'test-key' }),
     chat: async () => {
       throw new Error('should not call chat');
     },
     now: 5000,
   });
   const notConfigured = await answerCurrentVideoQuestion(context, local, {
-    config: userConfig({ currentVideoQaAiEnabled: true, apiKey: '' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: '' }),
     chat: async () => {
       throw new Error('should not call chat');
     },
     now: 5000,
   });
   const failed = await answerCurrentVideoQuestion(context, local, {
-    config: userConfig({ currentVideoQaAiEnabled: true, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     chat: async () => {
       throw new Error('AI_TEST_FAILURE');
     },
     now: 5000,
   });
   const lowConfidence = await answerCurrentVideoQuestion(context, local, {
-    config: userConfig({ currentVideoQaAiEnabled: true, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     chat: async () => ({
       answer: '有。可能相关。',
       status: 'answered',
@@ -150,7 +150,7 @@ test('rejects AI unknown candidate references and invented timestamps', async ()
   const context = withTranscriptEvidence(videoContext());
   const local = localQaResult(context);
   const unknown = await answerCurrentVideoQuestion(context, local, {
-    config: userConfig({ currentVideoQaAiEnabled: true, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     chat: async () => ({
       answer: '有。当前证据可以回答。',
       status: 'answered',
@@ -160,7 +160,7 @@ test('rejects AI unknown candidate references and invented timestamps', async ()
     now: 5000,
   });
   const inventedTime = await answerCurrentVideoQuestion(context, local, {
-    config: userConfig({ currentVideoQaAiEnabled: true, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     chat: async () => ({
       answer: '有。建议直接看 0:42 的解释。',
       status: 'answered',
@@ -344,7 +344,7 @@ function subagentSegments(): CurrentVideoTranscriptSegment[] {
 }
 
 function userConfig(overrides: {
-  currentVideoQaAiEnabled: boolean;
+  currentVideoAiAssistantEnabled: boolean;
   apiKey: string;
 }): UserConfig {
   return {
@@ -361,10 +361,8 @@ function userConfig(overrides: {
       chatModel: 'test-model',
     },
     assistant: {
-      aiSummariesEnabled: false,
+      currentVideoAiAssistantEnabled: overrides.currentVideoAiAssistantEnabled,
       smartFavoritesQaAiEnabled: false,
-      currentVideoSegmentRerankAiEnabled: false,
-      currentVideoQaAiEnabled: overrides.currentVideoQaAiEnabled,
     },
     dynamicBill: {
       aiExplanationsEnabled: false,

--- a/tests/current-video-segment-rerank.test.ts
+++ b/tests/current-video-segment-rerank.test.ts
@@ -37,7 +37,7 @@ test('applies valid AI rerank without changing local candidate evidence or jump 
   const firstLocalOrder = local.candidates.map(candidate => candidate.id);
 
   const result = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoSegmentRerankAiEnabled: true, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     chat: async (_config, messages) => {
       const payload = JSON.parse(messages[1].content);
       assert.equal(JSON.stringify(payload).includes('sourceHash'), false);
@@ -75,7 +75,7 @@ test('rejects unknown AI candidate IDs and keeps local candidate order visible',
   const context = withTranscriptEvidence(videoContext());
   const local = localSegmentResult(context);
   const result = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoSegmentRerankAiEnabled: true, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     chat: async () => ({
       rankedCandidates: [
         {
@@ -99,7 +99,7 @@ test('rejects invented timestamp text from AI output', async () => {
   const context = withTranscriptEvidence(videoContext());
   const local = localSegmentResult(context);
   const result = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoSegmentRerankAiEnabled: true, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     chat: async () => ({
       rankedCandidates: [
         {
@@ -124,7 +124,7 @@ test('rejects outside titles, unavailable sources, and extra evidence fields', a
   const local = localSegmentResult(context);
 
   const outsideTitle = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoSegmentRerankAiEnabled: true, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     chat: async () => ({
       rankedCandidates: [
         {
@@ -139,7 +139,7 @@ test('rejects outside titles, unavailable sources, and extra evidence fields', a
     now: 5000,
   });
   const unavailableSource = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoSegmentRerankAiEnabled: true, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     chat: async () => ({
       rankedCandidates: [
         {
@@ -154,7 +154,7 @@ test('rejects outside titles, unavailable sources, and extra evidence fields', a
     now: 5000,
   });
   const extraEvidence = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoSegmentRerankAiEnabled: true, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     chat: async () => ({
       rankedCandidates: [
         {
@@ -182,21 +182,21 @@ test('AI disabled, not configured, and failed states keep local candidates visib
   const context = withTranscriptEvidence(videoContext());
   const local = localSegmentResult(context);
   const disabled = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoSegmentRerankAiEnabled: false, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: false, apiKey: 'test-key' }),
     chat: async () => {
       throw new Error('should not call chat');
     },
     now: 5000,
   });
   const notConfigured = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoSegmentRerankAiEnabled: true, apiKey: '' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: '' }),
     chat: async () => {
       throw new Error('should not call chat');
     },
     now: 5000,
   });
   const failed = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoSegmentRerankAiEnabled: true, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     chat: async () => {
       throw new Error('AI_TEST_FAILURE');
     },
@@ -218,7 +218,7 @@ test('low-confidence AI output falls back to local candidate order', async () =>
   const context = withTranscriptEvidence(videoContext());
   const local = localSegmentResult(context);
   const result = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoSegmentRerankAiEnabled: true, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     chat: async () => ({
       rankedCandidates: [
         {
@@ -348,7 +348,7 @@ function transcriptSegments(): CurrentVideoTranscriptSegment[] {
 }
 
 function userConfig(overrides: {
-  currentVideoSegmentRerankAiEnabled: boolean;
+  currentVideoAiAssistantEnabled: boolean;
   apiKey: string;
 }): UserConfig {
   return {
@@ -365,10 +365,8 @@ function userConfig(overrides: {
       chatModel: 'test-model',
     },
     assistant: {
-      aiSummariesEnabled: false,
+      currentVideoAiAssistantEnabled: overrides.currentVideoAiAssistantEnabled,
       smartFavoritesQaAiEnabled: false,
-      currentVideoSegmentRerankAiEnabled: overrides.currentVideoSegmentRerankAiEnabled,
-      currentVideoQaAiEnabled: false,
     },
     dynamicBill: {
       aiExplanationsEnabled: false,

--- a/tests/current-video-segment-rerank.test.ts
+++ b/tests/current-video-segment-rerank.test.ts
@@ -31,211 +31,34 @@ test('builds a bounded fuzzy segment rerank payload without internal or sensitiv
   assert.equal('startSeconds' in built.payload.candidates[0], false);
 });
 
-test('applies valid AI rerank without changing local candidate evidence or jump preview', async () => {
+test('new current-video authorization does not call the legacy segment-rerank chat path', async () => {
   const context = withTranscriptEvidence(videoContext());
   const local = localSegmentResult(context);
   const firstLocalOrder = local.candidates.map(candidate => candidate.id);
+  let chatCalls = 0;
+  let auditCalls = 0;
 
   const result = await rerankCurrentVideoSegmentCandidates(context, local, {
     config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
-    chat: async (_config, messages) => {
-      const payload = JSON.parse(messages[1].content);
-      assert.equal(JSON.stringify(payload).includes('sourceHash'), false);
+    chat: async () => {
+      chatCalls += 1;
       return {
-        rankedCandidates: [
-          {
-            candidateId: 'candidate-2',
-            explanation: '这条候选更贴近用户说的架构线索。',
-            reason: '有界证据片段直接提到架构。',
-            confidence: 0.84,
-          },
-          {
-            candidateId: 'candidate-1',
-            explanation: '这条也相关，但更像上下文铺垫。',
-            reason: '命中问题词但细节较少。',
-            confidence: 0.72,
-          },
-        ],
-        overallConfidence: 0.81,
+        rankedCandidates: [],
+        overallConfidence: 0.9,
       };
     },
-    now: 5000,
-  });
-
-  assert.equal(result.aiRerank.status, 'generated');
-  assert.equal(result.candidates[0].id, firstLocalOrder[1]);
-  assert.equal(result.candidates[0].timeRangeLabel, local.candidates[1].timeRangeLabel);
-  assert.equal(result.candidates[0].evidenceText, local.candidates[1].evidenceText);
-  assert.deepEqual(result.candidates[0].jumpPreview, local.candidates[1].jumpPreview);
-  assert.equal(result.aiRerank.explanations[0].candidateId, firstLocalOrder[1]);
-  assert.ok(result.aiRerank.note.includes('跳转前必须确认'));
-});
-
-test('rejects unknown AI candidate IDs and keeps local candidate order visible', async () => {
-  const context = withTranscriptEvidence(videoContext());
-  const local = localSegmentResult(context);
-  const result = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
-    chat: async () => ({
-      rankedCandidates: [
-        {
-          candidateId: 'candidate-99',
-          explanation: '看起来相关。',
-          reason: '模型词重合。',
-          confidence: 0.9,
-        },
-      ],
-      overallConfidence: 0.9,
-    }),
-    now: 5000,
-  });
-
-  assert.equal(result.aiRerank.status, 'rejected');
-  assert.match(result.aiRerank.error ?? '', /AI_UNKNOWN_CANDIDATE_ID/);
-  assert.deepEqual(result.candidates.map(candidate => candidate.id), local.candidates.map(candidate => candidate.id));
-});
-
-test('rejects invented timestamp text from AI output', async () => {
-  const context = withTranscriptEvidence(videoContext());
-  const local = localSegmentResult(context);
-  const result = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
-    chat: async () => ({
-      rankedCandidates: [
-        {
-          candidateId: 'candidate-1',
-          explanation: '应该跳到 0:24 附近。',
-          reason: 'AI 试图输出时间点。',
-          confidence: 0.9,
-        },
-      ],
-      overallConfidence: 0.9,
-    }),
-    now: 5000,
-  });
-
-  assert.equal(result.aiRerank.status, 'rejected');
-  assert.match(result.aiRerank.error ?? '', /AI_TIMESTAMP_OUT_OF_SCHEMA/);
-  assert.deepEqual(result.candidates.map(candidate => candidate.id), local.candidates.map(candidate => candidate.id));
-});
-
-test('rejects outside titles, unavailable sources, and extra evidence fields', async () => {
-  const context = withTranscriptEvidence(videoContext());
-  const local = localSegmentResult(context);
-
-  const outsideTitle = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
-    chat: async () => ({
-      rankedCandidates: [
-        {
-          candidateId: 'candidate-1',
-          explanation: '参考《外部视频标题》判断相关。',
-          reason: '标题看似相关。',
-          confidence: 0.9,
-        },
-      ],
-      overallConfidence: 0.9,
-    }),
-    now: 5000,
-  });
-  const unavailableSource = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
-    chat: async () => ({
-      rankedCandidates: [
-        {
-          candidateId: 'candidate-1',
-          explanation: '根据评论和弹幕判断相关。',
-          reason: '引用了未提供来源。',
-          confidence: 0.9,
-        },
-      ],
-      overallConfidence: 0.9,
-    }),
-    now: 5000,
-  });
-  const extraEvidence = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
-    chat: async () => ({
-      rankedCandidates: [
-        {
-          candidateId: 'candidate-1',
-          explanation: '看起来相关。',
-          reason: '模型词重合。',
-          confidence: 0.9,
-          evidence: 'AI 自己补充的外部证据',
-        },
-      ],
-      overallConfidence: 0.9,
-    }),
-    now: 5000,
-  });
-
-  assert.equal(outsideTitle.aiRerank.status, 'rejected');
-  assert.match(outsideTitle.aiRerank.error ?? '', /AI_OUTSIDE_TITLE_REFERENCE/);
-  assert.equal(unavailableSource.aiRerank.status, 'rejected');
-  assert.match(unavailableSource.aiRerank.error ?? '', /AI_UNAVAILABLE_SOURCE_REFERENCE/);
-  assert.equal(extraEvidence.aiRerank.status, 'rejected');
-  assert.match(extraEvidence.aiRerank.error ?? '', /AI_SCHEMA_VIOLATION/);
-});
-
-test('AI disabled, not configured, and failed states keep local candidates visible', async () => {
-  const context = withTranscriptEvidence(videoContext());
-  const local = localSegmentResult(context);
-  const disabled = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoAiAssistantEnabled: false, apiKey: 'test-key' }),
-    chat: async () => {
-      throw new Error('should not call chat');
-    },
-    now: 5000,
-  });
-  const notConfigured = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: '' }),
-    chat: async () => {
-      throw new Error('should not call chat');
-    },
-    now: 5000,
-  });
-  const failed = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
-    chat: async () => {
-      throw new Error('AI_TEST_FAILURE');
+    auditPayload: () => {
+      auditCalls += 1;
     },
     now: 5000,
   });
 
-  assert.equal(disabled.aiRerank.status, 'disabled');
-  assert.equal(notConfigured.aiRerank.status, 'not_configured');
-  assert.equal(failed.aiRerank.status, 'failed');
-  assert.match(failed.aiRerank.error ?? '', /AI_TEST_FAILURE/);
-  for (const result of [disabled, notConfigured, failed]) {
-    assert.deepEqual(result.candidates.map(candidate => candidate.id), local.candidates.map(candidate => candidate.id));
-    assert.equal(result.candidates.length > 0, true);
-    assert.ok(result.aiRerank.note.includes('本地候选顺序'));
-  }
-});
-
-test('low-confidence AI output falls back to local candidate order', async () => {
-  const context = withTranscriptEvidence(videoContext());
-  const local = localSegmentResult(context);
-  const result = await rerankCurrentVideoSegmentCandidates(context, local, {
-    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
-    chat: async () => ({
-      rankedCandidates: [
-        {
-          candidateId: 'candidate-2',
-          explanation: '可能相关，但证据不够稳。',
-          reason: '只是弱重合。',
-          confidence: 0.31,
-        },
-      ],
-      overallConfidence: 0.32,
-    }),
-    now: 5000,
-  });
-
-  assert.equal(result.aiRerank.status, 'low_confidence');
-  assert.match(result.aiRerank.error ?? '', /AI_LOW_CONFIDENCE/);
+  assert.equal(chatCalls, 0);
+  assert.equal(auditCalls, 0);
+  assert.equal(result.aiRerank.status, 'disabled');
+  assert.match(result.aiRerank.note, /片段排序.*本地处理.*没有请求 AI/);
   assert.deepEqual(result.candidates.map(candidate => candidate.id), local.candidates.map(candidate => candidate.id));
+  assert.deepEqual(result.candidates.map(candidate => candidate.id), firstLocalOrder);
 });
 
 function localSegmentResult(context: CurrentVideoContext) {

--- a/tests/current-video-summary.test.ts
+++ b/tests/current-video-summary.test.ts
@@ -276,12 +276,12 @@ test('AI disabled and not configured keep transcript local evidence summary', as
   const context = withTranscriptEvidence(videoContext({}));
   const segments = transcriptSegments();
   const disabled = await generateCurrentVideoSummary(context, {
-    config: userConfig({ aiSummariesEnabled: false, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: false, apiKey: 'test-key' }),
     transcriptSegments: segments,
     now: 4000,
   });
   const notConfigured = await generateCurrentVideoSummary(context, {
-    config: userConfig({ aiSummariesEnabled: true, apiKey: '' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: '' }),
     transcriptSegments: segments,
     now: 4000,
   });
@@ -296,7 +296,7 @@ test('AI disabled and not configured keep transcript local evidence summary', as
 test('AI failed and low confidence keep transcript local evidence summary', async () => {
   const context = withTranscriptEvidence(videoContext({}));
   const failed = await generateCurrentVideoSummary(context, {
-    config: userConfig({ aiSummariesEnabled: true, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     transcriptSegments: transcriptSegments(),
     chat: async () => {
       throw new Error('AI_TEST_FAILURE');
@@ -304,7 +304,7 @@ test('AI failed and low confidence keep transcript local evidence summary', asyn
     now: 5000,
   });
   const lowConfidence = await generateCurrentVideoSummary(context, {
-    config: userConfig({ aiSummariesEnabled: true, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     transcriptSegments: transcriptSegments(),
     chat: async () => ({
       summary: 'AI low confidence answer',
@@ -325,7 +325,7 @@ test('AI failed and low confidence keep transcript local evidence summary', asyn
 test('rejects AI segment or timestamp references outside payload and keeps local transcript result', async () => {
   const context = withTranscriptEvidence(videoContext({}));
   const summary = await generateCurrentVideoSummary(context, {
-    config: userConfig({ aiSummariesEnabled: true, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     transcriptSegments: transcriptSegments(),
     chat: async () => ({
       summary: 'AI tries to cite transcript:outside:segment at 9:59.',
@@ -345,7 +345,7 @@ test('rejects AI segment or timestamp references outside payload and keeps local
 test('accepts valid AI transcript summary without replacing local evidence ranges', async () => {
   const context = withTranscriptEvidence(videoContext({}));
   const summary = await generateCurrentVideoSummary(context, {
-    config: userConfig({ aiSummariesEnabled: true, apiKey: 'test-key' }),
+    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     transcriptSegments: transcriptSegments(),
     chat: async () => ({
       summary: 'AI based on the supplied subtitle evidence around 0:00.',
@@ -482,7 +482,7 @@ function transcriptSegments(options: {
 }
 
 function userConfig(overrides: {
-  aiSummariesEnabled: boolean;
+  currentVideoAiAssistantEnabled: boolean;
   apiKey: string;
 }): UserConfig {
   return {
@@ -499,10 +499,8 @@ function userConfig(overrides: {
       chatModel: 'test-model',
     },
     assistant: {
-      aiSummariesEnabled: overrides.aiSummariesEnabled,
+      currentVideoAiAssistantEnabled: overrides.currentVideoAiAssistantEnabled,
       smartFavoritesQaAiEnabled: false,
-      currentVideoSegmentRerankAiEnabled: false,
-      currentVideoQaAiEnabled: false,
     },
     dynamicBill: {
       aiExplanationsEnabled: false,

--- a/tests/current-video-summary.test.ts
+++ b/tests/current-video-summary.test.ts
@@ -272,92 +272,25 @@ test('current video AI payload audit reports sensitive fields and tokens', () =>
   );
 });
 
-test('AI disabled and not configured keep transcript local evidence summary', async () => {
+test('new current-video authorization does not call the legacy bounded summary chat path', async () => {
   const context = withTranscriptEvidence(videoContext({}));
-  const segments = transcriptSegments();
-  const disabled = await generateCurrentVideoSummary(context, {
-    config: userConfig({ currentVideoAiAssistantEnabled: false, apiKey: 'test-key' }),
-    transcriptSegments: segments,
-    now: 4000,
-  });
-  const notConfigured = await generateCurrentVideoSummary(context, {
-    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: '' }),
-    transcriptSegments: segments,
-    now: 4000,
-  });
-
-  assert.equal(disabled.sourceTier, 'transcript_summary');
-  assert.equal(disabled.generationMode, 'local_fallback');
-  assert.equal(disabled.ai.status, 'disabled');
-  assert.equal(notConfigured.sourceTier, 'transcript_summary');
-  assert.equal(notConfigured.ai.status, 'not_configured');
-});
-
-test('AI failed and low confidence keep transcript local evidence summary', async () => {
-  const context = withTranscriptEvidence(videoContext({}));
-  const failed = await generateCurrentVideoSummary(context, {
-    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
-    transcriptSegments: transcriptSegments(),
-    chat: async () => {
-      throw new Error('AI_TEST_FAILURE');
-    },
-    now: 5000,
-  });
-  const lowConfidence = await generateCurrentVideoSummary(context, {
-    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
-    transcriptSegments: transcriptSegments(),
-    chat: async () => ({
-      summary: 'AI low confidence answer',
-      bullets: ['AI low confidence bullet'],
-      confidence: 0.2,
-    }),
-    now: 5000,
-  });
-
-  assert.equal(failed.sourceTier, 'transcript_summary');
-  assert.equal(failed.ai.status, 'failed');
-  assert.equal(failed.summary.includes('字幕正文证据'), true);
-  assert.equal(lowConfidence.sourceTier, 'transcript_summary');
-  assert.equal(lowConfidence.ai.status, 'low_confidence');
-  assert.equal(lowConfidence.generationMode, 'local_fallback');
-});
-
-test('rejects AI segment or timestamp references outside payload and keeps local transcript result', async () => {
-  const context = withTranscriptEvidence(videoContext({}));
+  let chatCalls = 0;
   const summary = await generateCurrentVideoSummary(context, {
     config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
     transcriptSegments: transcriptSegments(),
     chat: async () => ({
-      summary: 'AI tries to cite transcript:outside:segment at 9:59.',
-      bullets: ['This should be rejected.'],
-      confidence: 0.91,
-    }),
-    now: 6000,
-  });
-
-  assert.equal(summary.sourceTier, 'transcript_summary');
-  assert.equal(summary.generationMode, 'local_fallback');
-  assert.equal(summary.ai.status, 'invalid_output');
-  assert.match(summary.ai.error ?? '', /AI_SEGMENT_OUT_OF_PAYLOAD|AI_TIMESTAMP_OUT_OF_PAYLOAD/);
-  assert.ok(summary.evidence.some(item => item.source === 'transcript'));
-});
-
-test('accepts valid AI transcript summary without replacing local evidence ranges', async () => {
-  const context = withTranscriptEvidence(videoContext({}));
-  const summary = await generateCurrentVideoSummary(context, {
-    config: userConfig({ currentVideoAiAssistantEnabled: true, apiKey: 'test-key' }),
-    transcriptSegments: transcriptSegments(),
-    chat: async () => ({
-      summary: 'AI based on the supplied subtitle evidence around 0:00.',
-      bullets: ['0:00 starts from the provided subtitle range.'],
-      confidence: 0.78,
+      summary: `${++chatCalls}`,
+      bullets: ['legacy response'],
+      confidence: 0.9,
     }),
     now: 7000,
   });
 
+  assert.equal(chatCalls, 0);
   assert.equal(summary.sourceTier, 'transcript_summary');
-  assert.equal(summary.generationMode, 'ai');
-  assert.equal(summary.ai.status, 'generated');
+  assert.equal(summary.generationMode, 'local_fallback');
+  assert.equal(summary.ai.status, 'disabled');
+  assert.match(summary.ai.note, /没有向聊天服务发送视频内容/);
   assert.equal(summary.timestampRanges[0].label, '0:00-0:19');
   assert.ok(summary.evidence.some(item => item.source === 'transcript'));
 });

--- a/tests/settings-config-migration.test.ts
+++ b/tests/settings-config-migration.test.ts
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  loadConfig,
+  normalizeUserConfig,
+  saveConfig,
+} from '../src/background/storage/config-store.ts';
+
+interface MockChromeStorage {
+  userConfig?: unknown;
+  [key: string]: unknown;
+}
+
+test('settings migration keeps service config but does not inherit old current-video switches', async () => {
+  const store = installChromeStorageMock({
+    userConfig: {
+      dailyWatchGoal: 70,
+      weeklyWatchGoal: 500,
+      overDependencyThreshold: 0.4,
+      syncIntervalMinutes: 10,
+      retentionDays: 180,
+      showSidebar: false,
+      theme: 'light',
+      ai: {
+        baseURL: 'https://api.example.test',
+        apiKey: 'saved-key',
+        chatModel: 'example-model',
+      },
+      assistant: {
+        aiSummariesEnabled: true,
+        currentVideoSegmentRerankAiEnabled: true,
+        currentVideoQaAiEnabled: true,
+        videoBlindBoxAiEnabled: true,
+        smartFavoritesQaAiEnabled: true,
+      },
+      dynamicBill: {
+        aiExplanationsEnabled: true,
+      },
+    },
+  });
+
+  const config = await loadConfig();
+
+  assert.equal(config.ai.baseURL, 'https://api.example.test');
+  assert.equal(config.ai.apiKey, 'saved-key');
+  assert.equal(config.ai.chatModel, 'example-model');
+  assert.equal(config.assistant.currentVideoAiAssistantEnabled, false);
+  assert.equal(config.assistant.smartFavoritesQaAiEnabled, true);
+  assert.equal(config.dynamicBill.aiExplanationsEnabled, true);
+  assert.equal('aiSummariesEnabled' in config.assistant, false);
+  assert.equal('currentVideoSegmentRerankAiEnabled' in config.assistant, false);
+  assert.equal('currentVideoQaAiEnabled' in config.assistant, false);
+  assert.equal('videoBlindBoxAiEnabled' in config.assistant, false);
+
+  const persisted = store.userConfig as ReturnType<typeof normalizeUserConfig>;
+  assert.equal(persisted.assistant.currentVideoAiAssistantEnabled, false);
+  assert.equal('currentVideoQaAiEnabled' in persisted.assistant, false);
+});
+
+test('settings save preserves a saved API key when updating feature switches', async () => {
+  const store = installChromeStorageMock({
+    userConfig: normalizeUserConfig({
+      ai: {
+        baseURL: 'https://api.example.test',
+        apiKey: 'saved-key',
+        chatModel: 'old-model',
+      },
+      assistant: {
+        currentVideoAiAssistantEnabled: false,
+        smartFavoritesQaAiEnabled: false,
+      },
+      dynamicBill: {
+        aiExplanationsEnabled: false,
+      },
+    }),
+  });
+
+  await saveConfig({
+    ai: {
+      baseURL: 'https://api.example.test',
+      apiKey: 'saved-key',
+      chatModel: 'new-model',
+    },
+    assistant: {
+      currentVideoAiAssistantEnabled: true,
+      smartFavoritesQaAiEnabled: true,
+    },
+  });
+
+  const persisted = store.userConfig as ReturnType<typeof normalizeUserConfig>;
+  assert.equal(persisted.ai.apiKey, 'saved-key');
+  assert.equal(persisted.ai.chatModel, 'new-model');
+  assert.equal(persisted.assistant.currentVideoAiAssistantEnabled, true);
+  assert.equal(persisted.assistant.smartFavoritesQaAiEnabled, true);
+  assert.equal('videoBlindBoxAiEnabled' in persisted.assistant, false);
+});
+
+function installChromeStorageMock(initial: MockChromeStorage): MockChromeStorage {
+  const store: MockChromeStorage = { ...initial };
+  globalThis.chrome = {
+    storage: {
+      local: {
+        get: async (keys?: string | string[]) => {
+          if (typeof keys === 'string') return { [keys]: store[keys] };
+          if (Array.isArray(keys)) {
+            return Object.fromEntries(keys.map(key => [key, store[key]]));
+          }
+          return { ...store };
+        },
+        set: async (value: Record<string, unknown>) => {
+          Object.assign(store, value);
+        },
+        remove: async (keys: string | string[]) => {
+          for (const key of Array.isArray(keys) ? keys : [keys]) {
+            delete store[key];
+          }
+        },
+      },
+    },
+  } as typeof chrome;
+  return store;
+}

--- a/tests/settings-config-migration.test.ts
+++ b/tests/settings-config-migration.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
 import test from 'node:test';
+import {
+  saveSettingsDraft,
+  type SettingsDraft,
+} from '../dashboard/modules/settings/settings-save-state.ts';
 import {
   loadConfig,
   normalizeUserConfig,
@@ -96,25 +99,117 @@ test('settings save preserves a saved API key when updating feature switches', a
   assert.equal('videoBlindBoxAiEnabled' in persisted.assistant, false);
 });
 
-test('settings save failure keeps every draft field and reports that it is unsaved', async () => {
-  const source = await readFile(
-    new URL('../dashboard/modules/settings/SettingsPage.tsx', import.meta.url),
-    'utf8',
-  );
-  const saveFunction = source.match(
-    /async function saveSettings\(\)[\s\S]*?\n  async function testConnection/,
-  )?.[0];
-  assert.ok(saveFunction, 'saveSettings should remain executable from the settings page');
+test('settings save failure keeps the complete draft and does not apply unpersisted state', async () => {
+  const persistedConfig = normalizeUserConfig({
+    ai: {
+      baseURL: 'https://saved.example.test',
+      apiKey: 'saved-key',
+      chatModel: 'saved-model',
+    },
+    assistant: {
+      currentVideoAiAssistantEnabled: false,
+      smartFavoritesQaAiEnabled: false,
+    },
+    dynamicBill: {
+      aiExplanationsEnabled: false,
+    },
+  });
+  const draft = makeSettingsDraft();
+  let appliedConfig = persistedConfig;
 
-  const catchBody = saveFunction.match(/} catch \(err\) \{([\s\S]*?)\n    } finally/)?.[1];
-  assert.ok(catchBody, 'saveSettings should expose a failure branch');
-  assert.doesNotMatch(
-    catchBody,
-    /\b(?:refreshConfig|applyConfig|setForm|setAssistant|setDynamicBill)\s*\(/,
-    'a failed save must not replace service, model, key, or toggle drafts',
+  const result = await saveSettingsDraft(
+    { persistedConfig, draft },
+    {
+      persist: async () => {
+        throw new Error('raw persistence failure');
+      },
+      applyPersistedConfig: config => {
+        appliedConfig = config;
+      },
+    },
   );
-  assert.match(source, /设置未保存[^'"\n]*当前输入已保留/);
+
+  assert.equal(result.status, 'failure');
+  assert.deepEqual(result.draft, draft);
+  assert.deepEqual(result.persistedConfig, persistedConfig);
+  assert.equal(appliedConfig, persistedConfig);
+  assert.match(result.error, /设置未保存，当前输入已保留/);
+  assert.doesNotMatch(result.error, /raw persistence failure/);
 });
+
+test('settings save success persists and applies the complete draft', async () => {
+  const persistedConfig = normalizeUserConfig({
+    dailyWatchGoal: 75,
+    ai: {
+      baseURL: 'https://saved.example.test',
+      apiKey: 'saved-key',
+      chatModel: 'saved-model',
+    },
+    assistant: {
+      currentVideoAiAssistantEnabled: false,
+      smartFavoritesQaAiEnabled: false,
+    },
+    dynamicBill: {
+      aiExplanationsEnabled: false,
+    },
+  });
+  const draft = makeSettingsDraft();
+  let persistedPayload: typeof persistedConfig | null = null;
+  let appliedConfig = persistedConfig;
+
+  const result = await saveSettingsDraft(
+    { persistedConfig, draft },
+    {
+      persist: async config => {
+        persistedPayload = config;
+      },
+      applyPersistedConfig: config => {
+        appliedConfig = config;
+      },
+    },
+  );
+
+  const expectedConfig = {
+    ...persistedConfig,
+    ai: {
+      baseURL: 'https://draft.example.test/v1',
+      apiKey: 'draft-key',
+      chatModel: 'draft-model',
+    },
+    assistant: {
+      currentVideoAiAssistantEnabled: true,
+      smartFavoritesQaAiEnabled: true,
+    },
+    dynamicBill: {
+      aiExplanationsEnabled: true,
+    },
+  };
+  assert.equal(result.status, 'success');
+  assert.deepEqual(persistedPayload, expectedConfig);
+  assert.deepEqual(appliedConfig, expectedConfig);
+  assert.deepEqual(result.persistedConfig, expectedConfig);
+  assert.equal(result.draft.ai.apiKeyInput, '');
+  assert.equal(result.draft.ai.savedApiKey, 'draft-key');
+  assert.equal(result.error, '');
+});
+
+function makeSettingsDraft(): SettingsDraft {
+  return {
+    ai: {
+      baseURL: '  https://draft.example.test/v1  ',
+      chatModel: '  draft-model  ',
+      apiKeyInput: '  draft-key  ',
+      savedApiKey: 'saved-key',
+    },
+    assistant: {
+      currentVideoAiAssistantEnabled: true,
+      smartFavoritesQaAiEnabled: true,
+    },
+    dynamicBill: {
+      aiExplanationsEnabled: true,
+    },
+  };
+}
 
 function installChromeStorageMock(initial: MockChromeStorage): MockChromeStorage {
   const store: MockChromeStorage = { ...initial };

--- a/tests/settings-config-migration.test.ts
+++ b/tests/settings-config-migration.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 import {
   loadConfig,
@@ -93,6 +94,26 @@ test('settings save preserves a saved API key when updating feature switches', a
   assert.equal(persisted.assistant.currentVideoAiAssistantEnabled, true);
   assert.equal(persisted.assistant.smartFavoritesQaAiEnabled, true);
   assert.equal('videoBlindBoxAiEnabled' in persisted.assistant, false);
+});
+
+test('settings save failure keeps every draft field and reports that it is unsaved', async () => {
+  const source = await readFile(
+    new URL('../dashboard/modules/settings/SettingsPage.tsx', import.meta.url),
+    'utf8',
+  );
+  const saveFunction = source.match(
+    /async function saveSettings\(\)[\s\S]*?\n  async function testConnection/,
+  )?.[0];
+  assert.ok(saveFunction, 'saveSettings should remain executable from the settings page');
+
+  const catchBody = saveFunction.match(/} catch \(err\) \{([\s\S]*?)\n    } finally/)?.[1];
+  assert.ok(catchBody, 'saveSettings should expose a failure branch');
+  assert.doesNotMatch(
+    catchBody,
+    /\b(?:refreshConfig|applyConfig|setForm|setAssistant|setDynamicBill)\s*\(/,
+    'a failed save must not replace service, model, key, or toggle drafts',
+  );
+  assert.match(source, /设置未保存[^'"\n]*当前输入已保留/);
 });
 
 function installChromeStorageMock(initial: MockChromeStorage): MockChromeStorage {

--- a/tests/settings-local-data-privacy.test.ts
+++ b/tests/settings-local-data-privacy.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 import {
   buildLocalDataOperationMessage,
@@ -7,8 +8,17 @@ import {
   dangerousLocalDataClearScope,
   LOCAL_DATA_CLEAR_CONFIRMATION,
 } from '../src/shared/local-data-privacy.ts';
-import { validateLocalDataCategoryRegistration } from '../src/shared/local-data-category-contract.ts';
-import { getRegisteredLocalDataCategories } from '../src/background/storage/local-data-category-registry.ts';
+import {
+  runLocalDataCategoryLifecycles,
+  validateLocalDataCategoryRegistration,
+  type LocalDataCategoryRegistration,
+} from '../src/shared/local-data-category-contract.ts';
+import {
+  createRegisteredLocalDataCategories,
+  getRegisteredLocalDataCategories,
+  type LocalDataCategoryRegistryDependencies,
+  type LocalDataCategoryTable,
+} from '../src/background/storage/local-data-category-registry.ts';
 import type {
   LocalDataOperationResult,
   LocalDataPrivacySummary,
@@ -92,6 +102,75 @@ test('local data categories expose the shared lifecycle contract', () => {
   }
 });
 
+test('registered categories collect usage, clear independently, and read back the cleared state', async () => {
+  const dependencies = createRegistryDependencies();
+  const categories = createRegisteredLocalDataCategories(dependencies);
+  const usageBefore = await Promise.all(categories.map(category => category.collectUsage()));
+
+  assert.deepEqual(usageBefore.map(usage => usage.count), [3, 3, 2, 5, 2]);
+  assert.ok(usageBefore.every(usage => usage.usageBytes > 0));
+
+  const history = categories[0];
+  const favorites = categories[1];
+  const historyClear = await history.clear();
+  assert.equal(historyClear.cleared.historyRecords, 1);
+  assert.deepEqual(await history.readAfterClear(), {
+    count: 0,
+    usageBytes: 0,
+    empty: true,
+  });
+  assert.equal((await favorites.collectUsage()).count, 3, 'independent clear must not touch another category');
+
+  for (const category of categories.slice(1)) {
+    const clearResult = await category.clear();
+    assert.ok(Object.keys(clearResult.cleared).length > 0);
+    const readback = await category.readAfterClear();
+    assert.equal(readback.count, 0, category.label);
+    assert.equal(readback.empty, true, category.label);
+  }
+});
+
+test('lifecycle results retain completed categories and name a failed category in natural Chinese', async () => {
+  const calls: string[] = [];
+  const registrations = [
+    lifecycleRegistration('history', '观看历史', calls),
+    lifecycleRegistration('favorites', '收藏与智能索引', calls, 'clear'),
+    lifecycleRegistration('dynamicBill', '动态账单', calls),
+  ];
+
+  const results = await runLocalDataCategoryLifecycles(registrations);
+
+  assert.deepEqual(results.map(result => result.status), ['success', 'failure', 'success']);
+  assert.deepEqual(calls, [
+    '观看历史:usage',
+    '观看历史:clear',
+    '观看历史:readback',
+    '收藏与智能索引:usage',
+    '收藏与智能索引:clear',
+    '动态账单:usage',
+    '动态账单:clear',
+    '动态账单:readback',
+  ]);
+  assert.equal(results[0].status === 'success' && results[0].after.empty, true);
+  assert.equal(results[1].status, 'failure');
+  if (results[1].status === 'failure') {
+    assert.equal(results[1].failedStage, 'clear');
+    assert.match(results[1].message, /收藏与智能索引清理失败/);
+    assert.equal(results[1].before?.count, 1);
+  }
+});
+
+test('SET-013-A keeps the existing clear-all production transaction', async () => {
+  const source = await readFile(
+    new URL('../src/background/storage/local-data-privacy-repo.ts', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(source, /db\.transaction\(\s*'rw',\s*db\.tables/);
+  assert.match(source, /chrome\.storage\.local\.clear\(\)/);
+  assert.doesNotMatch(source, /clearRegisteredLocalDataCategories/);
+});
+
 function makeSummary(): LocalDataPrivacySummary {
   return {
     checkedAt: 1_718_000_000_000,
@@ -135,6 +214,83 @@ function makeSummary(): LocalDataPrivacySummary {
       lastGeneratedAt: 1_718_000_000_000,
       lastSyncedAt: 1_718_000_000_000,
       syncStatus: 'success',
+    },
+  };
+}
+
+function createRegistryDependencies(): LocalDataCategoryRegistryDependencies {
+  const tableNames: Array<keyof LocalDataCategoryRegistryDependencies['tables']> = [
+    'watchHistory',
+    'playerEvents',
+    'dailyAggregates',
+    'favoriteFolders',
+    'favoriteItems',
+    'smartFavoriteIndex',
+    'currentVideoTranscriptSources',
+    'currentVideoTranscriptSegments',
+    'followedCreators',
+    'followedVideoUpdates',
+    'dynamicBillItems',
+    'dynamicBillExplanations',
+    'dynamicBillFeedback',
+  ];
+  const tables = Object.fromEntries(
+    tableNames.map(name => [name, memoryTable([{ id: name, value: `row-${name}` }])]),
+  ) as LocalDataCategoryRegistryDependencies['tables'];
+  const storage = new Map<string, unknown>([
+    ['lastSyncTime', 100],
+    ['dynamicBillSyncState', { status: 'success' }],
+    ['userConfig', { assistant: {} }],
+    ['floatingPopupWindowId', 7],
+  ]);
+
+  return {
+    tables,
+    storage: {
+      get: async keys => Object.fromEntries(keys.map(key => [key, storage.get(key)])),
+      remove: async keys => {
+        for (const key of keys) storage.delete(key);
+      },
+    },
+    transaction: async (_tables, operation) => operation(),
+  };
+}
+
+function memoryTable(initialRows: unknown[]): LocalDataCategoryTable {
+  let rows = [...initialRows];
+  return {
+    count: async () => rows.length,
+    toArray: async () => [...rows],
+    clear: async () => {
+      rows = [];
+    },
+  };
+}
+
+function lifecycleRegistration(
+  id: LocalDataCategoryRegistration['id'],
+  label: string,
+  calls: string[],
+  failAt?: 'usage' | 'clear' | 'readback',
+): LocalDataCategoryRegistration {
+  return {
+    id,
+    label,
+    includeInClearAll: true,
+    collectUsage: async () => {
+      calls.push(`${label}:usage`);
+      if (failAt === 'usage') throw new Error('raw usage failure');
+      return { count: 1, usageBytes: 10 };
+    },
+    clear: async () => {
+      calls.push(`${label}:clear`);
+      if (failAt === 'clear') throw new Error('raw clear failure');
+      return { cleared: {} };
+    },
+    readAfterClear: async () => {
+      calls.push(`${label}:readback`);
+      if (failAt === 'readback') throw new Error('raw readback failure');
+      return { count: 0, usageBytes: 0, empty: true };
     },
   };
 }

--- a/tests/settings-local-data-privacy.test.ts
+++ b/tests/settings-local-data-privacy.test.ts
@@ -7,6 +7,8 @@ import {
   dangerousLocalDataClearScope,
   LOCAL_DATA_CLEAR_CONFIRMATION,
 } from '../src/shared/local-data-privacy.ts';
+import { validateLocalDataCategoryRegistration } from '../src/shared/local-data-category-contract.ts';
+import { getRegisteredLocalDataCategories } from '../src/background/storage/local-data-category-registry.ts';
 import type {
   LocalDataOperationResult,
   LocalDataPrivacySummary,
@@ -72,6 +74,22 @@ test('settings smart favorite rebuild message summarizes the run', () => {
   assert.match(message, /本地收藏 24 条/);
   assert.match(message, /失败项可在确认 AI 设置后再次重建/);
   assertCleanUserCopy(message);
+});
+
+test('local data categories expose the shared lifecycle contract', () => {
+  const categories = getRegisteredLocalDataCategories();
+  assert.deepEqual(categories.map(category => category.id), [
+    'history',
+    'favorites',
+    'currentVideoSubtitles',
+    'dynamicBill',
+    'localSettings',
+  ]);
+
+  for (const category of categories) {
+    assert.deepEqual(validateLocalDataCategoryRegistration(category), []);
+    assert.equal(category.includeInClearAll, true);
+  }
 });
 
 function makeSummary(): LocalDataPrivacySummary {

--- a/tests/settings-local-data-privacy.test.ts
+++ b/tests/settings-local-data-privacy.test.ts
@@ -9,9 +9,11 @@ import {
   LOCAL_DATA_CLEAR_CONFIRMATION,
 } from '../src/shared/local-data-privacy.ts';
 import {
+  runLocalDataCategoryLifecycle,
   runLocalDataCategoryLifecycles,
   validateLocalDataCategoryRegistration,
   type LocalDataCategoryRegistration,
+  type LocalDataCategoryReadback,
 } from '../src/shared/local-data-category-contract.ts';
 import {
   createRegisteredLocalDataCategories,
@@ -157,6 +159,41 @@ test('lifecycle results retain completed categories and name a failed category i
     assert.equal(results[1].failedStage, 'clear');
     assert.match(results[1].message, /收藏与智能索引清理失败/);
     assert.equal(results[1].before?.count, 1);
+  }
+});
+
+test('lifecycle reports a readback failure whenever cleared data remains', async t => {
+  const cases: Array<{ name: string; after: LocalDataCategoryReadback }> = [
+    {
+      name: 'empty is false',
+      after: { count: 0, usageBytes: 0, empty: false },
+    },
+    {
+      name: 'count is non-zero',
+      after: { count: 1, usageBytes: 0, empty: true },
+    },
+    {
+      name: 'usage is non-zero',
+      after: { count: 0, usageBytes: 16, empty: true },
+    },
+  ];
+
+  for (const currentCase of cases) {
+    await t.test(currentCase.name, async () => {
+      const registration = lifecycleRegistration('history', '观看历史', []);
+      registration.readAfterClear = async () => currentCase.after;
+
+      const result = await runLocalDataCategoryLifecycle(registration);
+
+      assert.equal(result.status, 'failure');
+      if (result.status === 'failure') {
+        assert.equal(result.failedStage, 'readback');
+        assert.equal(result.failureReason, 'data_remaining');
+        assert.deepEqual(result.after, currentCase.after);
+        assert.match(result.message, /观看历史已执行清理，但回读后仍有本地数据/);
+        assertCleanUserCopy(result.message);
+      }
+    });
   }
 });
 

--- a/tests/settings-mvp.mock.html
+++ b/tests/settings-mvp.mock.html
@@ -165,7 +165,7 @@
         </div>
         <div class="panel">
           <h2>AI 功能开关</h2>
-          <label class="toggle"><input id="current" type="checkbox" /> <span>当前视频摘要<br /><small class="muted">关闭后显示本地证据结果。</small></span></label>
+          <label class="toggle"><input id="current" type="checkbox" /> <span>当前视频 AI 助手<br /><small class="muted">开启后仅在用户主动生成或提问时使用当前分 P 的主要文本。</small></span></label>
           <label class="toggle"><input id="smart" type="checkbox" /> <span>智能收藏问答<br /><small class="muted">关闭后显示本地引用结果。</small></span></label>
           <label class="toggle"><input id="dynamic" type="checkbox" /> <span>动态账单解释<br /><small class="muted">关闭后写入本地证据说明。</small></span></label>
         </div>
@@ -184,7 +184,7 @@
       <section id="prompts-page" class="hidden">
         <div class="panel">
           <h1>未配置提示</h1>
-          <p id="current-prompt" class="warn">当前视频 AI 摘要已启用但尚未在设置中配置 API Key，当前显示本地证据结果。</p>
+          <p id="current-prompt" class="warn">当前视频 AI 助手已开启但尚未在设置中配置 API Key，当前显示本地证据结果。</p>
           <button id="current-settings" class="link-button" type="button">前往设置</button>
           <p id="dynamic-prompt" class="warn">动态账单 AI 解释已启用但尚未在设置中配置 API Key，生成解释时会回退到本地证据说明。</p>
           <button id="dynamic-settings" class="link-button" type="button">前往设置</button>
@@ -224,6 +224,10 @@
       document.getElementById('status').textContent = 'API Key 已保存在本地，不会在输入框中回显完整值。';
       document.getElementById('status').className = 'ok';
       document.getElementById('key').value = '';
+      localStorage.setItem('currentVideoAiAssistantEnabled', document.getElementById('current').checked ? 'true' : 'false');
+    });
+    window.addEventListener('pageshow', () => {
+      document.getElementById('current').checked = localStorage.getItem('currentVideoAiAssistantEnabled') === 'true';
     });
   </script>
 </body>

--- a/tests/settings-mvp.mock.html
+++ b/tests/settings-mvp.mock.html
@@ -160,7 +160,8 @@
           <div class="actions">
             <button id="test" type="button">测试连接</button>
             <button id="save" type="button">保存设置</button>
-            <span id="status" class="warn">Key 未保存</span>
+            <button id="save-fail" type="button">模拟保存失败</button>
+            <span id="status" class="warn" aria-live="polite">Key 未保存</span>
           </div>
         </div>
         <div class="panel">
@@ -184,7 +185,7 @@
       <section id="prompts-page" class="hidden">
         <div class="panel">
           <h1>未配置提示</h1>
-          <p id="current-prompt" class="warn">当前视频 AI 助手已开启但尚未在设置中配置 API Key，当前显示本地证据结果。</p>
+          <p id="current-prompt" class="warn">当前只显示本地证据结果，本次不会向聊天服务发送视频内容。</p>
           <button id="current-settings" class="link-button" type="button">前往设置</button>
           <p id="dynamic-prompt" class="warn">动态账单 AI 解释已启用但尚未在设置中配置 API Key，生成解释时会回退到本地证据说明。</p>
           <button id="dynamic-settings" class="link-button" type="button">前往设置</button>
@@ -225,6 +226,12 @@
       document.getElementById('status').className = 'ok';
       document.getElementById('key').value = '';
       localStorage.setItem('currentVideoAiAssistantEnabled', document.getElementById('current').checked ? 'true' : 'false');
+    });
+    document.getElementById('save-fail').addEventListener('click', () => {
+      document.getElementById('save-state').textContent = '有未保存更改';
+      document.getElementById('status').textContent = '设置未保存，当前输入已保留。请检查服务地址、模型名和浏览器授权后重试。';
+      document.getElementById('status').className = 'warn';
+      document.body.dataset.lastAction = 'save-failed';
     });
     window.addEventListener('pageshow', () => {
       document.getElementById('current').checked = localStorage.getItem('currentVideoAiAssistantEnabled') === 'true';

--- a/tests/smart-favorites-qa.test.ts
+++ b/tests/smart-favorites-qa.test.ts
@@ -441,10 +441,8 @@ function makeConfig(overrides: {
       chatModel: 'test-model',
     },
     assistant: {
-      aiSummariesEnabled: false,
+      currentVideoAiAssistantEnabled: false,
       smartFavoritesQaAiEnabled: overrides.smartFavoritesQaAiEnabled,
-      currentVideoSegmentRerankAiEnabled: false,
-      currentVideoQaAiEnabled: false,
     },
     dynamicBill: {
       aiExplanationsEnabled: false,


### PR DESCRIPTION
## Summary
- Migrate the 0.12 current-video switches into one default-off `当前视频 AI 助手` full-text authorization without inheriting old summary/rerank/QA flags.
- Preserve the AI service URL, model, and saved API Key state while retaining Smart Favorites Q&A and Dynamic Bill explanation switches and removing possible legacy blind-box AI state.
- Keep the old bounded current-video summary, cited-fragment Q&A, and segment rerank paths local-only. Enabling the new authorization still does not call those legacy chat paths.
- Keep the existing Dexie all-table transaction and `chrome.storage.local.clear()` production behavior. SET-013-A only establishes the shared category lifecycle contract; SET-013-B remains responsible for category orchestration and partial-failure UI.

## Second rework
- Failed settings persistence now runs through a behavior-tested state-transition helper used by `SettingsPage`. A rejected persist keeps the service URL, model, API Key input, and all three toggle drafts, leaves the persisted config unapplied, and returns a natural Chinese unsaved error.
- Successful persistence applies the normalized persisted config and clears only the submitted Key input while retaining the saved Key state.
- Category lifecycle success now requires `empty=true`, `count=0`, and `usageBytes=0`. Any residual signal returns `failedStage='readback'`, `failureReason='data_remaining'`, the actual readback value, and a natural Chinese failed-category message.

## Rework baseline
- Previous HEAD: `9adb5835d43e823b4ad0d29bef2b5d36946d9fb9`
- New HEAD: `d5746516ed027b6a76df9eda82d2d1d13ebb96f1`
- No rebase and no force-push. The second rework was added as a normal commit on the same branch and draft PR.

## Validation
- Focused rework run passed 41/41: settings migration and save transitions, local-data privacy/registry lifecycle, current-video summary, Q&A, segment rerank, and AI connection.
- Full repository run passed 169/169 tests across all 25 `tests/*.test.ts` files.
- `npm.cmd run typecheck` passed.
- `npm.cmd run build` passed. Vite emitted only the existing dynamic/static import and large `chunks/theme-*.js` warnings.
- `git diff --check` and `git diff --cached --check` passed.
- Changed-production copy scan found no prohibited ordinary-user copy or raw engineering fields.

## Browser / mock QA
- Passed against `http://127.0.0.1:4174/tests/settings-mvp.mock.html` through a local Vite server, alongside the executable production-helper behavior tests above.
- Desktop `1280x720`: after a simulated rejected save, the draft service URL, model, synthetic Key input, and all three toggles remained unchanged; the unsaved message remained visible after navigating to Smart Favorites and back.
- Mobile `390x844`: the same failed-save draft stayed intact, with no horizontal overflow or controls outside the viewport.
- No browser console warnings/errors and no prohibited visible-copy matches.

## Privacy
- Did not read Cookie files, browser profiles, Bilibili login-state files, local key files, or `C:\Users\LittleNub\Desktop\Key.txt`.
- Did not read real full history, favorites, following, feedback, or IndexedDB contents.
- Browser QA used synthetic draft values only and did not inspect browser storage or credentials.

## Scope guard
- No current-video full-text request implementation.
- No new feature data tables, cleanup entry points, or registry-driven production clear-all orchestration.
- No #82/#83 work and no release, tag, package version, or release asset changes.
