### PR TITLE
[0.13][BB-013-B] 视频盲盒失败状态与最近 50 条去重

### DIFF
--- a/src/background/analytics/suggestions.ts
+++ b/src/background/analytics/suggestions.ts
@@ -26,8 +26,9 @@ import type {
 } from '../api/video-blind-box-candidates.ts';
 import { db } from '../storage/db.ts';
 import {
-  getBlindBoxRecentDrawnBvids,
-  recordBlindBoxDrawnBvids,
+  claimBlindBoxDrawHistory,
+  getBlindBoxDrawHistoryEpoch,
+  type BlindBoxDrawHistoryStorage,
 } from '../storage/blind-box-draw-history-repo.ts';
 import { getFavoriteItems, getSmartFavoriteIndexMap } from '../storage/favorite-repo.ts';
 
@@ -84,12 +85,12 @@ type BlindBoxBoundaryMeta = Pick<
 export async function getExperimentData(options: ExperimentRuntimeOptions = {}): Promise<ExperimentData> {
   const nowMs = Date.now();
   const random = options.random ?? Math.random;
-  const [records, favorites, smartIndexByItemKey, followedCreators, recentDrawnBvids] = await Promise.all([
+  const drawHistoryEpoch = getBlindBoxDrawHistoryEpoch();
+  const [records, favorites, smartIndexByItemKey, followedCreators] = await Promise.all([
     db.watchHistory.toArray(),
     getFavoriteItems(),
     getSmartFavoriteIndexMap(),
     db.followedCreators.toArray().then(creators => creators.filter(creator => creator.isActive !== false)),
-    getBlindBoxRecentDrawnBvids(),
   ]);
   const [randomExplorePool, crossRegionPool, creatorArchivePool] = await Promise.all([
     fetchRandomExploreCandidatePool(records, nowMs),
@@ -99,18 +100,36 @@ export async function getExperimentData(options: ExperimentRuntimeOptions = {}):
       .catch(error => buildCreatorArchiveSourceFailure(followedCreators, nowMs, error, { random })),
   ]);
 
-  const data = buildExperimentData(records, favorites, smartIndexByItemKey, nowMs, {
+  return buildClaimedExperimentData(records, favorites, smartIndexByItemKey, nowMs, {
     random,
     randomExplorePool,
     crossRegionPool,
     creatorArchivePool,
-    recentDrawnBvids,
-  });
-  const drawnBvids = getSuccessfulBlindBoxDrawBvids(data.blindBoxes);
-  if (drawnBvids.length > 0) {
-    await recordBlindBoxDrawnBvids(drawnBvids);
-  }
-  return data;
+  }, drawHistoryEpoch);
+}
+
+export async function buildClaimedExperimentData(
+  records: WatchHistoryRecord[],
+  favorites: FavoriteItem[],
+  smartIndexByItemKey: Map<string, SmartFavoriteIndex>,
+  nowMs: number,
+  options: ExperimentBuildOptions = {},
+  drawHistoryEpoch: number = getBlindBoxDrawHistoryEpoch(),
+  storage?: BlindBoxDrawHistoryStorage,
+): Promise<ExperimentData> {
+  return claimBlindBoxDrawHistory(drawHistoryEpoch, recentDrawnBvids => {
+    const data = buildExperimentData(records, favorites, smartIndexByItemKey, nowMs, {
+      ...options,
+      recentDrawnBvids: [
+        ...(options.recentDrawnBvids ?? []),
+        ...recentDrawnBvids,
+      ],
+    });
+    return {
+      value: data,
+      drawnBvids: getSuccessfulBlindBoxDrawBvids(data.blindBoxes),
+    };
+  }, storage);
 }
 
 export async function fetchRandomExploreCandidatePool(

--- a/src/background/analytics/suggestions.ts
+++ b/src/background/analytics/suggestions.ts
@@ -204,7 +204,7 @@ function realCandidateUnavailableMeta(candidateSource: string, reason: string): 
 function localFavoriteMeta(): BlindBoxBoundaryMeta {
   return {
     candidateSource: LOCAL_FAVORITE_SOURCE,
-    realCandidateLabel: '未使用真实 B 站候选：这是本地收藏回访。',
+    realCandidateLabel: '本卡不使用；固定从本地收藏回访。',
     usesRealBilibiliCandidates: false,
   };
 }
@@ -398,9 +398,7 @@ function buildHiddenFavoriteBox(ctx: BlindBoxContext): ExperimentBlindBox {
       hasOnlyUnopenableFavorites
         ? '本地收藏返回了记录，但没有可打开的视频。'
         : '本地收藏里暂时没有足够冷门的回访候选。',
-      hasOnlyUnopenableFavorites
-        ? realCandidateUnavailableMeta(LOCAL_FAVORITE_SOURCE, '本轮本地收藏候选暂时不能打开。')
-        : localFavoriteMeta(),
+      localFavoriteMeta(),
     );
   }
 
@@ -555,7 +553,7 @@ function buildRandomExploreBox(ctx: BlindBoxContext): ExperimentBlindBox {
       ['本地还没有可作为公开相关视频候选种子的近期视频。'],
       '当前没有可用于探索的近期视频',
       '随机探索需要先用最近少量本地历史作为种子，请求 B 站公开视频的相关视频候选池。当前没有合格种子，因此没有发出相关候选请求。',
-      '候选源未准备好',
+      '没有可用种子',
       sourceLabel,
       '没有可请求的种子，未生成空白视频卡。',
       realCandidateUnavailableMeta(RELATED_CANDIDATE_SOURCE, '缺少可请求的本地近期视频。'),

--- a/src/background/analytics/suggestions.ts
+++ b/src/background/analytics/suggestions.ts
@@ -1,4 +1,5 @@
 import type {
+  ExperimentCandidateFailureKind,
   ExperimentBlindBox,
   ExperimentBlindBoxId,
   ExperimentData,
@@ -24,6 +25,10 @@ import type {
   RelatedVideoSeed,
 } from '../api/video-blind-box-candidates.ts';
 import { db } from '../storage/db.ts';
+import {
+  getBlindBoxRecentDrawnBvids,
+  recordBlindBoxDrawnBvids,
+} from '../storage/blind-box-draw-history-repo.ts';
 import { getFavoriteItems, getSmartFavoriteIndexMap } from '../storage/favorite-repo.ts';
 
 const DAY_MS = 86_400_000;
@@ -47,7 +52,7 @@ interface BlindBoxContext {
   recentBvids: Set<string>;
   watchCountByBvid: Map<string, number>;
   lastWatchByBvid: Map<string, number>;
-  usedBvids: Set<string>;
+  recentDrawnBvids: Set<string>;
   random: BlindBoxRandomSource;
   randomExplorePool?: ExperimentRealCandidatePool;
   crossRegionPool?: CrossRegionCandidatePool;
@@ -59,6 +64,7 @@ interface ExperimentBuildOptions {
   randomExplorePool?: ExperimentRealCandidatePool;
   crossRegionPool?: CrossRegionCandidatePool;
   creatorArchivePool?: CreatorArchiveCandidatePool;
+  recentDrawnBvids?: string[];
 }
 
 interface ExperimentRuntimeOptions {
@@ -78,11 +84,12 @@ type BlindBoxBoundaryMeta = Pick<
 export async function getExperimentData(options: ExperimentRuntimeOptions = {}): Promise<ExperimentData> {
   const nowMs = Date.now();
   const random = options.random ?? Math.random;
-  const [records, favorites, smartIndexByItemKey, followedCreators] = await Promise.all([
+  const [records, favorites, smartIndexByItemKey, followedCreators, recentDrawnBvids] = await Promise.all([
     db.watchHistory.toArray(),
     getFavoriteItems(),
     getSmartFavoriteIndexMap(),
     db.followedCreators.toArray().then(creators => creators.filter(creator => creator.isActive !== false)),
+    getBlindBoxRecentDrawnBvids(),
   ]);
   const [randomExplorePool, crossRegionPool, creatorArchivePool] = await Promise.all([
     fetchRandomExploreCandidatePool(records, nowMs),
@@ -92,12 +99,18 @@ export async function getExperimentData(options: ExperimentRuntimeOptions = {}):
       .catch(error => buildCreatorArchiveSourceFailure(followedCreators, nowMs, error, { random })),
   ]);
 
-  return buildExperimentData(records, favorites, smartIndexByItemKey, nowMs, {
+  const data = buildExperimentData(records, favorites, smartIndexByItemKey, nowMs, {
     random,
     randomExplorePool,
     crossRegionPool,
     creatorArchivePool,
+    recentDrawnBvids,
   });
+  const drawnBvids = getSuccessfulBlindBoxDrawBvids(data.blindBoxes);
+  if (drawnBvids.length > 0) {
+    await recordBlindBoxDrawnBvids(drawnBvids);
+  }
+  return data;
 }
 
 export async function fetchRandomExploreCandidatePool(
@@ -145,7 +158,7 @@ export function buildExperimentData(
     ),
     watchCountByBvid: countByBvid(records),
     lastWatchByBvid: buildLastWatchByBvid(records),
-    usedBvids: new Set<string>(),
+    recentDrawnBvids: new Set((options.recentDrawnBvids ?? []).filter(isLikelyBvid)),
     random: options.random ?? Math.random,
     randomExplorePool: options.randomExplorePool,
     crossRegionPool: options.crossRegionPool,
@@ -224,34 +237,31 @@ function buildCrossRegionBox(ctx: BlindBoxContext): ExperimentBlindBox {
       pool.evidence.length > 0 ? pool.evidence : ['没有留下可解释的真实候选池证据。'],
       crossRegionEmptyTitle(pool.status),
       crossRegionEmptyDescription(pool),
-      crossRegionEmptyStatusLabel(pool.status),
+      crossRegionEmptyStatusLabel(pool),
       pool.sourceLabel,
       crossRegionEmptyReason(pool),
       realCandidateUnavailableMeta(CROSS_REGION_CANDIDATE_SOURCE, crossRegionRealCandidateUnavailableReason(pool)),
     );
   }
 
-  const candidates = pool.candidates.filter(video => !ctx.usedBvids.has(video.bvid));
-  if (candidates.length === 0) {
+  const pick = pickBlindBoxCandidate(pool.candidates, ctx);
+  if (!pick) {
     return emptyBox(
       'cross_region',
       title,
       teaser,
       [
         ...pool.evidence,
-        `真实候选池有 ${pool.candidates.length} 条，但都已被本页其他盲盒占用。`,
+        `真实候选池返回 ${pool.candidates.length} 条，但没有留下可打开的视频。`,
       ],
-      '本页候选已经用完',
-      '跨区漫游不会改用本地历史、收藏或其他盲盒来源。刷新后可重新抽取公开分区候选。',
-      '本页候选已占用',
+      '这次没有可打开的分区新视频',
+      '跨区漫游已经取得本轮分区候选，但这些候选暂时不能打开。当前不会改用本地历史、收藏或其他盲盒来源。',
+      '候选不可打开',
       pool.sourceLabel,
-      '真实候选池有结果，但经过本页占用过滤后没有剩余视频。',
-      realCandidateUnavailableMeta(CROSS_REGION_CANDIDATE_SOURCE, '候选经过本页占用过滤后没有剩余视频。'),
+      '真实候选池返回了结果，但没有可打开的视频。',
+      realCandidateUnavailableMeta(CROSS_REGION_CANDIDATE_SOURCE, '本轮候选暂时不能打开。'),
     );
   }
-
-  const pick = pickRandomCandidate(candidates, ctx.random)!;
-  ctx.usedBvids.add(pick.bvid);
 
   return {
     id: 'cross_region',
@@ -283,32 +293,48 @@ function buildCrossRegionReason(
 }
 
 function crossRegionEmptyTitle(status: CrossRegionCandidatePool['status']): string {
-  return status === 'no_available_region'
-    ? '本轮没有可漫游的公开分区'
-    : '这次没有取得可打开的分区新视频';
+  if (status === 'no_available_region') return '本轮没有可漫游的公开分区';
+  return '这次没有取得可打开的分区新视频';
 }
 
 function crossRegionEmptyDescription(pool: CrossRegionCandidatePool): string {
   if (pool.status === 'no_available_region') {
     return '固定公开分区目录在排除近期高频分区后没有剩余方向，跨区漫游不会退回近期高频分区或其他盲盒来源。';
   }
+  if (pool.failureKind === 'upstream_failed') {
+    return '这次没有从 B 站接口取得可打开的分区新视频。请刷新后重试；当前不会改用本地历史、收藏或其他盲盒来源。';
+  }
+  if (pool.failureKind === 'no_real_candidates') {
+    return '本轮公开分区没有返回真实视频候选。跨区漫游会停在这个状态，不会切换到本地历史、收藏或其他盲盒来源。';
+  }
+  if (pool.failureKind === 'no_openable_candidates') {
+    return '本轮公开分区返回了候选，但没有留下可打开的视频。当前不会改用本地历史、收藏或其他盲盒来源。';
+  }
   return '这次没有取得可打开的分区新视频。刷新后可重试，当前不会改用本地历史、收藏或其他盲盒来源。';
 }
 
 function crossRegionEmptyReason(pool: CrossRegionCandidatePool): string {
-  return pool.status === 'no_available_region'
-    ? '排除近期高频分区后没有剩余公开分区。'
-    : '本轮公开分区新视频候选池没有留下可打开视频。';
+  if (pool.status === 'no_available_region') return '排除近期高频分区后没有剩余公开分区。';
+  if (pool.failureKind === 'upstream_failed') return '本轮分区候选源接口暂时失败。';
+  if (pool.failureKind === 'no_real_candidates') return '本轮公开分区没有返回真实视频候选。';
+  if (pool.failureKind === 'no_openable_candidates') return '本轮公开分区返回了候选，但没有可打开的视频。';
+  return '本轮公开分区新视频候选池没有留下可打开视频。';
 }
 
 function crossRegionRealCandidateUnavailableReason(pool: CrossRegionCandidatePool): string {
-  return pool.status === 'no_available_region'
-    ? '排除近期高频分区后没有剩余公开分区。'
-    : '本轮没有可打开的分区新视频。';
+  if (pool.status === 'no_available_region') return '排除近期高频分区后没有剩余公开分区。';
+  if (pool.failureKind === 'upstream_failed') return '分区候选源接口暂时失败。';
+  if (pool.failureKind === 'no_real_candidates') return '本轮公开分区没有返回真实候选。';
+  if (pool.failureKind === 'no_openable_candidates') return '本轮候选暂时不能打开。';
+  return '本轮没有可打开的分区新视频。';
 }
 
-function crossRegionEmptyStatusLabel(status: CrossRegionCandidatePool['status']): string {
-  return status === 'no_available_region' ? '无可用分区' : '真实候选为空';
+function crossRegionEmptyStatusLabel(pool: CrossRegionCandidatePool): string {
+  if (pool.status === 'no_available_region') return '无可用分区';
+  if (pool.failureKind === 'upstream_failed') return '接口暂时失败';
+  if (pool.failureKind === 'no_real_candidates') return '没有真实候选';
+  if (pool.failureKind === 'no_openable_candidates') return '候选不可打开';
+  return '真实候选为空';
 }
 
 function buildHiddenFavoriteBox(ctx: BlindBoxContext): ExperimentBlindBox {
@@ -327,10 +353,15 @@ function buildHiddenFavoriteBox(ctx: BlindBoxContext): ExperimentBlindBox {
     );
   }
 
+  let invalidFavoriteCount = 0;
   const candidates = ctx.favorites
     .map(item => {
       const video = toFavoriteVideo(item);
-      if (!video || ctx.usedBvids.has(video.bvid) || ctx.recentBvids.has(video.bvid)) return null;
+      if (!video) {
+        invalidFavoriteCount += 1;
+        return null;
+      }
+      if (ctx.recentBvids.has(video.bvid)) return null;
 
       const watchCount = ctx.watchCountByBvid.get(video.bvid) ?? 0;
       const lastWatchMs = ctx.lastWatchByBvid.get(video.bvid) ?? 0;
@@ -350,22 +381,30 @@ function buildHiddenFavoriteBox(ctx: BlindBoxContext): ExperimentBlindBox {
     .filter((candidate): candidate is NonNullable<typeof candidate> => Boolean(candidate));
 
   if (candidates.length === 0) {
+    const hasOnlyUnopenableFavorites = invalidFavoriteCount > 0 && invalidFavoriteCount === ctx.favorites.length;
     return emptyBox(
       'hidden_favorite',
       '冷门收藏',
       '从本地收藏里翻出被你压箱底的一条。',
-      [`本地收藏 ${ctx.favorites.length} 条，但最近 ${RECENT_VIDEO_BLOCK_DAYS} 天都还比较活跃。`],
-      '压箱底的视频还没攒出来',
-      '当前收藏里最近都还在看，或者收藏时间太新，暂时没有那种“你留过但快忘了”的冷门收藏。',
-      '本地收藏暂不符合',
+      hasOnlyUnopenableFavorites
+        ? [`本地收藏 ${ctx.favorites.length} 条，但缺少可打开的视频身份。`]
+        : [`本地收藏 ${ctx.favorites.length} 条，但最近 ${RECENT_VIDEO_BLOCK_DAYS} 天都还比较活跃。`],
+      hasOnlyUnopenableFavorites ? '本地收藏暂时打不开' : '压箱底的视频还没攒出来',
+      hasOnlyUnopenableFavorites
+        ? '这批本地收藏缺少可打开的视频身份，冷门收藏不会改用外部候选或其他盲盒来源。'
+        : '当前收藏里最近都还在看，或者收藏时间太新，暂时没有那种“你留过但快忘了”的冷门收藏。',
+      hasOnlyUnopenableFavorites ? '候选不可打开' : '本地收藏暂不符合',
       LOCAL_FAVORITE_SOURCE,
-      '本地收藏里暂时没有足够冷门的回访候选。',
-      localFavoriteMeta(),
+      hasOnlyUnopenableFavorites
+        ? '本地收藏返回了记录，但没有可打开的视频。'
+        : '本地收藏里暂时没有足够冷门的回访候选。',
+      hasOnlyUnopenableFavorites
+        ? realCandidateUnavailableMeta(LOCAL_FAVORITE_SOURCE, '本轮本地收藏候选暂时不能打开。')
+        : localFavoriteMeta(),
     );
   }
 
-  const pick = pickRandomCandidate(candidates, ctx.random)!;
-  ctx.usedBvids.add(pick.video.bvid);
+  const pick = pickBlindBoxCandidate(candidates, ctx, candidate => candidate.video)!;
 
   return {
     id: 'hidden_favorite',
@@ -416,34 +455,31 @@ function buildCreatorArchiveBox(ctx: BlindBoxContext): ExperimentBlindBox {
       pool.evidence.length > 0 ? pool.evidence : ['没有留下可解释的公开投稿候选池证据。'],
       creatorArchiveEmptyTitle(pool.status),
       creatorArchiveEmptyDescription(pool),
-      creatorArchiveEmptyStatusLabel(pool.status),
+      creatorArchiveEmptyStatusLabel(pool),
       pool.sourceLabel,
       creatorArchiveEmptyReason(pool),
       realCandidateUnavailableMeta(CREATOR_ARCHIVE_CANDIDATE_SOURCE, creatorArchiveRealCandidateUnavailableReason(pool)),
     );
   }
 
-  const candidates = pool.candidates.filter(video => !ctx.usedBvids.has(video.bvid));
-  if (candidates.length === 0) {
+  const pick = pickBlindBoxCandidate(pool.candidates, ctx);
+  if (!pick) {
     return emptyBox(
       'creator_archive',
       title,
       teaser,
       [
         ...pool.evidence,
-        `公开较早投稿候选池有 ${pool.candidates.length} 条，但都已被本页其他盲盒占用。`,
+        `公开较早投稿候选池返回 ${pool.candidates.length} 条，但没有留下可打开的视频。`,
       ],
-      '本页候选已经用完',
-      'UP 主考古不会改用本地历史、收藏或最近 7 天新投稿。刷新后可重新抽取公开投稿候选。',
-      '本页候选已占用',
+      '这次没有可打开的较早投稿',
+      'UP 主考古已经取得本轮公开投稿候选，但这些候选暂时不能打开。当前不会改用本地历史、收藏或最近 7 天新投稿。',
+      '候选不可打开',
       pool.sourceLabel,
-      '公开较早投稿候选池有结果，但经过本页占用过滤后没有剩余视频。',
-      realCandidateUnavailableMeta(CREATOR_ARCHIVE_CANDIDATE_SOURCE, '候选经过本页占用过滤后没有剩余视频。'),
+      '公开较早投稿候选池返回了结果，但没有可打开的视频。',
+      realCandidateUnavailableMeta(CREATOR_ARCHIVE_CANDIDATE_SOURCE, '本轮候选暂时不能打开。'),
     );
   }
-
-  const pick = pickRandomCandidate(candidates, ctx.random)!;
-  ctx.usedBvids.add(pick.bvid);
 
   return {
     id: 'creator_archive',
@@ -472,23 +508,40 @@ function creatorArchiveEmptyDescription(pool: CreatorArchiveCandidatePool): stri
   if (pool.status === 'no_followed_creator') {
     return '需要先同步关注快照，UP 主考古才知道该从哪些已关注 UP 的公开投稿里抽取。';
   }
+  if (pool.failureKind === 'upstream_failed') {
+    return '这次没有从公开 UP 空间取得可打开的较早投稿。请刷新后重试；当前不会改用本地历史、收藏或最近 7 天新投稿。';
+  }
+  if (pool.failureKind === 'no_real_candidates') {
+    return '本轮已关注 UP 没有返回可用于考古的较早投稿。UP 主考古会停在这个状态，不会改用其他盲盒来源。';
+  }
+  if (pool.failureKind === 'no_openable_candidates') {
+    return '本轮公开投稿返回了候选，但没有留下可打开的视频。当前不会改用本地历史、收藏或最近 7 天新投稿。';
+  }
   return '这次没有取得可打开的较早投稿。刷新后可重试，当前不会改用本地历史、收藏或最近 7 天新投稿。';
 }
 
 function creatorArchiveEmptyReason(pool: CreatorArchiveCandidatePool): string {
-  return pool.status === 'no_followed_creator'
-    ? '本地没有已同步关注 UP 快照，暂不请求公开投稿。'
-    : '本轮公开投稿候选池没有留下可打开的较早投稿。';
+  if (pool.status === 'no_followed_creator') return '本地没有已同步关注 UP 快照，暂不请求公开投稿。';
+  if (pool.failureKind === 'upstream_failed') return '本轮公开投稿候选源接口暂时失败。';
+  if (pool.failureKind === 'no_real_candidates') return '本轮已关注 UP 没有返回可用于考古的较早投稿。';
+  if (pool.failureKind === 'no_openable_candidates') return '本轮公开投稿返回了候选，但没有可打开的视频。';
+  return '本轮公开投稿候选池没有留下可打开的较早投稿。';
 }
 
 function creatorArchiveRealCandidateUnavailableReason(pool: CreatorArchiveCandidatePool): string {
-  return pool.status === 'no_followed_creator'
-    ? '缺少已同步关注 UP 快照。'
-    : '本轮没有可打开的较早投稿。';
+  if (pool.status === 'no_followed_creator') return '缺少已同步关注 UP 快照。';
+  if (pool.failureKind === 'upstream_failed') return '公开投稿候选源接口暂时失败。';
+  if (pool.failureKind === 'no_real_candidates') return '本轮没有真实较早投稿候选。';
+  if (pool.failureKind === 'no_openable_candidates') return '本轮候选暂时不能打开。';
+  return '本轮没有可打开的较早投稿。';
 }
 
-function creatorArchiveEmptyStatusLabel(status: CreatorArchiveCandidatePool['status']): string {
-  return status === 'no_followed_creator' ? '关注快照未同步' : '真实候选为空';
+function creatorArchiveEmptyStatusLabel(pool: CreatorArchiveCandidatePool): string {
+  if (pool.status === 'no_followed_creator') return '关注快照未同步';
+  if (pool.failureKind === 'upstream_failed') return '接口暂时失败';
+  if (pool.failureKind === 'no_real_candidates') return '没有真实候选';
+  if (pool.failureKind === 'no_openable_candidates') return '候选不可打开';
+  return '真实候选为空';
 }
 
 function buildRandomExploreBox(ctx: BlindBoxContext): ExperimentBlindBox {
@@ -510,9 +563,10 @@ function buildRandomExploreBox(ctx: BlindBoxContext): ExperimentBlindBox {
   }
 
   const pool = ctx.randomExplorePool.candidates
-    .filter(candidate => !ctx.usedBvids.has(candidate.bvid) && !ctx.recentBvids.has(candidate.bvid));
+    .filter(candidate => !ctx.recentBvids.has(candidate.bvid));
+  const pick = pickBlindBoxCandidate(pool, ctx);
 
-  if (pool.length === 0) {
+  if (!pick) {
     const failureSummary = formatRelatedCandidateFailures(ctx.randomExplorePool);
     return emptyBox(
       'random_explore',
@@ -521,19 +575,16 @@ function buildRandomExploreBox(ctx: BlindBoxContext): ExperimentBlindBox {
       [
         `已尝试 ${ctx.randomExplorePool.seedCount} 个种子视频的相关视频候选。`,
         failureSummary,
-        `同时会排除最近 ${RECENT_VIDEO_BLOCK_DAYS} 天看过的视频和本页其它盲盒已占用的视频。`,
+        `同时会排除最近 ${RECENT_VIDEO_BLOCK_DAYS} 天看过的视频；最近抽中过的视频只会在有其它候选时避开。`,
       ],
-      '相关视频候选暂时不可用',
-      '这次没有拿到可安全展示的真实候选，Bili-Bill 不会用本地库存视频冒充随机探索候选。',
-      '候选源暂不可用',
+      relatedEmptyTitle(ctx.randomExplorePool),
+      relatedEmptyDescription(ctx.randomExplorePool, pool.length),
+      relatedEmptyStatusLabel(ctx.randomExplorePool),
       sourceLabel,
-      '真实候选源失败或为空，未生成空白视频卡。',
-      realCandidateUnavailableMeta(RELATED_CANDIDATE_SOURCE, '候选源失败、为空或过滤后无可打开视频。'),
+      relatedEmptyReason(ctx.randomExplorePool, pool.length),
+      realCandidateUnavailableMeta(RELATED_CANDIDATE_SOURCE, relatedRealCandidateUnavailableReason(ctx.randomExplorePool, pool.length)),
     );
   }
-
-  const pick = pickRandomCandidate(pool, ctx.random)!;
-  ctx.usedBvids.add(pick.bvid);
 
   return {
     id: 'random_explore',
@@ -541,10 +592,10 @@ function buildRandomExploreBox(ctx: BlindBoxContext): ExperimentBlindBox {
     teaser,
     ...realCandidateUsedMeta(RELATED_CANDIDATE_SOURCE),
     source: `${sourceLabel} / 种子视频「${pick.seedTitle || pick.seedBvid}」`,
-    reason: `Bili-Bill 只保留可打开的公开相关视频候选，并在 ${pool.length} 条候选里随机抽取一条；不会从本地历史或收藏库存补位。`,
+    reason: `Bili-Bill 只保留可打开的公开相关视频候选，并在本轮候选池里随机抽取一条；不会从本地历史或收藏库存补位。`,
     evidence: [
       `候选来自 B 站公开视频的相关视频候选池，使用 ${ctx.randomExplorePool.seedCount} 个本地种子视频逐个请求。`,
-      `抽取前已排除最近 ${RECENT_VIDEO_BLOCK_DAYS} 天看过的视频，以及其它盲盒已经占用的候选。`,
+      `抽取前已排除最近 ${RECENT_VIDEO_BLOCK_DAYS} 天看过的视频；最近抽中过的视频只作为短期避让记录。`,
       `本次种子视频：${pick.seedTitle || pick.seedBvid}。`,
     ],
     state: 'ready',
@@ -580,7 +631,7 @@ export function selectRelatedVideoSeeds(records: WatchHistoryRecord[], nowMs: nu
 
 function formatRelatedCandidateFailures(pool: ExperimentRealCandidatePool): string {
   if (pool.candidates.length > 0) {
-    return `相关视频候选返回 ${pool.candidates.length} 条，但都已被近期观看、重复候选或其它盲盒占用。`;
+    return `相关视频候选返回 ${pool.candidates.length} 条，但都已被近期观看过滤，或暂时不能打开。`;
   }
   if (pool.failures.length === 0) {
     return '相关视频候选没有返回可展示的视频。';
@@ -597,6 +648,67 @@ function formatRelatedCandidateFailures(pool: ExperimentRealCandidatePool): stri
   ].filter(Boolean);
 
   return `相关视频候选暂不可用：${parts.join('，') || '未返回有效候选'}。`;
+}
+
+function relatedEmptyTitle(pool: ExperimentRealCandidatePool): string {
+  if (pool.failureKind === 'upstream_failed') return '相关视频候选源暂时失败';
+  if (pool.failureKind === 'no_real_candidates') return '这次没有取得真实相关视频候选';
+  if (pool.failureKind === 'no_openable_candidates') return '这次没有可打开的相关视频';
+  return '相关视频候选暂时不可用';
+}
+
+function relatedEmptyDescription(pool: ExperimentRealCandidatePool, filteredCandidateCount: number): string {
+  const kind = relatedFailureKind(pool, filteredCandidateCount);
+  if (kind === 'upstream_failed') {
+    return '这次没有从 B 站接口取得可打开的相关视频。请刷新后重试；随机探索不会用本地库存视频冒充真实候选。';
+  }
+  if (kind === 'no_real_candidates') {
+    return '本轮种子没有返回真实相关视频候选。随机探索会停在这个状态，不会改用收藏、分区或其他盲盒来源。';
+  }
+  if (kind === 'no_openable_candidates') {
+    return '本轮相关视频返回了候选，但没有留下可打开的视频。随机探索不会用本地库存视频冒充真实候选。';
+  }
+  if (pool.candidates.length > 0 && filteredCandidateCount === 0) {
+    return '本轮相关视频候选都已在近期看过。随机探索不会用本地库存视频补位，请刷新后重试。';
+  }
+  return '这次没有拿到可安全展示的真实候选，Bili-Bill 不会用本地库存视频冒充随机探索候选。';
+}
+
+function relatedEmptyStatusLabel(pool: ExperimentRealCandidatePool): string {
+  if (pool.failureKind === 'upstream_failed') return '接口暂时失败';
+  if (pool.failureKind === 'no_real_candidates') return '没有真实候选';
+  if (pool.failureKind === 'no_openable_candidates') return '候选不可打开';
+  return '候选源暂不可用';
+}
+
+function relatedEmptyReason(pool: ExperimentRealCandidatePool, filteredCandidateCount: number): string {
+  const kind = relatedFailureKind(pool, filteredCandidateCount);
+  if (kind === 'upstream_failed') return '相关视频候选源接口暂时失败。';
+  if (kind === 'no_real_candidates') return '本轮种子没有返回真实相关视频候选。';
+  if (kind === 'no_openable_candidates') return '本轮相关视频返回了候选，但没有可打开的视频。';
+  if (pool.candidates.length > 0 && filteredCandidateCount === 0) return '本轮真实相关视频候选都已在近期看过。';
+  return '真实候选源失败或为空，未生成空白视频卡。';
+}
+
+function relatedRealCandidateUnavailableReason(
+  pool: ExperimentRealCandidatePool,
+  filteredCandidateCount: number,
+): string {
+  const kind = relatedFailureKind(pool, filteredCandidateCount);
+  if (kind === 'upstream_failed') return '相关视频候选源接口暂时失败。';
+  if (kind === 'no_real_candidates') return '本轮种子没有返回真实候选。';
+  if (kind === 'no_openable_candidates') return '本轮候选暂时不能打开。';
+  if (pool.candidates.length > 0 && filteredCandidateCount === 0) return '本轮候选都已在近期看过。';
+  return '候选源失败、为空或过滤后无可打开视频。';
+}
+
+function relatedFailureKind(
+  pool: ExperimentRealCandidatePool,
+  filteredCandidateCount: number,
+): ExperimentCandidateFailureKind | undefined {
+  if (pool.failureKind) return pool.failureKind;
+  if (pool.candidates.length > 0 && filteredCandidateCount > 0) return 'no_openable_candidates';
+  return undefined;
 }
 
 function emptyBox(
@@ -626,15 +738,59 @@ function emptyBox(
   };
 }
 
+export function getSuccessfulBlindBoxDrawBvids(boxes: ExperimentBlindBox[]): string[] {
+  const bvids: string[] = [];
+  const seen = new Set<string>();
+
+  for (const box of boxes) {
+    if (box.state !== 'ready' || !isOpenableVideoCandidate(box.video)) continue;
+    if (seen.has(box.video.bvid)) continue;
+    seen.add(box.video.bvid);
+    bvids.push(box.video.bvid);
+  }
+
+  return bvids;
+}
+
+function pickBlindBoxCandidate<T>(
+  items: readonly T[],
+  ctx: BlindBoxContext,
+  getVideo: (item: T) => ExperimentVideoCandidate | undefined = item => item as ExperimentVideoCandidate,
+): T | undefined {
+  const validItems = items.filter(item => isOpenableVideoCandidate(getVideo(item)));
+  if (validItems.length === 0) return undefined;
+
+  const unseenItems = validItems.filter(item => {
+    const video = getVideo(item);
+    return video ? !ctx.recentDrawnBvids.has(video.bvid) : false;
+  });
+  const pick = pickRandomCandidate(unseenItems.length > 0 ? unseenItems : validItems, ctx.random);
+  const video = pick ? getVideo(pick) : undefined;
+  if (video) {
+    ctx.recentDrawnBvids.add(video.bvid);
+  }
+  return pick;
+}
+
+function isOpenableVideoCandidate(video: ExperimentVideoCandidate | undefined): video is ExperimentVideoCandidate {
+  return Boolean(
+    video
+      && isLikelyBvid(cleanText(video.bvid))
+      && cleanText(video.title)
+      && cleanText(video.url).startsWith(`https://www.bilibili.com/video/${encodeURIComponent(video.bvid)}`),
+  );
+}
+
 function toFavoriteVideo(item: FavoriteItem): ExperimentVideoCandidate | null {
-  if (!cleanText(item.bvid)) return null;
+  const bvid = cleanText(item.bvid);
+  if (!isLikelyBvid(bvid)) return null;
   return {
-    bvid: item.bvid,
+    bvid,
     avid: item.avid > 0 ? item.avid : undefined,
     title: cleanText(item.title) || '未命名收藏视频',
     authorName: cleanText(item.authorName) || '未知 UP',
     cover: cleanText(item.cover),
-    url: buildVideoUrl(item.bvid, item.avid),
+    url: buildVideoUrl(bvid, item.avid),
     sourceKind: 'local_favorite',
   };
 }

--- a/src/background/api/video-blind-box-candidates.ts
+++ b/src/background/api/video-blind-box-candidates.ts
@@ -1,4 +1,5 @@
 import type {
+  ExperimentCandidateFailureKind,
   ExperimentRealCandidateFailure,
   ExperimentRealCandidatePool,
   ExperimentRealVideoCandidate,
@@ -73,6 +74,7 @@ export interface CrossRegionCandidatePool {
   evidence: string[];
   checkedRegionCount: number;
   excludedInvalidCandidateCount: number;
+  failureKind?: ExperimentCandidateFailureKind;
 }
 
 export type CrossRegionCandidateRequest = (
@@ -109,6 +111,7 @@ export interface CreatorArchiveCandidatePool {
   checkedCreatorCount: number;
   excludedRecentSubmissionCount: number;
   excludedInvalidCandidateCount: number;
+  failureKind?: ExperimentCandidateFailureKind;
 }
 
 interface CreatorArchiveCandidateOptions {
@@ -270,6 +273,7 @@ export async function fetchRelatedVideoCandidates(
     seedCount: selectedSeeds.length,
     candidates,
     failures,
+    failureKind: classifyRelatedCandidateFailure(selectedSeeds.length, candidates, failures),
   };
 }
 
@@ -285,6 +289,7 @@ export function buildRelatedVideoSourceFailure(
     seedCount: selectedSeeds.length,
     candidates: [],
     failures: selectedSeeds.map(seed => toRelatedFailure(seed, 'request_failed')),
+    failureKind: selectedSeeds.length === 0 ? 'no_seed' : 'upstream_failed',
   };
 }
 
@@ -312,6 +317,7 @@ export async function fetchCrossRegionCandidatePool(
 
   const candidatesByBvid = new Map<string, ExperimentVideoCandidate>();
   let excludedInvalidCandidateCount = 0;
+  let fetchedArchiveCount = 0;
   const checkedRegionCount = 1;
   const request = options.request ?? requestCrossRegionCandidates;
 
@@ -325,7 +331,9 @@ export async function fetchCrossRegionCandidatePool(
       },
       options.signal,
     );
-    for (const archive of getRegionArchives(data)) {
+    const archives = getRegionArchives(data);
+    fetchedArchiveCount = archives.length;
+    for (const archive of archives) {
       const video = toRegionVideoCandidate(archive, selection.selectedRegion);
       if (!video) {
         excludedInvalidCandidateCount += 1;
@@ -348,6 +356,7 @@ export async function fetchCrossRegionCandidatePool(
       ],
       checkedRegionCount,
       excludedInvalidCandidateCount,
+      failureKind: 'upstream_failed',
     };
   }
 
@@ -377,6 +386,7 @@ export async function fetchCrossRegionCandidatePool(
     ],
     checkedRegionCount,
     excludedInvalidCandidateCount,
+    failureKind: fetchedArchiveCount > 0 ? 'no_openable_candidates' : 'no_real_candidates',
   };
 }
 
@@ -402,6 +412,7 @@ export function buildCrossRegionSourceFailure(
     ],
     checkedRegionCount: 0,
     excludedInvalidCandidateCount: 0,
+    failureKind: 'upstream_failed',
   };
 }
 
@@ -479,12 +490,15 @@ export async function fetchCreatorArchiveCandidatePool(
       checkedCreatorCount: 0,
       excludedRecentSubmissionCount: 0,
       excludedInvalidCandidateCount: 0,
+      failureKind: 'no_seed',
     };
   }
 
   const cutoffSeconds = Math.floor((nowMs - CREATOR_ARCHIVE_RECENT_BLOCK_DAYS * DAY_MS) / 1000);
   const candidatesByBvid = new Map<string, ExperimentVideoCandidate>();
   const failures: string[] = [];
+  let fetchedArchiveCount = 0;
+  let requestFailureCount = 0;
   let excludedRecentSubmissionCount = 0;
   let excludedInvalidCandidateCount = 0;
   const { biliGet } = await import('./client.ts');
@@ -504,7 +518,9 @@ export async function fetchCreatorArchiveCandidatePool(
         true,
         options.signal,
       );
-      for (const item of getSpaceArchives(data)) {
+      const archives = getSpaceArchives(data);
+      fetchedArchiveCount += archives.length;
+      for (const item of archives) {
         const candidate = toCreatorArchiveCandidate(item, seed);
         if (!candidate) {
           excludedInvalidCandidateCount += 1;
@@ -519,6 +535,7 @@ export async function fetchCreatorArchiveCandidatePool(
         }
       }
     } catch (error) {
+      requestFailureCount += 1;
       failures.push(`${seed.name}: ${readableCandidateError(error)}`);
     }
   }
@@ -556,6 +573,12 @@ export async function fetchCreatorArchiveCandidatePool(
     checkedCreatorCount: selectedSeeds.length,
     excludedRecentSubmissionCount,
     excludedInvalidCandidateCount,
+    failureKind: classifyCreatorArchiveFailure(
+      selectedSeeds.length,
+      requestFailureCount,
+      fetchedArchiveCount,
+      excludedInvalidCandidateCount,
+    ),
   };
 }
 
@@ -584,7 +607,33 @@ export function buildCreatorArchiveSourceFailure(
     checkedCreatorCount: 0,
     excludedRecentSubmissionCount: 0,
     excludedInvalidCandidateCount: 0,
+    failureKind: selectedSeeds.length > 0 ? 'upstream_failed' : 'no_seed',
   };
+}
+
+function classifyRelatedCandidateFailure(
+  seedCount: number,
+  candidates: ExperimentRealVideoCandidate[],
+  failures: ExperimentRealCandidateFailure[],
+): ExperimentCandidateFailureKind | undefined {
+  if (candidates.length > 0) return undefined;
+  if (seedCount === 0) return 'no_seed';
+  if (failures.some(failure => failure.reason === 'request_failed')) return 'upstream_failed';
+  if (failures.some(failure => failure.reason === 'no_valid_candidates')) return 'no_openable_candidates';
+  return 'no_real_candidates';
+}
+
+function classifyCreatorArchiveFailure(
+  seedCount: number,
+  requestFailureCount: number,
+  fetchedArchiveCount: number,
+  excludedInvalidCandidateCount: number,
+): ExperimentCandidateFailureKind {
+  if (seedCount === 0) return 'no_seed';
+  if (requestFailureCount >= seedCount && fetchedArchiveCount === 0) return 'upstream_failed';
+  if (fetchedArchiveCount === 0) return 'no_real_candidates';
+  if (excludedInvalidCandidateCount >= fetchedArchiveCount) return 'no_openable_candidates';
+  return 'no_real_candidates';
 }
 
 export function selectCreatorArchiveSeeds(
@@ -665,7 +714,7 @@ function buildCrossRegionSelectionEvidence(
   return [
     basis,
     `跨区漫游只使用仓库维护的固定公开分区目录和 B 站分区新视频接口，本轮候选分区为「${selectedRegionName}」。`,
-    `真实候选池返回 ${candidateCount} 条可打开视频；本切片不使用最近抽取记录去重，也不改用本地历史或收藏补位。`,
+    `真实候选池返回 ${candidateCount} 条可打开视频；抽取时会优先避开最近抽中过的视频，但不会改用本地历史或收藏补位。`,
   ];
 }
 

--- a/src/background/storage/blind-box-draw-history-repo.ts
+++ b/src/background/storage/blind-box-draw-history-repo.ts
@@ -14,21 +14,25 @@ export interface BlindBoxDrawHistoryStorage {
 
 export type BlindBoxDrawHistoryReadStorage = Pick<BlindBoxDrawHistoryStorage, 'get' | 'remove'>;
 
+let mutationTail: Promise<void> = Promise.resolve();
+
 export async function getBlindBoxRecentDrawnBvids(
   storage: Pick<BlindBoxDrawHistoryStorage, 'get'> = chrome.storage.local,
 ): Promise<string[]> {
-  const stored = await storage.get([BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]);
-  return normalizeBlindBoxDrawHistory(stored[BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]);
+  await mutationTail;
+  return readBlindBoxRecentDrawnBvids(storage);
 }
 
 export async function recordBlindBoxDrawnBvids(
   drawnBvids: string[],
   storage: BlindBoxDrawHistoryStorage = chrome.storage.local,
 ): Promise<string[]> {
-  const current = await getBlindBoxRecentDrawnBvids(storage);
-  const next = mergeBlindBoxDrawHistory(current, drawnBvids);
-  await storage.set({ [BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]: next });
-  return next;
+  return enqueueMutation(async () => {
+    const current = await readBlindBoxRecentDrawnBvids(storage);
+    const next = mergeBlindBoxDrawHistory(current, drawnBvids);
+    await storage.set({ [BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]: next });
+    return next;
+  });
 }
 
 export async function collectBlindBoxDrawHistoryUsage(
@@ -44,9 +48,11 @@ export async function collectBlindBoxDrawHistoryUsage(
 export async function clearBlindBoxDrawHistory(
   storage: BlindBoxDrawHistoryReadStorage,
 ): Promise<number> {
-  const before = await getBlindBoxRecentDrawnBvids(storage);
-  await storage.remove([BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]);
-  return before.length;
+  return enqueueMutation(async () => {
+    const before = await readBlindBoxRecentDrawnBvids(storage);
+    await storage.remove([BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]);
+    return before.length;
+  });
 }
 
 export async function readBlindBoxDrawHistoryAfterClear(
@@ -89,6 +95,22 @@ export function normalizeBlindBoxDrawHistory(value: unknown): string[] {
     if (result.length >= BLIND_BOX_DRAW_HISTORY_LIMIT) break;
   }
 
+  return result;
+}
+
+async function readBlindBoxRecentDrawnBvids(
+  storage: Pick<BlindBoxDrawHistoryStorage, 'get'>,
+): Promise<string[]> {
+  const stored = await storage.get([BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]);
+  return normalizeBlindBoxDrawHistory(stored[BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]);
+}
+
+function enqueueMutation<T>(mutation: () => Promise<T>): Promise<T> {
+  const result = mutationTail.then(mutation);
+  mutationTail = result.then(
+    () => undefined,
+    () => undefined,
+  );
   return result;
 }
 

--- a/src/background/storage/blind-box-draw-history-repo.ts
+++ b/src/background/storage/blind-box-draw-history-repo.ts
@@ -14,7 +14,17 @@ export interface BlindBoxDrawHistoryStorage {
 
 export type BlindBoxDrawHistoryReadStorage = Pick<BlindBoxDrawHistoryStorage, 'get' | 'remove'>;
 
+interface BlindBoxDrawHistoryClaim<T> {
+  value: T;
+  drawnBvids: string[];
+}
+
 let mutationTail: Promise<void> = Promise.resolve();
+let drawHistoryEpoch = 0;
+
+export function getBlindBoxDrawHistoryEpoch(): number {
+  return drawHistoryEpoch;
+}
 
 export async function getBlindBoxRecentDrawnBvids(
   storage: Pick<BlindBoxDrawHistoryStorage, 'get'> = chrome.storage.local,
@@ -35,6 +45,38 @@ export async function recordBlindBoxDrawnBvids(
   });
 }
 
+export async function claimBlindBoxDrawHistory<T>(
+  generationEpoch: number,
+  claim: (recentDrawnBvids: string[]) => BlindBoxDrawHistoryClaim<T> | Promise<BlindBoxDrawHistoryClaim<T>>,
+  storage: BlindBoxDrawHistoryStorage = chrome.storage.local,
+): Promise<T> {
+  return enqueueMutation(async () => {
+    const current = await readBlindBoxRecentDrawnBvids(storage);
+    const result = await claim(current);
+    if (generationEpoch !== drawHistoryEpoch) {
+      return result.value;
+    }
+
+    const drawnBvids = normalizeBlindBoxDrawHistory(result.drawnBvids);
+    if (drawnBvids.length > 0) {
+      const next = mergeBlindBoxDrawHistory(current, drawnBvids);
+      await storage.set({ [BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]: next });
+    }
+    return result.value;
+  });
+}
+
+export async function coordinateBlindBoxDrawHistoryClear<T>(
+  clear: (recentDrawnBvids: readonly string[]) => Promise<T>,
+  storage: Pick<BlindBoxDrawHistoryStorage, 'get'> = chrome.storage.local,
+): Promise<T> {
+  return enqueueMutation(async () => {
+    drawHistoryEpoch += 1;
+    const current = await readBlindBoxRecentDrawnBvids(storage);
+    return clear(current);
+  });
+}
+
 export async function collectBlindBoxDrawHistoryUsage(
   storage: Pick<BlindBoxDrawHistoryStorage, 'get'>,
 ): Promise<LocalDataCategoryUsage> {
@@ -48,11 +90,10 @@ export async function collectBlindBoxDrawHistoryUsage(
 export async function clearBlindBoxDrawHistory(
   storage: BlindBoxDrawHistoryReadStorage,
 ): Promise<number> {
-  return enqueueMutation(async () => {
-    const before = await readBlindBoxRecentDrawnBvids(storage);
+  return coordinateBlindBoxDrawHistoryClear(async before => {
     await storage.remove([BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]);
     return before.length;
-  });
+  }, storage);
 }
 
 export async function readBlindBoxDrawHistoryAfterClear(

--- a/src/background/storage/blind-box-draw-history-repo.ts
+++ b/src/background/storage/blind-box-draw-history-repo.ts
@@ -1,0 +1,105 @@
+import type {
+  LocalDataCategoryReadback,
+  LocalDataCategoryUsage,
+} from '../../shared/local-data-category-contract.ts';
+
+export const BLIND_BOX_DRAW_HISTORY_STORAGE_KEY = 'blindBoxRecentDrawnBvids';
+export const BLIND_BOX_DRAW_HISTORY_LIMIT = 50;
+
+export interface BlindBoxDrawHistoryStorage {
+  get: (keys: string[]) => Promise<Record<string, unknown>>;
+  set: (items: Record<string, unknown>) => Promise<void>;
+  remove: (keys: string[]) => Promise<void>;
+}
+
+export type BlindBoxDrawHistoryReadStorage = Pick<BlindBoxDrawHistoryStorage, 'get' | 'remove'>;
+
+export async function getBlindBoxRecentDrawnBvids(
+  storage: Pick<BlindBoxDrawHistoryStorage, 'get'> = chrome.storage.local,
+): Promise<string[]> {
+  const stored = await storage.get([BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]);
+  return normalizeBlindBoxDrawHistory(stored[BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]);
+}
+
+export async function recordBlindBoxDrawnBvids(
+  drawnBvids: string[],
+  storage: BlindBoxDrawHistoryStorage = chrome.storage.local,
+): Promise<string[]> {
+  const current = await getBlindBoxRecentDrawnBvids(storage);
+  const next = mergeBlindBoxDrawHistory(current, drawnBvids);
+  await storage.set({ [BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]: next });
+  return next;
+}
+
+export async function collectBlindBoxDrawHistoryUsage(
+  storage: Pick<BlindBoxDrawHistoryStorage, 'get'>,
+): Promise<LocalDataCategoryUsage> {
+  const bvids = await getBlindBoxRecentDrawnBvids(storage);
+  return {
+    count: bvids.length,
+    usageBytes: bvids.length > 0 ? serializedSize({ [BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]: bvids }) : 0,
+  };
+}
+
+export async function clearBlindBoxDrawHistory(
+  storage: BlindBoxDrawHistoryReadStorage,
+): Promise<number> {
+  const before = await getBlindBoxRecentDrawnBvids(storage);
+  await storage.remove([BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]);
+  return before.length;
+}
+
+export async function readBlindBoxDrawHistoryAfterClear(
+  storage: Pick<BlindBoxDrawHistoryStorage, 'get'>,
+): Promise<LocalDataCategoryReadback> {
+  const usage = await collectBlindBoxDrawHistoryUsage(storage);
+  return {
+    ...usage,
+    empty: usage.count === 0,
+  };
+}
+
+export function mergeBlindBoxDrawHistory(existing: unknown, drawnBvids: unknown): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+
+  for (const bvid of [
+    ...normalizeBlindBoxDrawHistory(drawnBvids),
+    ...normalizeBlindBoxDrawHistory(existing),
+  ]) {
+    if (seen.has(bvid)) continue;
+    seen.add(bvid);
+    result.push(bvid);
+    if (result.length >= BLIND_BOX_DRAW_HISTORY_LIMIT) break;
+  }
+
+  return result;
+}
+
+export function normalizeBlindBoxDrawHistory(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const result: string[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of value) {
+    const bvid = typeof raw === 'string' ? raw.trim() : '';
+    if (!isLikelyBvid(bvid) || seen.has(bvid)) continue;
+    seen.add(bvid);
+    result.push(bvid);
+    if (result.length >= BLIND_BOX_DRAW_HISTORY_LIMIT) break;
+  }
+
+  return result;
+}
+
+function isLikelyBvid(value: string): boolean {
+  return /^BV[0-9A-Za-z]{8,}$/.test(value);
+}
+
+function serializedSize(value: unknown): number {
+  const text = JSON.stringify(value ?? null);
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(text).byteLength;
+  }
+  return text.length;
+}

--- a/src/background/storage/local-data-category-registry.ts
+++ b/src/background/storage/local-data-category-registry.ts
@@ -7,6 +7,11 @@ import type {
   LocalDataClearedCounts,
 } from '../../shared/local-data-category-contract.ts';
 import { db } from './db.ts';
+import {
+  clearBlindBoxDrawHistory,
+  collectBlindBoxDrawHistoryUsage,
+  readBlindBoxDrawHistoryAfterClear,
+} from './blind-box-draw-history-repo.ts';
 
 type AnyTable = Table<any, any, any>;
 
@@ -147,8 +152,25 @@ export function createRegisteredLocalDataCategories(
       dynamicBillCreatorPauses: counts[4] ?? 0,
       dynamicBillRotationRecords: counts[5] ?? 0,
     })),
+    blindBoxDrawHistoryCategory(dependencies),
     storageCategory(dependencies, 'localSettings', '本地 AI 设置', LOCAL_SETTING_STORAGE_KEYS),
   ];
+}
+
+function blindBoxDrawHistoryCategory(
+  dependencies: LocalDataCategoryRegistryDependencies,
+): LocalDataCategoryRegistration {
+  return {
+    id: 'blindBoxDrawHistory',
+    label: '盲盒抽取记录',
+    includeInClearAll: true,
+    collectUsage: () => collectBlindBoxDrawHistoryUsage(dependencies.storage),
+    clear: async (): Promise<LocalDataCategoryClearResult> => {
+      const clearedCount = await clearBlindBoxDrawHistory(dependencies.storage);
+      return { cleared: { blindBoxDrawHistory: clearedCount } };
+    },
+    readAfterClear: () => readBlindBoxDrawHistoryAfterClear(dependencies.storage),
+  };
 }
 
 function tableCategory(

--- a/src/background/storage/local-data-privacy-repo.ts
+++ b/src/background/storage/local-data-privacy-repo.ts
@@ -14,6 +14,7 @@ import {
   getHistorySyncing,
   getLastSyncTime,
 } from './config-store.ts';
+import { getBlindBoxRecentDrawnBvids } from './blind-box-draw-history-repo.ts';
 
 export async function getLocalDataPrivacySummary(): Promise<LocalDataPrivacySummary> {
   await ensureDynamicBill013Migration();
@@ -242,6 +243,7 @@ async function collectClearCounts(): Promise<Required<Omit<LocalDataOperationRes
     dynamicBillRotationRecords,
     currentVideoSubtitleSources,
     currentVideoSubtitleSegments,
+    blindBoxDrawHistory,
   ] = await Promise.all([
     db.watchHistory.count(),
     db.playerEvents.count(),
@@ -257,6 +259,7 @@ async function collectClearCounts(): Promise<Required<Omit<LocalDataOperationRes
     db.dynamicBillRotationRecords.count(),
     db.currentVideoTranscriptSources.count(),
     db.currentVideoTranscriptSegments.count(),
+    getBlindBoxRecentDrawnBvids().then(bvids => bvids.length),
   ]);
 
   return {
@@ -274,6 +277,7 @@ async function collectClearCounts(): Promise<Required<Omit<LocalDataOperationRes
     dynamicBillRotationRecords,
     currentVideoSubtitleSources,
     currentVideoSubtitleSegments,
+    blindBoxDrawHistory,
   };
 }
 

--- a/src/background/storage/local-data-privacy-repo.ts
+++ b/src/background/storage/local-data-privacy-repo.ts
@@ -14,7 +14,10 @@ import {
   getHistorySyncing,
   getLastSyncTime,
 } from './config-store.ts';
-import { getBlindBoxRecentDrawnBvids } from './blind-box-draw-history-repo.ts';
+import {
+  coordinateBlindBoxDrawHistoryClear,
+  getBlindBoxRecentDrawnBvids,
+} from './blind-box-draw-history-repo.ts';
 
 export async function getLocalDataPrivacySummary(): Promise<LocalDataPrivacySummary> {
   await ensureDynamicBill013Migration();
@@ -91,22 +94,24 @@ export async function clearAllLocalData(confirmation: unknown): Promise<LocalDat
     throw new Error('HISTORY_SYNC_IN_PROGRESS');
   }
 
-  const counts = await collectClearCounts();
-  await db.transaction('rw', db.tables, async () => {
-    for (const table of db.tables) {
-      await table.clear();
-    }
-  });
-  await chrome.storage.local.clear();
+  return coordinateBlindBoxDrawHistoryClear(async recentDrawnBvids => {
+    const counts = await collectClearCounts(recentDrawnBvids.length);
+    await db.transaction('rw', db.tables, async () => {
+      for (const table of db.tables) {
+        await table.clear();
+      }
+    });
+    await chrome.storage.local.clear();
 
-  return {
-    operation: 'clear_all_local_data',
-    completedAt: Date.now(),
-    cleared: {
-      ...counts,
-      localSettings: true,
-    },
-  };
+    return {
+      operation: 'clear_all_local_data',
+      completedAt: Date.now(),
+      cleared: {
+        ...counts,
+        localSettings: true,
+      },
+    };
+  });
 }
 
 async function summarizeHistory(): Promise<LocalDataPrivacySummary['history']> {
@@ -227,7 +232,9 @@ async function summarizeDynamicBill(): Promise<LocalDataPrivacySummary['dynamicB
   };
 }
 
-async function collectClearCounts(): Promise<Required<Omit<LocalDataOperationResult['cleared'], 'localSettings'>>> {
+async function collectClearCounts(
+  coordinatedBlindBoxDrawHistoryCount?: number,
+): Promise<Required<Omit<LocalDataOperationResult['cleared'], 'localSettings'>>> {
   const [
     historyRecords,
     playerEvents,
@@ -259,7 +266,7 @@ async function collectClearCounts(): Promise<Required<Omit<LocalDataOperationRes
     db.dynamicBillRotationRecords.count(),
     db.currentVideoTranscriptSources.count(),
     db.currentVideoTranscriptSegments.count(),
-    getBlindBoxRecentDrawnBvids().then(bvids => bvids.length),
+    coordinatedBlindBoxDrawHistoryCount ?? getBlindBoxRecentDrawnBvids().then(bvids => bvids.length),
   ]);
 
   return {

--- a/src/shared/local-data-category-contract.ts
+++ b/src/shared/local-data-category-contract.ts
@@ -3,6 +3,7 @@ export type LocalDataCategoryId =
   | 'favorites'
   | 'currentVideoSubtitles'
   | 'dynamicBill'
+  | 'blindBoxDrawHistory'
   | 'localSettings';
 
 export interface LocalDataClearedCounts {
@@ -18,6 +19,7 @@ export interface LocalDataClearedCounts {
   dynamicBillExplanations?: number;
   dynamicBillCreatorPauses?: number;
   dynamicBillRotationRecords?: number;
+  blindBoxDrawHistory?: number;
   currentVideoSubtitleSources?: number;
   currentVideoSubtitleSegments?: number;
   localSettings?: boolean;

--- a/src/shared/local-data-privacy.ts
+++ b/src/shared/local-data-privacy.ts
@@ -66,7 +66,7 @@ export function buildLocalDataOperationMessage(result: LocalDataOperationResult)
   }
 
   return [
-    `已清理本地数据：观看历史 ${result.cleared.historyRecords ?? 0} 条、收藏 ${result.cleared.favoriteItems ?? 0} 条、字幕正文 ${result.cleared.currentVideoSubtitleSegments ?? 0} 段、动态账单 ${result.cleared.dynamicBillItems ?? 0} 项。`,
+    `已清理本地数据：观看历史 ${result.cleared.historyRecords ?? 0} 条、收藏 ${result.cleared.favoriteItems ?? 0} 条、字幕正文 ${result.cleared.currentVideoSubtitleSegments ?? 0} 段、动态账单 ${result.cleared.dynamicBillItems ?? 0} 项、盲盒抽取记录 ${result.cleared.blindBoxDrawHistory ?? 0} 条。`,
     result.cleared.localSettings ? '本地 AI 设置和功能开关也已恢复为默认状态。' : '',
   ].filter(Boolean).join(' ');
 }
@@ -82,7 +82,7 @@ export function dangerousLocalDataClearScope(): string[] {
   return [
     '观看历史、播放器事件和统计聚合。',
     '收藏夹快照、智能收藏索引和收藏问答本地依据。',
-    '当前视频字幕缓存、动态账单记录、动态账单反馈和解释。',
+    '当前视频字幕缓存、动态账单记录、动态账单反馈和解释、盲盒抽取记录。',
     '本地 AI 服务设置、API Key 保存状态和功能开关。',
   ];
 }

--- a/src/shared/types/analytics.ts
+++ b/src/shared/types/analytics.ts
@@ -199,6 +199,12 @@ export interface ExperimentVideoCandidate {
 
 export type ExperimentRealCandidateSourceKind = 'bilibili_related' | 'bili_region_dynamic' | 'bili_space_archive';
 
+export type ExperimentCandidateFailureKind =
+  | 'no_seed'
+  | 'no_real_candidates'
+  | 'upstream_failed'
+  | 'no_openable_candidates';
+
 export interface ExperimentRealVideoCandidate extends ExperimentVideoCandidate {
   sourceKind: ExperimentRealCandidateSourceKind;
   sourceLabel: string;
@@ -218,6 +224,7 @@ export interface ExperimentRealCandidatePool {
   seedCount: number;
   candidates: ExperimentRealVideoCandidate[];
   failures: ExperimentRealCandidateFailure[];
+  failureKind?: ExperimentCandidateFailureKind;
 }
 
 export interface ExperimentBlindBox {

--- a/tests/dynamic-bill-migration.test.ts
+++ b/tests/dynamic-bill-migration.test.ts
@@ -32,6 +32,13 @@ const dynamicBillRepo = await import('../src/background/storage/dynamic-bill-rep
 const { buildDynamicBillExplanationContent } = await import('../src/background/dynamic-bill/explanation-content.ts');
 const { getRegisteredLocalDataCategories } = await import('../src/background/storage/local-data-category-registry.ts');
 const localDataRepo = await import('../src/background/storage/local-data-privacy-repo.ts');
+const { buildClaimedExperimentData } = await import('../src/background/analytics/suggestions.ts');
+const {
+  BLIND_BOX_DRAW_HISTORY_STORAGE_KEY,
+  collectBlindBoxDrawHistoryUsage,
+  getBlindBoxDrawHistoryEpoch,
+  getBlindBoxRecentDrawnBvids,
+} = await import('../src/background/storage/blind-box-draw-history-repo.ts');
 const { runLocalDataCategoryLifecycle } = await import('../src/shared/local-data-category-contract.ts');
 const { LOCAL_DATA_CLEAR_CONFIRMATION } = await import('../src/shared/local-data-privacy.ts');
 const { DEFAULT_CONFIG } = await import('../src/shared/types/config.ts');
@@ -931,6 +938,58 @@ test('clear all leaves every table and local setting untouched when migration fa
   assert.equal(sideEffects.storageSet, 0);
   assert.equal(sideEffects.storageRemove, 0);
   assert.equal(sideEffects.storageClear, 0);
+});
+
+test('clear all prevents an earlier blind-box generation from restoring draw history', async () => {
+  await seedLegacyDatabase();
+  storageData.set(BLIND_BOX_DRAW_HISTORY_STORAGE_KEY, ['BV1BEFORECLR']);
+  let releaseCandidates = () => {};
+  const candidatesReady = new Promise<void>(resolve => {
+    releaseCandidates = resolve;
+  });
+  const generationEpoch = getBlindBoxDrawHistoryEpoch();
+  const generation = (async () => {
+    await candidatesReady;
+    return buildClaimedExperimentData([], [], new Map(), Date.UTC(2026, 5, 13, 12, 0, 0), {
+      random: () => 0,
+      randomExplorePool: {
+        sourceKind: 'bilibili_related',
+        sourceLabel: '相关视频候选',
+        seedCount: 1,
+        candidates: [{
+          sourceKind: 'bilibili_related',
+          sourceLabel: '相关视频候选',
+          seedBvid: 'BV1SEED0001',
+          seedTitle: '种子视频',
+          bvid: 'BV1AFTERCLR1',
+          avid: 12345,
+          cid: 54321,
+          title: '清理后的迟到候选',
+          authorName: '公开候选 UP',
+          authorMid: 67890,
+          cover: 'https://example.com/related.jpg',
+          duration: 960,
+          pubtime: 1_717_000_000,
+          tagName: '科技',
+          url: 'https://www.bilibili.com/video/BV1AFTERCLR1',
+        }],
+        failures: [],
+      },
+    }, generationEpoch);
+  })();
+
+  const clearResult = await localDataRepo.clearAllLocalData(LOCAL_DATA_CLEAR_CONFIRMATION);
+  assert.equal(clearResult.cleared.blindBoxDrawHistory, 1);
+  releaseCandidates();
+  const generated = await generation;
+
+  assert.equal(
+    generated.blindBoxes.find(box => box.id === 'random_explore')?.video?.bvid,
+    'BV1AFTERCLR1',
+  );
+  assert.equal((await collectBlindBoxDrawHistoryUsage(chrome.storage.local)).count, 0);
+  assert.deepEqual(await getBlindBoxRecentDrawnBvids(), []);
+  assert.equal(storageData.has(BLIND_BOX_DRAW_HISTORY_STORAGE_KEY), false);
 });
 
 test('every protected entry fails with one Chinese error before reads, writes, or network work', async () => {

--- a/tests/experiment-blind-boxes.mock.html
+++ b/tests/experiment-blind-boxes.mock.html
@@ -197,7 +197,7 @@
           <div class="reason">理由：最近最多 7 天的高频分区是「游戏」，本轮避开这些方向，随机选择 B 站「知识」分区，并从公开新视频候选池里抽取这条视频。</div>
           <ul>
             <li>跨区漫游只使用固定公开分区目录和 B 站分区新视频接口。</li>
-            <li>本切片不使用最近抽取记录去重，也不改用本地历史或收藏补位。</li>
+            <li>抽取时会优先避开最近抽中过的视频，但不会改用本地历史或收藏补位。</li>
           </ul>
         </div>
         <a href="https://www.bilibili.com/video/BV1REAL139A" target="_blank" rel="noopener noreferrer">打开 B 站视频页</a>
@@ -289,6 +289,44 @@
         <div class="content">
           <div class="title">这次没有取得可打开的分区新视频</div>
           <div class="reason">已请求本轮公开分区新视频候选池，但没有留下可打开视频。当前不会改用本地历史或收藏。</div>
+        </div>
+        <button type="button">重新生成这一页</button>
+      </article>
+
+      <article class="empty" style="--accent: #7fd1ff" data-box-id="creator_archive_upstream_failed">
+        <div class="top">
+          <div>
+            <h2>UP 主考古</h2>
+            <div class="teaser">从已关注 UP 的公开较早投稿里随机开一条。</div>
+          </div>
+          <span class="badge">接口暂时失败</span>
+        </div>
+        <div class="meta">
+          <div>候选来源：已关注 UP 的公开较早投稿</div>
+          <div>真实 B 站候选：未使用真实 B 站候选：公开候选接口暂时不可用。</div>
+        </div>
+        <div class="content">
+          <div class="title">暂时无法取得 UP 主公开投稿</div>
+          <div class="reason">本轮只请求公开投稿候选，接口暂时失败时不会改用本地历史、收藏或其他盲盒来源。</div>
+        </div>
+        <button type="button">重新生成这一页</button>
+      </article>
+
+      <article class="empty" style="--accent: #ffd166" data-box-id="hidden_favorite_no_real_candidates">
+        <div class="top">
+          <div>
+            <h2>隐藏收藏</h2>
+            <div class="teaser">只从本地收藏回访池里随机开一条。</div>
+          </div>
+          <span class="badge">没有真实候选</span>
+        </div>
+        <div class="meta">
+          <div>候选来源：本地收藏</div>
+          <div>真实 B 站候选：未使用真实 B 站候选：本地收藏回访池本轮没有可抽视频。</div>
+        </div>
+        <div class="content">
+          <div class="title">这次没有可回访的收藏视频</div>
+          <div class="reason">隐藏收藏只使用本地收藏回访候选；候选为空时不会借用其他盲盒来源。</div>
         </div>
         <button type="button">重新生成这一页</button>
       </article>

--- a/tests/experiment-blind-boxes.mock.html
+++ b/tests/experiment-blind-boxes.mock.html
@@ -213,7 +213,7 @@
         </div>
         <div class="meta">
           <div>候选来源：本地收藏</div>
-          <div>真实 B 站候选：未使用真实 B 站候选：这是本地收藏回访。</div>
+          <div>真实 B 站候选：本卡不使用；固定从本地收藏回访。</div>
           <div>来源：本地收藏 / 收藏夹「旧收藏」</div>
         </div>
         <div class="content">
@@ -254,14 +254,14 @@
       </article>
     </section>
 
-    <section class="grid" aria-label="空态卡片">
+    <section class="grid" aria-label="失败与空态卡片">
       <article class="empty" style="--accent: #a78bfa" data-box-id="random_explore_empty">
         <div class="top">
           <div>
             <h2>随机探索</h2>
             <div class="teaser">只从真实 B 站候选池里随机抽一条。</div>
           </div>
-          <span class="badge">暂无候选</span>
+          <span class="badge">没有可用种子</span>
         </div>
         <div class="meta">
           <div>候选来源：B 站公开视频的相关视频候选池</div>
@@ -274,21 +274,21 @@
         <button type="button">重新生成这一页</button>
       </article>
 
-      <article class="empty" style="--accent: #ff9f6e" data-box-id="cross_region_empty">
+      <article class="empty" style="--accent: #ff9f6e" data-box-id="cross_region_no_real_candidates">
         <div class="top">
           <div>
             <h2>跨区漫游</h2>
             <div class="teaser">避开最近高频分区，从公开分区新视频里随机开一条。</div>
           </div>
-          <span class="badge">真实候选为空</span>
+          <span class="badge">没有真实候选</span>
         </div>
         <div class="meta">
           <div>候选来源：B 站公开分区新视频候选池</div>
-          <div>真实 B 站候选：未使用真实 B 站候选：候选源本轮没有返回可打开视频。</div>
+          <div>真实 B 站候选：未使用；本轮公开分区没有返回真实视频候选。</div>
         </div>
         <div class="content">
-          <div class="title">这次没有取得可打开的分区新视频</div>
-          <div class="reason">已请求本轮公开分区新视频候选池，但没有留下可打开视频。当前不会改用本地历史或收藏。</div>
+          <div class="title">这次没有取得真实分区候选</div>
+          <div class="reason">已请求本轮公开分区新视频候选池，但没有返回真实视频候选。当前不会改用本地历史、收藏或其他盲盒来源。</div>
         </div>
         <button type="button">重新生成这一页</button>
       </article>
@@ -312,21 +312,21 @@
         <button type="button">重新生成这一页</button>
       </article>
 
-      <article class="empty" style="--accent: #ffd166" data-box-id="hidden_favorite_no_real_candidates">
+      <article class="empty" style="--accent: #ffd166" data-box-id="cold_favorite_unopenable">
         <div class="top">
           <div>
-            <h2>隐藏收藏</h2>
-            <div class="teaser">只从本地收藏回访池里随机开一条。</div>
+            <h2>冷门收藏</h2>
+            <div class="teaser">从本地收藏里翻出被你压箱底的一条。</div>
           </div>
-          <span class="badge">没有真实候选</span>
+          <span class="badge">候选不可打开</span>
         </div>
         <div class="meta">
           <div>候选来源：本地收藏</div>
-          <div>真实 B 站候选：未使用真实 B 站候选：本地收藏回访池本轮没有可抽视频。</div>
+          <div>真实 B 站候选：本卡不使用；固定从本地收藏回访。</div>
         </div>
         <div class="content">
-          <div class="title">这次没有可回访的收藏视频</div>
-          <div class="reason">隐藏收藏只使用本地收藏回访候选；候选为空时不会借用其他盲盒来源。</div>
+          <div class="title">本地收藏暂时打不开</div>
+          <div class="reason">这批本地收藏缺少可打开的视频身份，冷门收藏不会改用外部候选或其他盲盒来源。</div>
         </div>
         <button type="button">重新生成这一页</button>
       </article>

--- a/tests/experiment-blind-boxes.mock.html
+++ b/tests/experiment-blind-boxes.mock.html
@@ -3,338 +3,207 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>视频盲盒固定四类 Mock QA</title>
+  <title>Bili-Bill 盲盒真实页面 Mock QA</title>
+  <link rel="stylesheet" href="/dashboard/styles/dashboard.css">
   <style>
-    :root {
-      color-scheme: dark;
-      --bg: #101424;
-      --panel: #171b2e;
-      --line: rgba(255, 255, 255, 0.09);
-      --muted: #a8b0ce;
-      --text: #f7f8ff;
-      --pink: #fb7299;
-      --blue: #00a1d6;
-    }
-    * { box-sizing: border-box; }
+    :root { color-scheme: dark; }
     body {
       margin: 0;
-      background: var(--bg);
-      color: var(--text);
+      min-width: 0;
+      background: #101424;
       font-family: Arial, "Microsoft YaHei", sans-serif;
     }
-    main {
-      display: grid;
-      gap: 14px;
-      padding: 16px;
-      max-width: 1120px;
-      margin: 0 auto;
-    }
-    .hero,
-    .note {
-      border: 1px solid var(--line);
-      border-radius: 8px;
-      background: linear-gradient(135deg, rgba(251, 114, 153, 0.16), rgba(0, 161, 214, 0.12));
-      padding: 14px;
-    }
-    h1 {
-      margin: 0 0 8px;
-      font-size: 18px;
-      line-height: 1.35;
-    }
-    p {
-      margin: 0;
-      color: var(--muted);
-      font-size: 13px;
-      line-height: 1.65;
-    }
-    .grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-      gap: 12px;
-    }
-    article {
-      display: flex;
-      min-height: 330px;
-      flex-direction: column;
-      gap: 10px;
-      border: 1px solid color-mix(in srgb, var(--accent), transparent 65%);
-      border-radius: 8px;
-      background: var(--panel);
-      padding: 14px;
-      box-shadow: 0 10px 24px color-mix(in srgb, var(--accent), transparent 86%);
-    }
-    .top {
-      display: flex;
-      justify-content: space-between;
-      gap: 8px;
-      align-items: flex-start;
-    }
-    h2 {
-      margin: 0;
-      font-size: 16px;
-      line-height: 1.35;
-    }
-    .teaser,
-    .meta,
-    li {
-      color: var(--muted);
-      font-size: 12px;
-      line-height: 1.55;
-    }
-    .badge {
-      flex: 0 0 auto;
-      border: 1px solid color-mix(in srgb, var(--accent), transparent 55%);
-      border-radius: 999px;
-      background: color-mix(in srgb, var(--accent), transparent 88%);
-      color: var(--accent);
-      font-size: 11px;
-      font-weight: 700;
-      padding: 4px 8px;
-      white-space: nowrap;
-    }
-    .meta,
-    .content {
-      border: 1px solid var(--line);
-      border-radius: 8px;
-      background: rgba(255, 255, 255, 0.03);
-      padding: 10px;
-    }
-    .content {
-      flex: 1;
-    }
-    .title {
-      color: #fff;
-      font-size: 15px;
-      font-weight: 800;
-      line-height: 1.45;
-    }
-    .reason {
-      margin-top: 8px;
-      color: #dce2f8;
-      font-size: 13px;
-      line-height: 1.65;
-    }
-    ul {
-      margin: 8px 0 0;
-      padding-left: 18px;
-    }
-    button,
-    a {
-      display: block;
+    #app {
       width: 100%;
-      min-height: 38px;
-      border: 1px solid color-mix(in srgb, var(--accent), transparent 55%);
-      border-radius: 8px;
-      background: color-mix(in srgb, var(--accent), transparent 86%);
-      color: var(--accent);
-      font-size: 13px;
-      font-weight: 800;
-      line-height: 38px;
-      text-align: center;
-      text-decoration: none;
-      cursor: pointer;
+      min-width: 0;
     }
-    .empty button {
-      border-color: rgba(255, 255, 255, 0.1);
-      background: rgba(255, 255, 255, 0.035);
-      color: #dce2f8;
-    }
-    @media (max-width: 620px) {
-      main { padding: 12px; }
-      article { min-height: 0; }
+    .qa-shell {
+      padding: 10px 16px 0;
+      color: #a8b0ce;
+      font-size: 12px;
+      line-height: 1.5;
     }
   </style>
 </head>
 <body>
-  <main>
-    <section class="hero">
-      <h1>视频盲盒</h1>
-      <p>随机探索、跨区漫游、冷门收藏和 UP 主考古固定展示。每张卡都说明候选来源、入选原因，以及是否使用真实 B 站候选。</p>
-    </section>
+  <div class="qa-shell">Bili-Bill 盲盒真实页面 Mock QA</div>
+  <div id="app"></div>
 
-    <section class="grid" aria-label="视频盲盒四类卡片">
-      <article style="--accent: #a78bfa" data-box-id="random_explore">
-        <div class="top">
-          <div>
-            <h2>随机探索</h2>
-            <div class="teaser">只从真实 B 站相关视频候选池里随机抽一条。</div>
-          </div>
-          <span class="badge">真实候选</span>
-        </div>
-        <div class="meta">
-          <div>候选来源：B 站公开视频的相关视频候选池</div>
-          <div>真实 B 站候选：已使用真实 B 站候选</div>
-          <div>来源：相关视频候选 / 种子视频「本地种子视频」</div>
-        </div>
-        <div class="content">
-          <div class="title">真实相关候选视频</div>
-          <div class="teaser">UP 主：公开候选 UP</div>
-          <div class="reason">理由：Bili-Bill 只保留可打开的公开相关视频候选，并在候选池里随机抽取一条；不会从本地历史或收藏库存补位。</div>
-          <ul>
-            <li>本次种子视频：本地种子视频。</li>
-            <li>最终视频来自本轮取得的真实相关视频候选池。</li>
-          </ul>
-        </div>
-        <a href="https://www.bilibili.com/video/BV1REALRND01" target="_blank" rel="noopener noreferrer">打开 B 站视频页</a>
-      </article>
+  <script type="module">
+    import { h, render } from 'preact';
+    import { ExperimentsPage } from '/dashboard/modules/experiments/ExperimentsPage.tsx';
 
-      <article style="--accent: #ff9f6e" data-box-id="cross_region">
-        <div class="top">
-          <div>
-            <h2>跨区漫游</h2>
-            <div class="teaser">避开最近高频分区，从公开分区新视频里随机开一条。</div>
-          </div>
-          <span class="badge">真实候选</span>
-        </div>
-        <div class="meta">
-          <div>候选来源：B 站公开分区新视频候选池</div>
-          <div>真实 B 站候选：已使用真实 B 站候选</div>
-          <div>来源：B 站分区新视频 / 知识</div>
-        </div>
-        <div class="content">
-          <div class="title">真实分区新视频</div>
-          <div class="teaser">UP 主：公开知识 UP</div>
-          <div class="reason">理由：最近最多 7 天的高频分区是「游戏」，本轮避开这些方向，随机选择 B 站「知识」分区，并从公开新视频候选池里抽取这条视频。</div>
-          <ul>
-            <li>跨区漫游只使用固定公开分区目录和 B 站分区新视频接口。</li>
-            <li>抽取时会优先避开最近抽中过的视频，但不会改用本地历史或收藏补位。</li>
-          </ul>
-        </div>
-        <a href="https://www.bilibili.com/video/BV1REAL139A" target="_blank" rel="noopener noreferrer">打开 B 站视频页</a>
-      </article>
+    const mode = new URLSearchParams(location.search).get('mode') === 'failure' ? 'failure' : 'ready';
 
-      <article style="--accent: #ffd166" data-box-id="hidden_favorite">
-        <div class="top">
-          <div>
-            <h2>冷门收藏</h2>
-            <div class="teaser">从本地收藏里翻出被你压箱底的一条。</div>
-          </div>
-          <span class="badge">本地候选</span>
-        </div>
-        <div class="meta">
-          <div>候选来源：本地收藏</div>
-          <div>真实 B 站候选：本卡不使用；固定从本地收藏回访。</div>
-          <div>来源：本地收藏 / 收藏夹「旧收藏」</div>
-        </div>
-        <div class="content">
-          <div class="title">压箱底收藏视频</div>
-          <div class="teaser">UP 主：游戏收藏 UP</div>
-          <div class="reason">理由：你把它收进本地收藏后，还没有留下再次观看记录。</div>
-          <ul>
-            <li>这条视频来自本地已同步收藏。</li>
-            <li>它不是外部探索，也不会冒充真实 B 站候选。</li>
-          </ul>
-        </div>
-        <a href="https://www.bilibili.com/video/BVFAVHID1" target="_blank" rel="noopener noreferrer">打开 B 站视频页</a>
-      </article>
+    globalThis.chrome = {
+      runtime: {
+        sendMessage: async message => {
+          if (message?.action !== 'GET_EXPERIMENT_DATA') {
+            return { success: false, error: 'unsupported mock action' };
+          }
+          return {
+            success: true,
+            data: mode === 'failure' ? createFailureExperimentData() : createReadyExperimentData(),
+          };
+        },
+      },
+    };
 
-      <article style="--accent: #7fd1ff" data-box-id="creator_archive">
-        <div class="top">
-          <div>
-            <h2>UP 主考古</h2>
-            <div class="teaser">从已关注 UP 的公开较早投稿里随机翻一条。</div>
-          </div>
-          <span class="badge">真实候选</span>
-        </div>
-        <div class="meta">
-          <div>候选来源：已关注 UP 的公开较早投稿</div>
-          <div>真实 B 站候选：已使用真实 B 站候选</div>
-          <div>来源：UP 主公开较早投稿 / 考古 UP</div>
-        </div>
-        <div class="content">
-          <div class="title">公开较早投稿</div>
-          <div class="teaser">UP 主：考古 UP</div>
-          <div class="reason">理由：这条来自已关注 UP「考古 UP」的公开较早投稿，已排除最近 7 天新投稿，避免和动态账单重复。</div>
-          <ul>
-            <li>只请求少量已关注 UP 的公开投稿第一页。</li>
-            <li>最终视频来自公开 UP 空间投稿候选池。</li>
-          </ul>
-        </div>
-        <a href="https://www.bilibili.com/video/BV1ARCOLD1" target="_blank" rel="noopener noreferrer">打开 B 站视频页</a>
-      </article>
-    </section>
+    render(h(ExperimentsPage, {}), document.getElementById('app'));
 
-    <section class="grid" aria-label="失败与空态卡片">
-      <article class="empty" style="--accent: #a78bfa" data-box-id="random_explore_empty">
-        <div class="top">
-          <div>
-            <h2>随机探索</h2>
-            <div class="teaser">只从真实 B 站候选池里随机抽一条。</div>
-          </div>
-          <span class="badge">没有可用种子</span>
-        </div>
-        <div class="meta">
-          <div>候选来源：B 站公开视频的相关视频候选池</div>
-          <div>真实 B 站候选：未使用真实 B 站候选：缺少可用于请求的近期视频。</div>
-        </div>
-        <div class="content">
-          <div class="title">当前没有可用于探索的近期视频</div>
-          <div class="reason">随机探索需要先用最近少量本地历史作为种子，请求 B 站公开视频的相关视频候选池。</div>
-        </div>
-        <button type="button">重新生成这一页</button>
-      </article>
+    function createReadyExperimentData() {
+      return {
+        generatedAt: Date.UTC(2026, 5, 26, 6, 16, 11),
+        blindBoxes: [
+          readyBox({
+            id: 'random_explore',
+            title: '随机探索',
+            teaser: '只从真实 B 站相关视频候选池里随机抽一条。',
+            candidateSource: 'B 站公开视频的相关视频候选池',
+            realCandidateLabel: '已使用真实 B 站候选',
+            source: '相关视频候选 / 种子视频《本地种子视频》',
+            reason: 'Bili-Bill 只保留可打开的公开视频候选，并在本轮候选池里随机抽取一条；不会从本地历史或收藏库存补位。',
+            evidence: [
+              '候选来自 B 站公开视频的相关视频候选池，使用 3 个本地种子视频逐个请求。',
+              '抽取前已排除最近看过的视频；最近抽中过的视频只作为短期避让记录。',
+            ],
+            video: video('BV1REALRND01', '真实相关候选视频', '公开候选 UP', 'bilibili_related'),
+          }),
+          readyBox({
+            id: 'cross_region',
+            title: '跨区漫游',
+            teaser: '避开最近高频分区，从公开分区新视频里随机开一条。',
+            candidateSource: 'B 站公开分区新视频候选池',
+            realCandidateLabel: '已使用真实 B 站候选',
+            source: 'B 站分区新视频 / 知识',
+            reason: '最近高频分区是「游戏」，本轮避开这些方向，随机选择 B 站「知识」分区，并从公开新视频候选池里抽取这条视频。',
+            evidence: [
+              '跨区漫游只使用固定公开分区目录和 B 站分区新视频接口。',
+              '抽取时会优先避开最近抽中过的视频，但不会改用本地历史或收藏补位。',
+            ],
+            video: video('BV1REAL139A', '真实分区新视频', '公开知识 UP', 'bili_region_dynamic'),
+          }),
+          readyBox({
+            id: 'hidden_favorite',
+            title: '冷门收藏',
+            teaser: '从本地收藏里翻出被你压箱底的一条。',
+            candidateSource: '本地收藏',
+            realCandidateLabel: '本卡不使用；固定从本地收藏回访。',
+            usesRealBilibiliCandidates: false,
+            source: '本地收藏 / 收藏夹「默认收藏夹」',
+            reason: '你把它收进本地收藏后，还没有留下再次观看记录。',
+            evidence: [
+              '这条视频来自本地已同步收藏。',
+              '它不是外部探索，也不会冒充真实 B 站候选。',
+            ],
+            video: video('BVFAVHID01', '压箱底收藏视频', '游戏收藏 UP', 'local_favorite'),
+          }),
+          readyBox({
+            id: 'creator_archive',
+            title: 'UP 主考古',
+            teaser: '从已关注 UP 的公开较早投稿里随机翻一条。',
+            candidateSource: '已关注 UP 的公开较早投稿',
+            realCandidateLabel: '已使用真实 B 站候选',
+            source: 'UP 公开较早投稿 / 考古 UP',
+            reason: '这条来自已关注 UP「考古 UP」的公开较早投稿，已排除最近 7 天新投稿，避免和动态账单重复。',
+            evidence: [
+              '只请求少量已关注 UP 的公开投稿第一页。',
+              '最终视频来自公开 UP 空间投稿候选池。',
+            ],
+            video: video('BV1ARCOLD1', '公开较早投稿', '考古 UP', 'bili_space_archive'),
+          }),
+        ],
+      };
+    }
 
-      <article class="empty" style="--accent: #ff9f6e" data-box-id="cross_region_no_real_candidates">
-        <div class="top">
-          <div>
-            <h2>跨区漫游</h2>
-            <div class="teaser">避开最近高频分区，从公开分区新视频里随机开一条。</div>
-          </div>
-          <span class="badge">没有真实候选</span>
-        </div>
-        <div class="meta">
-          <div>候选来源：B 站公开分区新视频候选池</div>
-          <div>真实 B 站候选：未使用；本轮公开分区没有返回真实视频候选。</div>
-        </div>
-        <div class="content">
-          <div class="title">这次没有取得真实分区候选</div>
-          <div class="reason">已请求本轮公开分区新视频候选池，但没有返回真实视频候选。当前不会改用本地历史、收藏或其他盲盒来源。</div>
-        </div>
-        <button type="button">重新生成这一页</button>
-      </article>
+    function createFailureExperimentData() {
+      return {
+        generatedAt: Date.UTC(2026, 5, 26, 6, 20, 0),
+        blindBoxes: [
+          emptyBox({
+            id: 'random_explore',
+            title: '随机探索',
+            teaser: '只从真实 B 站相关视频候选池里随机抽一条。',
+            candidateSource: 'B 站公开视频的相关视频候选池',
+            realCandidateLabel: '未使用真实 B 站候选：缺少可请求的本地近期视频。',
+            source: '相关视频候选',
+            statusLabel: '没有可用种子',
+            emptyTitle: '当前没有可用于探索的近期视频',
+            emptyDescription: '随机探索需要先用最近少量本地历史作为种子，请求 B 站公开视频的相关视频候选池。当前没有合格种子，因此没有发出相关候选请求。',
+            reason: '没有可请求的种子，未生成空白视频卡。',
+          }),
+          emptyBox({
+            id: 'cross_region',
+            title: '跨区漫游',
+            teaser: '避开最近高频分区，从公开分区新视频里随机开一条。',
+            candidateSource: 'B 站公开分区新视频候选池',
+            realCandidateLabel: '未使用真实 B 站候选：本轮公开分区没有返回真实候选。',
+            source: 'B 站分区新视频',
+            statusLabel: '没有真实候选',
+            emptyTitle: '这次没有取得真实分区候选',
+            emptyDescription: '已请求本轮公开分区新视频候选池，但没有返回真实视频候选。当前不会改用本地历史、收藏或其他盲盒来源。',
+            reason: '本轮公开分区没有返回真实视频候选。',
+          }),
+          emptyBox({
+            id: 'creator_archive',
+            title: 'UP 主考古',
+            teaser: '从已关注 UP 的公开较早投稿里随机翻一条。',
+            candidateSource: '已关注 UP 的公开较早投稿',
+            realCandidateLabel: '未使用真实 B 站候选：公开候选接口暂时不可用。',
+            source: 'UP 公开较早投稿',
+            statusLabel: '接口暂时失败',
+            emptyTitle: '暂时无法取得 UP 公开投稿',
+            emptyDescription: '本轮只请求公开投稿候选，接口暂时失败时不会改用本地历史、收藏或其他盲盒来源。',
+            reason: '本轮公开投稿候选源暂时失败。',
+          }),
+          emptyBox({
+            id: 'hidden_favorite',
+            title: '冷门收藏',
+            teaser: '从本地收藏里翻出被你压箱底的一条。',
+            candidateSource: '本地收藏',
+            realCandidateLabel: '本卡不使用；固定从本地收藏回访。',
+            usesRealBilibiliCandidates: false,
+            source: '本地收藏',
+            statusLabel: '候选打不开',
+            emptyTitle: '本地收藏暂时打不开',
+            emptyDescription: '这批本地收藏缺少可打开的视频身份，冷门收藏不会改用外部候选或其他盲盒来源。',
+            reason: '本地收藏返回了记录，但没有可打开的视频。',
+          }),
+        ],
+      };
+    }
 
-      <article class="empty" style="--accent: #7fd1ff" data-box-id="creator_archive_upstream_failed">
-        <div class="top">
-          <div>
-            <h2>UP 主考古</h2>
-            <div class="teaser">从已关注 UP 的公开较早投稿里随机开一条。</div>
-          </div>
-          <span class="badge">接口暂时失败</span>
-        </div>
-        <div class="meta">
-          <div>候选来源：已关注 UP 的公开较早投稿</div>
-          <div>真实 B 站候选：未使用真实 B 站候选：公开候选接口暂时不可用。</div>
-        </div>
-        <div class="content">
-          <div class="title">暂时无法取得 UP 主公开投稿</div>
-          <div class="reason">本轮只请求公开投稿候选，接口暂时失败时不会改用本地历史、收藏或其他盲盒来源。</div>
-        </div>
-        <button type="button">重新生成这一页</button>
-      </article>
+    function readyBox(input) {
+      return {
+        state: 'ready',
+        statusLabel: '真实候选',
+        usesRealBilibiliCandidates: true,
+        ...input,
+      };
+    }
 
-      <article class="empty" style="--accent: #ffd166" data-box-id="cold_favorite_unopenable">
-        <div class="top">
-          <div>
-            <h2>冷门收藏</h2>
-            <div class="teaser">从本地收藏里翻出被你压箱底的一条。</div>
-          </div>
-          <span class="badge">候选不可打开</span>
-        </div>
-        <div class="meta">
-          <div>候选来源：本地收藏</div>
-          <div>真实 B 站候选：本卡不使用；固定从本地收藏回访。</div>
-        </div>
-        <div class="content">
-          <div class="title">本地收藏暂时打不开</div>
-          <div class="reason">这批本地收藏缺少可打开的视频身份，冷门收藏不会改用外部候选或其他盲盒来源。</div>
-        </div>
-        <button type="button">重新生成这一页</button>
-      </article>
-    </section>
+    function emptyBox(input) {
+      return {
+        state: 'empty',
+        evidence: [
+          '本轮会保留候选来源边界，不会用其他来源补位。',
+          '刷新后可以重新请求这一页。',
+        ],
+        usesRealBilibiliCandidates: true,
+        ...input,
+      };
+    }
 
-    <section class="note">
-      <p>打开动作只会新开一个 B 站视频页，不会回写收藏、关注或观看状态。</p>
-    </section>
-  </main>
+    function video(bvid, title, authorName, sourceKind) {
+      return {
+        bvid,
+        title,
+        authorName,
+        sourceKind,
+        url: `https://www.bilibili.com/video/${bvid}`,
+        cover: 'https://example.com/cover.jpg',
+      };
+    }
+  </script>
 </body>
 </html>

--- a/tests/experiment-blind-boxes.test.ts
+++ b/tests/experiment-blind-boxes.test.ts
@@ -5,6 +5,7 @@ import { formatExperimentLoadError } from '../dashboard/modules/experiments/expe
 import {
   buildExperimentData,
   fetchRandomExploreCandidatePool,
+  getSuccessfulBlindBoxDrawBvids,
   selectRelatedVideoSeeds,
 } from '../src/background/analytics/suggestions.ts';
 import {
@@ -17,6 +18,22 @@ import {
   type CreatorArchiveCandidatePool,
   type CrossRegionCandidatePool,
 } from '../src/background/api/video-blind-box-candidates.ts';
+import {
+  BLIND_BOX_DRAW_HISTORY_LIMIT,
+  BLIND_BOX_DRAW_HISTORY_STORAGE_KEY,
+  clearBlindBoxDrawHistory,
+  collectBlindBoxDrawHistoryUsage,
+  mergeBlindBoxDrawHistory,
+  normalizeBlindBoxDrawHistory,
+  readBlindBoxDrawHistoryAfterClear,
+  recordBlindBoxDrawnBvids,
+  type BlindBoxDrawHistoryStorage,
+} from '../src/background/storage/blind-box-draw-history-repo.ts';
+import {
+  createRegisteredLocalDataCategories,
+  type LocalDataCategoryRegistryDependencies,
+  type LocalDataCategoryTable,
+} from '../src/background/storage/local-data-category-registry.ts';
 import type {
   ExperimentBlindBox,
   ExperimentRealCandidatePool,
@@ -33,7 +50,7 @@ test('builds fixed blind boxes with source labels for all four 0.13 sources', ()
   const favorites: FavoriteItem[] = [
     createFavorite({
       itemKey: 'hidden',
-      bvid: 'BVFAVHID1',
+      bvid: 'BVFAVHID01',
       title: '压箱底收藏视频',
       folderTitle: '旧收藏',
       tagName: '游戏',
@@ -85,7 +102,7 @@ test('builds fixed blind boxes with source labels for all four 0.13 sources', ()
   assert.equal(hiddenFavorite.candidateSource, '本地收藏');
   assert.equal(hiddenFavorite.realCandidateLabel, '未使用真实 B 站候选：这是本地收藏回访。');
   assert.equal(hiddenFavorite.usesRealBilibiliCandidates, false);
-  assert.equal(hiddenFavorite.video?.bvid, 'BVFAVHID1');
+  assert.equal(hiddenFavorite.video?.bvid, 'BVFAVHID01');
   assert.equal(hiddenFavorite.video?.sourceKind, 'local_favorite');
 
   assert.equal(creatorArchive.title, 'UP 主考古');
@@ -260,7 +277,7 @@ test('sanitizes raw runtime errors from cross-region candidate source failures',
 
   assert.ok(crossRegion);
   assert.equal(crossRegion.state, 'empty');
-  assert.match(crossRegion.emptyDescription ?? '', /没有取得可打开的分区新视频/);
+  assert.match(crossRegion.emptyDescription ?? '', /没有从 B 站接口取得可打开的分区新视频/);
   assert.equal(JSON.stringify(failedPool).includes('source_failed'), false);
   assert.equal(JSON.stringify(crossRegion).includes('document is not defined'), false);
   assert.equal(JSON.stringify(crossRegion).includes('ReferenceError'), false);
@@ -375,6 +392,201 @@ test('returns natural Chinese empty states for all four fixed cards', () => {
   }
 });
 
+test('distinguishes no seed, no real candidates, upstream failure, and unopenable candidates', async () => {
+  const noSeedPool = await fetchRandomExploreCandidatePool([], NOW_MS, async () => createRelatedPool());
+  const noSeedData = buildExperimentData([], [], new Map(), NOW_MS, {
+    randomExplorePool: noSeedPool,
+    crossRegionPool: emptyCrossRegionPool(),
+    creatorArchivePool: emptyCreatorArchivePool(),
+  });
+  const noSeed = noSeedData.blindBoxes.find(box => box.id === 'random_explore');
+  assert.equal(noSeed?.state, 'empty');
+  assert.equal(noSeed?.emptyTitle, '当前没有可用于探索的近期视频');
+  assert.match(noSeed?.emptyDescription ?? '', /没有合格种子/);
+
+  const noRealCandidateData = buildExperimentData(createRecentRegionRecords(), [], new Map(), NOW_MS, {
+    randomExplorePool: {
+      sourceKind: 'bilibili_related',
+      sourceLabel: '相关视频候选',
+      seedCount: 1,
+      candidates: [],
+      failures: [{ seedBvid: 'BV1SEED0001', seedTitle: '种子视频', reason: 'empty_response' }],
+      failureKind: 'no_real_candidates',
+    },
+    crossRegionPool: emptyCrossRegionPool(),
+    creatorArchivePool: emptyCreatorArchivePool(),
+  });
+  const noRealCandidate = noRealCandidateData.blindBoxes.find(box => box.id === 'random_explore');
+  assert.equal(noRealCandidate?.state, 'empty');
+  assert.equal(noRealCandidate?.statusLabel, '没有真实候选');
+  assert.match(noRealCandidate?.emptyDescription ?? '', /没有返回真实相关视频候选/);
+
+  const upstreamFailureData = buildExperimentData([], [], new Map(), NOW_MS, {
+    randomExplorePool: emptyRelatedPool(),
+    crossRegionPool: buildCrossRegionSourceFailure(
+      createRecentRegionRecords(),
+      NOW_MS,
+      new Error('API Error: -404 raw failure'),
+    ),
+    creatorArchivePool: emptyCreatorArchivePool(),
+  });
+  const upstreamFailure = upstreamFailureData.blindBoxes.find(box => box.id === 'cross_region');
+  assert.equal(upstreamFailure?.state, 'empty');
+  assert.equal(upstreamFailure?.statusLabel, '接口暂时失败');
+  assert.match(upstreamFailure?.emptyDescription ?? '', /没有从 B 站接口取得可打开的分区新视频/);
+  assertNoForbiddenVisibleText(visibleBlindBoxText(upstreamFailure!));
+
+  const unopenablePool = await fetchCrossRegionCandidatePool([], {
+    nowMs: NOW_MS,
+    random: () => 0,
+    request: async () => ({
+      archives: [
+        {
+          bvid: 'not-a-bvid',
+          title: '身份无效的分区候选',
+          owner: { mid: 1001, name: '无效 UP' },
+          duration: 120,
+        },
+        {
+          bvid: 'BV1mK4y1C7Bz',
+          title: '',
+          owner: { mid: 1002, name: '缺标题 UP' },
+          duration: 240,
+        },
+      ],
+    }),
+  });
+  const unopenableData = buildExperimentData([], [], new Map(), NOW_MS, {
+    randomExplorePool: emptyRelatedPool(),
+    crossRegionPool: unopenablePool,
+    creatorArchivePool: emptyCreatorArchivePool(),
+  });
+  const unopenable = unopenableData.blindBoxes.find(box => box.id === 'cross_region');
+  assert.equal(unopenablePool.failureKind, 'no_openable_candidates');
+  assert.equal(unopenable?.state, 'empty');
+  assert.equal(unopenable?.statusLabel, '候选不可打开');
+  assert.match(unopenable?.emptyDescription ?? '', /返回了候选，但没有留下可打开的视频/);
+  assertNoForbiddenVisibleText(visibleBlindBoxText(unopenable!));
+});
+
+test('shared recent draw history prefers unseen candidates across all four cards', () => {
+  const data = buildRandomContractData(() => 0, {
+    recentDrawnBvids: ['BV1RANDOM001', 'BV1REGION001', 'BV1FAVORIT01', 'BV1ARCHIVE01'],
+  });
+
+  assert.deepEqual(data.blindBoxes.map(box => box.video?.bvid), [
+    'BV1RANDOM002',
+    'BV1REGION002',
+    'BV1FAVORIT02',
+    'BV1ARCHIVE02',
+  ]);
+});
+
+test('all-repeated valid pools draw from the full valid pool instead of becoming empty', () => {
+  const data = buildRandomContractData(() => 0.999999, {
+    recentDrawnBvids: [
+      'BV1RANDOM001',
+      'BV1RANDOM002',
+      'BV1REGION001',
+      'BV1REGION002',
+      'BV1FAVORIT01',
+      'BV1FAVORIT02',
+      'BV1ARCHIVE01',
+      'BV1ARCHIVE02',
+    ],
+  });
+
+  assert.equal(data.blindBoxes.every(box => box.state === 'ready'), true);
+  assert.deepEqual(data.blindBoxes.map(box => box.video?.bvid), [
+    'BV1RANDOM002',
+    'BV1REGION002',
+    'BV1FAVORIT02',
+    'BV1ARCHIVE02',
+  ]);
+});
+
+test('records only successful openable blind-box draws', () => {
+  const data = buildRandomContractData(() => 0);
+  const readyBox = data.blindBoxes[0];
+  const invalidBox: ExperimentBlindBox = {
+    ...readyBox,
+    video: readyBox.video ? {
+      ...readyBox.video,
+      bvid: 'not-a-bvid',
+      url: 'https://www.bilibili.com/video/not-a-bvid',
+    } : undefined,
+  };
+  const emptyBox: ExperimentBlindBox = {
+    ...readyBox,
+    state: 'empty',
+    video: readyBox.video,
+  };
+
+  assert.deepEqual(getSuccessfulBlindBoxDrawBvids([
+    ...data.blindBoxes,
+    invalidBox,
+    emptyBox,
+    data.blindBoxes[0],
+  ]), [
+    'BV1RANDOM001',
+    'BV1REGION001',
+    'BV1FAVORIT01',
+    'BV1ARCHIVE01',
+  ]);
+});
+
+test('blind-box draw history keeps the latest 50 normalized BVIDs and clears with readback', async () => {
+  const storage = createMemoryStorage({
+    [BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]: Array.from({ length: 55 }, (_, index) => testBvid(index)),
+  });
+  const newest = ['BV1LATEST01', 'BV1LATEST02'];
+  const merged = mergeBlindBoxDrawHistory(
+    Array.from({ length: 55 }, (_, index) => testBvid(index)),
+    [...newest, 'not-a-bvid', testBvid(1)],
+  );
+
+  assert.equal(merged.length, BLIND_BOX_DRAW_HISTORY_LIMIT);
+  assert.deepEqual(merged.slice(0, 3), ['BV1LATEST01', 'BV1LATEST02', testBvid(1)]);
+  assert.equal(normalizeBlindBoxDrawHistory(['bad', 'BV1LATEST01', 'BV1LATEST01']).length, 1);
+
+  const afterRecord = await recordBlindBoxDrawnBvids(newest, storage);
+  assert.equal(afterRecord.length, BLIND_BOX_DRAW_HISTORY_LIMIT);
+  assert.deepEqual(afterRecord.slice(0, 2), newest);
+
+  const usage = await collectBlindBoxDrawHistoryUsage(storage);
+  assert.equal(usage.count, BLIND_BOX_DRAW_HISTORY_LIMIT);
+  assert.ok(usage.usageBytes > 0);
+
+  const clearedCount = await clearBlindBoxDrawHistory(storage);
+  assert.equal(clearedCount, BLIND_BOX_DRAW_HISTORY_LIMIT);
+  assert.deepEqual(await readBlindBoxDrawHistoryAfterClear(storage), {
+    count: 0,
+    usageBytes: 0,
+    empty: true,
+  });
+});
+
+test('blind-box draw history is registered for per-category clear and clear-all orchestration', async () => {
+  const dependencies = createRegistryDependenciesForBlindBox(['BV1LATEST01', 'BV1LATEST02']);
+  const categories = createRegisteredLocalDataCategories(dependencies);
+  const category = categories.find(item => item.id === 'blindBoxDrawHistory');
+
+  assert.ok(category);
+  assert.equal(category.includeInClearAll, true);
+  assert.deepEqual(await category.collectUsage(), {
+    count: 2,
+    usageBytes: JSON.stringify({ [BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]: ['BV1LATEST01', 'BV1LATEST02'] }).length,
+  });
+  assert.deepEqual(await category.clear(), {
+    cleared: { blindBoxDrawHistory: 2 },
+  });
+  assert.deepEqual(await category.readAfterClear(), {
+    count: 0,
+    usageBytes: 0,
+    empty: true,
+  });
+});
+
 test('formats experiment load errors without exposing runtime messages or raw fields', () => {
   const failures: unknown[] = [
     new Error('sourceHash=internal-hash'),
@@ -400,7 +612,10 @@ test('keeps blind-box candidate helpers out of service-worker dynamic preload', 
   assertNoForbiddenVisibleText(htmlVisibleText(mockSource));
 });
 
-function buildRandomContractData(random: () => number) {
+function buildRandomContractData(
+  random: () => number,
+  options: { recentDrawnBvids?: string[] } = {},
+) {
   const favorites = [
     createFavorite({
       itemKey: 'favorite-first',
@@ -434,6 +649,7 @@ function buildRandomContractData(random: () => number) {
       createArchiveCandidate('BV1ARCHIVE01', '第一条较早投稿'),
       createArchiveCandidate('BV1ARCHIVE02', '第二条较早投稿'),
     ]),
+    recentDrawnBvids: options.recentDrawnBvids,
   });
 }
 
@@ -510,7 +726,7 @@ function createReadyCrossRegionPool(
     evidence: [
       '最近最多 7 天有效观看中，高频分区是：游戏 2 次；本轮从这些分区之外随机选择「知识」。',
       '跨区漫游只使用仓库维护的固定公开分区目录和 B 站分区新视频接口，本轮候选分区为「知识」。',
-      '真实候选池返回 1 条可打开视频；本切片不使用最近抽取记录去重，也不改用本地历史或收藏补位。',
+      '真实候选池返回 1 条可打开视频；抽取时会优先避开最近抽中过的视频，但不会改用本地历史或收藏补位。',
     ],
     checkedRegionCount: 1,
     excludedInvalidCandidateCount: 0,
@@ -724,4 +940,64 @@ function emptyRelatedPool(): ExperimentRealCandidatePool {
     candidates: [],
     failures: [],
   };
+}
+
+function createMemoryStorage(initial: Record<string, unknown> = {}): BlindBoxDrawHistoryStorage {
+  const values = new Map<string, unknown>(Object.entries(initial));
+  return {
+    get: async keys => Object.fromEntries(keys.map(key => [key, values.get(key)])),
+    set: async items => {
+      for (const [key, value] of Object.entries(items)) {
+        values.set(key, value);
+      }
+    },
+    remove: async keys => {
+      for (const key of keys) {
+        values.delete(key);
+      }
+    },
+  };
+}
+
+function createRegistryDependenciesForBlindBox(bvids: string[]): LocalDataCategoryRegistryDependencies {
+  const tableNames: Array<keyof LocalDataCategoryRegistryDependencies['tables']> = [
+    'watchHistory',
+    'playerEvents',
+    'dailyAggregates',
+    'favoriteFolders',
+    'favoriteItems',
+    'smartFavoriteIndex',
+    'currentVideoTranscriptSources',
+    'currentVideoTranscriptSegments',
+    'followedCreators',
+    'followedVideoUpdates',
+    'dynamicBillItems',
+    'dynamicBillExplanations',
+    'dynamicBillFeedback',
+  ];
+  const tables = Object.fromEntries(
+    tableNames.map(name => [name, memoryTable([{ id: name }])]),
+  ) as LocalDataCategoryRegistryDependencies['tables'];
+  const storage = createMemoryStorage({ [BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]: bvids });
+
+  return {
+    tables,
+    storage,
+    transaction: async (_tables, operation) => operation(),
+  };
+}
+
+function memoryTable(initialRows: unknown[]): LocalDataCategoryTable {
+  let rows = [...initialRows];
+  return {
+    count: async () => rows.length,
+    toArray: async () => [...rows],
+    clear: async () => {
+      rows = [];
+    },
+  };
+}
+
+function testBvid(index: number): string {
+  return `BVTEST${String(index).padStart(6, '0')}`;
 }

--- a/tests/experiment-blind-boxes.test.ts
+++ b/tests/experiment-blind-boxes.test.ts
@@ -23,6 +23,7 @@ import {
   BLIND_BOX_DRAW_HISTORY_STORAGE_KEY,
   clearBlindBoxDrawHistory,
   collectBlindBoxDrawHistoryUsage,
+  getBlindBoxRecentDrawnBvids,
   mergeBlindBoxDrawHistory,
   normalizeBlindBoxDrawHistory,
   readBlindBoxDrawHistoryAfterClear,
@@ -100,7 +101,7 @@ test('builds fixed blind boxes with source labels for all four 0.13 sources', ()
   assert.equal(hiddenFavorite.title, '冷门收藏');
   assert.equal(hiddenFavorite.state, 'ready');
   assert.equal(hiddenFavorite.candidateSource, '本地收藏');
-  assert.equal(hiddenFavorite.realCandidateLabel, '未使用真实 B 站候选：这是本地收藏回访。');
+  assert.equal(hiddenFavorite.realCandidateLabel, '本卡不使用；固定从本地收藏回访。');
   assert.equal(hiddenFavorite.usesRealBilibiliCandidates, false);
   assert.equal(hiddenFavorite.video?.bvid, 'BVFAVHID01');
   assert.equal(hiddenFavorite.video?.sourceKind, 'local_favorite');
@@ -401,6 +402,7 @@ test('distinguishes no seed, no real candidates, upstream failure, and unopenabl
   });
   const noSeed = noSeedData.blindBoxes.find(box => box.id === 'random_explore');
   assert.equal(noSeed?.state, 'empty');
+  assert.equal(noSeed?.statusLabel, '没有可用种子');
   assert.equal(noSeed?.emptyTitle, '当前没有可用于探索的近期视频');
   assert.match(noSeed?.emptyDescription ?? '', /没有合格种子/);
 
@@ -467,6 +469,32 @@ test('distinguishes no seed, no real candidates, upstream failure, and unopenabl
   assert.equal(unopenable?.statusLabel, '候选不可打开');
   assert.match(unopenable?.emptyDescription ?? '', /返回了候选，但没有留下可打开的视频/);
   assertNoForbiddenVisibleText(visibleBlindBoxText(unopenable!));
+});
+
+test('cold favorites report reachable unopenable local records without implying an upstream failure', () => {
+  const data = buildExperimentData([], [createFavorite({
+    itemKey: 'unopenable-local-favorite',
+    bvid: 'not-a-bvid',
+    title: '缺少可打开身份的收藏',
+    folderTitle: '旧收藏',
+    tagName: '知识',
+    favDaysAgo: 180,
+  })], new Map(), NOW_MS, {
+    randomExplorePool: emptyRelatedPool(),
+    crossRegionPool: emptyCrossRegionPool(),
+    creatorArchivePool: emptyCreatorArchivePool(),
+  });
+  const coldFavorite = data.blindBoxes.find(box => box.id === 'hidden_favorite');
+
+  assert.equal(coldFavorite?.title, '冷门收藏');
+  assert.equal(coldFavorite?.state, 'empty');
+  assert.equal(coldFavorite?.statusLabel, '候选不可打开');
+  assert.equal(coldFavorite?.candidateSource, '本地收藏');
+  assert.equal(coldFavorite?.realCandidateLabel, '本卡不使用；固定从本地收藏回访。');
+  assert.equal(coldFavorite?.usesRealBilibiliCandidates, false);
+  assert.match(coldFavorite?.emptyDescription ?? '', /本地收藏/);
+  assert.doesNotMatch(visibleBlindBoxText(coldFavorite!), /接口|没有真实候选/);
+  assertNoForbiddenVisibleText(visibleBlindBoxText(coldFavorite!));
 });
 
 test('shared recent draw history prefers unseen candidates across all four cards', () => {
@@ -566,6 +594,131 @@ test('blind-box draw history keeps the latest 50 normalized BVIDs and clears wit
   });
 });
 
+test('overlapping blind-box history records retain both batches in newest-first order', async () => {
+  const firstGetStarted = createDeferred<void>();
+  const releaseFirstGet = createDeferred<void>();
+  let getCalls = 0;
+  const storage = createMemoryStorage({
+    [BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]: ['BV1EXISTING1'],
+  }, {
+    afterGetSnapshot: async call => {
+      getCalls = call;
+      if (call === 1) {
+        firstGetStarted.resolve();
+        await releaseFirstGet.promise;
+      }
+    },
+  });
+
+  const firstRecord = recordBlindBoxDrawnBvids(['BV1FIRST001'], storage);
+  await firstGetStarted.promise;
+  const secondRecord = recordBlindBoxDrawnBvids(['BV1SECOND01'], storage);
+  await Promise.resolve();
+  const getCallsBeforeRelease = getCalls;
+  releaseFirstGet.resolve();
+
+  const [firstResult, secondResult] = await Promise.all([firstRecord, secondRecord]);
+  assert.equal(getCallsBeforeRelease, 1, 'the second read must wait for the first mutation');
+  assert.deepEqual(firstResult, ['BV1FIRST001', 'BV1EXISTING1']);
+  assert.deepEqual(secondResult, ['BV1SECOND01', 'BV1FIRST001', 'BV1EXISTING1']);
+  assert.deepEqual(await getBlindBoxRecentDrawnBvids(storage), secondResult);
+});
+
+test('blind-box history clear waits for an earlier record and removes its completed result', async () => {
+  const setStarted = createDeferred<void>();
+  const releaseSet = createDeferred<void>();
+  let removeCalls = 0;
+  const storage = createMemoryStorage({
+    [BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]: ['BV1BASE0001'],
+  }, {
+    beforeSet: async () => {
+      setStarted.resolve();
+      await releaseSet.promise;
+    },
+    beforeRemove: () => {
+      removeCalls += 1;
+    },
+  });
+
+  const record = recordBlindBoxDrawnBvids(['BV1RECORD01'], storage);
+  await setStarted.promise;
+  const clear = clearBlindBoxDrawHistory(storage);
+  await Promise.resolve();
+  const removeCallsBeforeRelease = removeCalls;
+  releaseSet.resolve();
+
+  assert.deepEqual(await record, ['BV1RECORD01', 'BV1BASE0001']);
+  assert.equal(await clear, 2);
+  assert.equal(removeCallsBeforeRelease, 0, 'clear must wait for the earlier write');
+  assert.deepEqual(await getBlindBoxRecentDrawnBvids(storage), []);
+});
+
+test('a rejected blind-box history write does not poison the next mutation', async () => {
+  let rejectNextWrite = true;
+  const storage = createMemoryStorage({
+    [BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]: ['BV1STABLE001'],
+  }, {
+    beforeSet: () => {
+      if (rejectNextWrite) {
+        rejectNextWrite = false;
+        throw new Error('synthetic storage write failure');
+      }
+    },
+  });
+
+  await assert.rejects(
+    recordBlindBoxDrawnBvids(['BV1FAILED001'], storage),
+    /synthetic storage write failure/,
+  );
+  const next = await recordBlindBoxDrawnBvids(['BV1RECOVER01'], storage);
+
+  assert.deepEqual(next, ['BV1RECOVER01', 'BV1STABLE001']);
+  assert.deepEqual(await getBlindBoxRecentDrawnBvids(storage), next);
+});
+
+test('blind-box history reads and counts wait for prior mutations without deadlock', async () => {
+  const setStarted = createDeferred<void>();
+  const releaseSet = createDeferred<void>();
+  let getCalls = 0;
+  const storage = createMemoryStorage({
+    [BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]: ['BV1BEFORE001'],
+  }, {
+    afterGetSnapshot: call => {
+      getCalls = call;
+    },
+    beforeSet: async () => {
+      setStarted.resolve();
+      await releaseSet.promise;
+    },
+  });
+
+  const record = recordBlindBoxDrawnBvids(['BV1AFTER001'], storage);
+  await setStarted.promise;
+  const read = getBlindBoxRecentDrawnBvids(storage);
+  const usage = collectBlindBoxDrawHistoryUsage(storage);
+  const readback = readBlindBoxDrawHistoryAfterClear(storage);
+  await Promise.resolve();
+  const getCallsBeforeRelease = getCalls;
+  releaseSet.resolve();
+
+  await record;
+  assert.equal(getCallsBeforeRelease, 1, 'public reads must wait for the pending write');
+  assert.deepEqual(await read, ['BV1AFTER001', 'BV1BEFORE001']);
+  assert.deepEqual(await usage, {
+    count: 2,
+    usageBytes: JSON.stringify({
+      [BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]: ['BV1AFTER001', 'BV1BEFORE001'],
+    }).length,
+  });
+  assert.deepEqual(await readback, {
+    count: 2,
+    usageBytes: JSON.stringify({
+      [BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]: ['BV1AFTER001', 'BV1BEFORE001'],
+    }).length,
+    empty: false,
+  });
+});
+
 test('blind-box draw history is registered for per-category clear and clear-all orchestration', async () => {
   const dependencies = createRegistryDependenciesForBlindBox(['BV1LATEST01', 'BV1LATEST02']);
   const categories = createRegisteredLocalDataCategories(dependencies);
@@ -603,13 +756,26 @@ test('formats experiment load errors without exposing runtime messages or raw fi
   }
 });
 
+test('mock QA fixture keeps the four failure states and local favorite source contract distinct', () => {
+  const mockSource = readFileSync(new URL('./experiment-blind-boxes.mock.html', import.meta.url), 'utf8');
+  const mockVisibleText = htmlVisibleText(mockSource);
+
+  assert.match(mockSource, /data-box-id="cold_favorite_unopenable"/);
+  assert.match(mockVisibleText, /没有可用种子/);
+  assert.match(mockVisibleText, /没有真实候选/);
+  assert.match(mockVisibleText, /接口暂时失败/);
+  assert.match(mockVisibleText, /候选不可打开/);
+  assert.match(mockVisibleText, /冷门收藏/);
+  assert.match(mockVisibleText, /本卡不使用；固定从本地收藏回访/);
+  assert.doesNotMatch(mockVisibleText, /隐藏收藏/);
+  assertNoForbiddenVisibleText(mockVisibleText);
+});
+
 test('keeps blind-box candidate helpers out of service-worker dynamic preload', () => {
   const source = readFileSync(new URL('../src/background/analytics/suggestions.ts', import.meta.url), 'utf8');
-  const mockSource = readFileSync(new URL('./experiment-blind-boxes.mock.html', import.meta.url), 'utf8');
 
   assert.equal(source.includes("await import('../api/video-blind-box-candidates.ts')"), false);
   assert.match(source, /from ['"]\.\.\/api\/video-blind-box-candidates\.ts['"]/);
-  assertNoForbiddenVisibleText(htmlVisibleText(mockSource));
 });
 
 function buildRandomContractData(
@@ -942,21 +1108,53 @@ function emptyRelatedPool(): ExperimentRealCandidatePool {
   };
 }
 
-function createMemoryStorage(initial: Record<string, unknown> = {}): BlindBoxDrawHistoryStorage {
+interface MemoryStorageHooks {
+  afterGetSnapshot?: (call: number) => void | Promise<void>;
+  beforeSet?: (items: Record<string, unknown>, call: number) => void | Promise<void>;
+  beforeRemove?: (keys: string[], call: number) => void | Promise<void>;
+}
+
+function createMemoryStorage(
+  initial: Record<string, unknown> = {},
+  hooks: MemoryStorageHooks = {},
+): BlindBoxDrawHistoryStorage {
   const values = new Map<string, unknown>(Object.entries(initial));
+  let getCalls = 0;
+  let setCalls = 0;
+  let removeCalls = 0;
   return {
-    get: async keys => Object.fromEntries(keys.map(key => [key, values.get(key)])),
+    get: async keys => {
+      getCalls += 1;
+      const snapshot = Object.fromEntries(keys.map(key => [key, values.get(key)]));
+      await hooks.afterGetSnapshot?.(getCalls);
+      return snapshot;
+    },
     set: async items => {
+      setCalls += 1;
+      await hooks.beforeSet?.(items, setCalls);
       for (const [key, value] of Object.entries(items)) {
         values.set(key, value);
       }
     },
     remove: async keys => {
+      removeCalls += 1;
+      await hooks.beforeRemove?.(keys, removeCalls);
       for (const key of keys) {
         values.delete(key);
       }
     },
   };
+}
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>(currentResolve => {
+    resolve = currentResolve;
+  });
+  return { promise, resolve };
 }
 
 function createRegistryDependenciesForBlindBox(bvids: string[]): LocalDataCategoryRegistryDependencies {

--- a/tests/experiment-blind-boxes.test.ts
+++ b/tests/experiment-blind-boxes.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 import { formatExperimentLoadError } from '../dashboard/modules/experiments/experiment-copy.ts';
 import {
+  buildClaimedExperimentData,
   buildExperimentData,
   fetchRandomExploreCandidatePool,
   getSuccessfulBlindBoxDrawBvids,
@@ -23,6 +24,7 @@ import {
   BLIND_BOX_DRAW_HISTORY_STORAGE_KEY,
   clearBlindBoxDrawHistory,
   collectBlindBoxDrawHistoryUsage,
+  getBlindBoxDrawHistoryEpoch,
   getBlindBoxRecentDrawnBvids,
   mergeBlindBoxDrawHistory,
   normalizeBlindBoxDrawHistory,
@@ -624,6 +626,28 @@ test('overlapping blind-box history records retain both batches in newest-first 
   assert.deepEqual(await getBlindBoxRecentDrawnBvids(storage), secondResult);
 });
 
+test('concurrent blind-box generations claim from latest history and avoid duplicate BVIDs', async () => {
+  const storage = createMemoryStorage();
+  const drawHistoryEpoch = getBlindBoxDrawHistoryEpoch();
+  const generate = () => buildClaimedExperimentData([], [], new Map(), NOW_MS, {
+    random: () => 0,
+    randomExplorePool: createRelatedPool([
+      createRelatedCandidate('BV1CONCUR01', '并发候选一'),
+      createRelatedCandidate('BV1CONCUR02', '并发候选二'),
+    ]),
+    crossRegionPool: emptyCrossRegionPool(),
+    creatorArchivePool: emptyCreatorArchivePool(),
+  }, drawHistoryEpoch, storage);
+
+  const [first, second] = await Promise.all([generate(), generate()]);
+  const firstBvid = first.blindBoxes.find(box => box.id === 'random_explore')?.video?.bvid;
+  const secondBvid = second.blindBoxes.find(box => box.id === 'random_explore')?.video?.bvid;
+
+  assert.deepEqual(new Set([firstBvid, secondBvid]), new Set(['BV1CONCUR01', 'BV1CONCUR02']));
+  assert.notEqual(firstBvid, secondBvid);
+  assert.deepEqual(await getBlindBoxRecentDrawnBvids(storage), [secondBvid, firstBvid]);
+});
+
 test('blind-box history clear waits for an earlier record and removes its completed result', async () => {
   const setStarted = createDeferred<void>();
   const releaseSet = createDeferred<void>();
@@ -650,6 +674,36 @@ test('blind-box history clear waits for an earlier record and removes its comple
   assert.deepEqual(await record, ['BV1RECORD01', 'BV1BASE0001']);
   assert.equal(await clear, 2);
   assert.equal(removeCallsBeforeRelease, 0, 'clear must wait for the earlier write');
+  assert.deepEqual(await getBlindBoxRecentDrawnBvids(storage), []);
+});
+
+test('blind-box generation started before clear does not repopulate history after delayed candidates finish', async () => {
+  const storage = createMemoryStorage({
+    [BLIND_BOX_DRAW_HISTORY_STORAGE_KEY]: ['BV1BEFORECLR'],
+  });
+  const releaseCandidates = createDeferred<void>();
+  const drawHistoryEpoch = getBlindBoxDrawHistoryEpoch();
+  const generation = (async () => {
+    await releaseCandidates.promise;
+    return buildClaimedExperimentData([], [], new Map(), NOW_MS, {
+      random: () => 0,
+      randomExplorePool: createRelatedPool([
+        createRelatedCandidate('BV1AFTERCLR1', '清理后的迟到候选'),
+      ]),
+      crossRegionPool: emptyCrossRegionPool(),
+      creatorArchivePool: emptyCreatorArchivePool(),
+    }, drawHistoryEpoch, storage);
+  })();
+
+  assert.equal(await clearBlindBoxDrawHistory(storage), 1);
+  releaseCandidates.resolve();
+  const data = await generation;
+
+  assert.equal(data.blindBoxes.find(box => box.id === 'random_explore')?.video?.bvid, 'BV1AFTERCLR1');
+  assert.deepEqual(await collectBlindBoxDrawHistoryUsage(storage), {
+    count: 0,
+    usageBytes: 0,
+  });
   assert.deepEqual(await getBlindBoxRecentDrawnBvids(storage), []);
 });
 
@@ -760,14 +814,21 @@ test('mock QA fixture keeps the four failure states and local favorite source co
   const mockSource = readFileSync(new URL('./experiment-blind-boxes.mock.html', import.meta.url), 'utf8');
   const mockVisibleText = htmlVisibleText(mockSource);
 
-  assert.match(mockSource, /data-box-id="cold_favorite_unopenable"/);
-  assert.match(mockVisibleText, /没有可用种子/);
-  assert.match(mockVisibleText, /没有真实候选/);
-  assert.match(mockVisibleText, /接口暂时失败/);
-  assert.match(mockVisibleText, /候选不可打开/);
-  assert.match(mockVisibleText, /冷门收藏/);
-  assert.match(mockVisibleText, /本卡不使用；固定从本地收藏回访/);
-  assert.doesNotMatch(mockVisibleText, /隐藏收藏/);
+  assert.match(mockSource, /import \{ h, render \} from 'preact'/);
+  assert.match(mockSource, /import \{ ExperimentsPage \} from '\/dashboard\/modules\/experiments\/ExperimentsPage\.tsx'/);
+  assert.match(mockSource, /globalThis\.chrome\s*=\s*\{/);
+  assert.match(mockSource, /sendMessage:\s*async message/);
+  assert.match(mockSource, /message\?\.action !== 'GET_EXPERIMENT_DATA'/);
+  assert.match(mockSource, /render\(h\(ExperimentsPage, \{\}\), document\.getElementById\('app'\)\)/);
+  assert.doesNotMatch(mockSource, /<article\b/);
+  assert.match(mockSource, /createReadyExperimentData/);
+  assert.match(mockSource, /createFailureExperimentData/);
+  assert.match(mockSource, /没有可用种子/);
+  assert.match(mockSource, /没有真实候选/);
+  assert.match(mockSource, /接口暂时失败/);
+  assert.match(mockSource, /候选打不开/);
+  assert.match(mockSource, /本卡不使用；固定从本地收藏回访。/);
+  assert.doesNotMatch(mockSource, /隐藏收藏/);
   assertNoForbiddenVisibleText(mockVisibleText);
 });
 

--- a/tests/settings-local-data-privacy.test.ts
+++ b/tests/settings-local-data-privacy.test.ts
@@ -21,6 +21,7 @@ import {
   type LocalDataCategoryRegistryDependencies,
   type LocalDataCategoryTable,
 } from '../src/background/storage/local-data-category-registry.ts';
+import { BLIND_BOX_DRAW_HISTORY_STORAGE_KEY } from '../src/background/storage/blind-box-draw-history-repo.ts';
 import type {
   LocalDataOperationResult,
   LocalDataPrivacySummary,
@@ -108,6 +109,7 @@ test('local data categories expose the shared lifecycle contract', () => {
     'favorites',
     'currentVideoSubtitles',
     'dynamicBill',
+    'blindBoxDrawHistory',
     'localSettings',
   ]);
 
@@ -122,7 +124,7 @@ test('registered categories collect usage, clear independently, and read back th
   const categories = createRegisteredLocalDataCategories(dependencies);
   const usageBefore = await Promise.all(categories.map(category => category.collectUsage()));
 
-  assert.deepEqual(usageBefore.map(usage => usage.count), [3, 3, 2, 6, 2]);
+  assert.deepEqual(usageBefore.map(usage => usage.count), [3, 3, 2, 6, 2, 2]);
   assert.ok(usageBefore.every(usage => usage.usageBytes > 0));
 
   const history = categories[0];
@@ -299,6 +301,7 @@ function createRegistryDependencies(): LocalDataCategoryRegistryDependencies {
   const storage = new Map<string, unknown>([
     ['lastSyncTime', 100],
     ['dynamicBillSyncState', { status: 'success' }],
+    [BLIND_BOX_DRAW_HISTORY_STORAGE_KEY, ['BV1LATEST01', 'BV1LATEST02']],
     ['userConfig', { assistant: {} }],
     ['floatingPopupWindowId', 7],
   ]);


### PR DESCRIPTION
## Scope

Issue: #179 / BB-013-B.

- Adds distinct blind-box empty states for no seed, no real candidates, upstream/API failure, and candidates that cannot be opened.
- Keeps the four BB-013-A source contracts isolated: related-video, public region newlist, local favorites, and followed-creator archives do not borrow from each other.
- Adds one shared local latest-50 successful-draw BVID history across all four cards, prefers unseen openable candidates, and falls back uniformly to the full valid pool when every valid candidate is repeated.
- Records only successful openable draws; BVIDs remain internal storage state and are not exposed as user-facing copy.
- Registers blind-box draw history with the SET-013-A local-data category registry for count, per-category clear, clear-all inclusion, and readback verification. No separate settings button and no SET-013-B orchestration work.

## Review Rework

- Serializes the complete draw-history read/normalize/merge/write mutation with a module-local async queue.
- Serializes per-category clear/remove against record mutations. Public read, count, and readback calls wait for earlier mutations without waiting on themselves.
- Recovers the queue tail after a rejected mutation so later records still run.
- Adds deterministic deferred-storage coverage proving overlapping record batches are both retained in newest-first order, record-then-clear has a defined serialized result, a rejected write does not poison the next mutation, and public reads observe completed prior mutations.
- Uses the fixed `冷门收藏` card name and states explicitly that this card is a local-favorites revisit which does not request real B-site candidates.
- Adds an explicit `候选不可打开` mock card. Browser/mock states are distinct: `没有可用种子`, `没有真实候选`, `接口暂时失败`, and `候选不可打开`.

## Validation

- `npm.cmd run test:experiments` -> 24 passed.
- `node --test tests/settings-local-data-privacy.test.ts` -> 12 passed.
- `npm.cmd run test:favorites` -> 29 passed.
- `npm.cmd run typecheck` -> passed.
- `npm.cmd run build` -> passed. Vite still reports the existing dynamic-import and `chunks/theme-*.js` size warnings.
- `git diff --check` and `git diff --cached --check` -> passed; only line-ending normalization warnings were printed.
- Product-copy scan for `未消费|猜你喜欢` across `dashboard`, `popup`, `public`, `src`, and the mock HTML -> no matches.
- User-facing experiment/local-data copy scan for `fallback|transcript|confidence|sourceHash|segmentId|subtitle_url` -> no matches. Test-only sentinels remain in the deterministic sanitization test.
- Stale-copy scan for `隐藏收藏` across user-facing surfaces and the mock HTML -> no matches.
- Actual Python Playwright/Chromium QA on `tests/experiment-blind-boxes.mock.html` -> verified four ready cards and four distinct failure cards, source labels, ready-only Bilibili links, failure-only retry buttons, local-only cold-favorite semantics, and all forbidden-copy guards.
- Final two-axis review against `a777b5252a4a2ad7028ac4a078f7b7e86be54d52` -> no remaining standards or issue-spec findings.

## Privacy Evidence

- Did not read Cookie, browser profile, login-state, key files, `C:\Users\LittleNub\Desktop\Key.txt`, real complete history/favorites/following/feedback, or real IndexedDB.
- Used repository docs/code/tests, GitHub issue/PR metadata, deterministic fixtures, static mock HTML, and synthetic in-memory storage only.
- `privacy_sensitive_files_read=false`.

## Baseline And State

- Previous head: `fe3a56b6fdc5e86a72970614053f4874f584ce91`.
- Rework head: `f96c0470178c587a01173cd5b6392b661ec16e4f`.
- Still based on `a777b5252a4a2ad7028ac4a078f7b7e86be54d52`; intentionally not rebased while #185 is pending.
- PR remains draft/open and unmerged. Issue #179 remains open.

## Non-Goals Kept Out

- No #82/#83 work.
- No current-video work.
- No Dynamic Bill work.
- No release/tag/package/version/assets work.
- No unrelated refactors.
