### PR TITLE
feat: add full-text current-video Q&A

### DIFF
--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -21,6 +21,10 @@ import type {
   CurrentVideoSummaryHighlightBinding,
   CurrentVideoSummaryHighlightsResult,
 } from '../src/shared/types/current-video-summary';
+import type {
+  CurrentVideoFullTextQaCitation,
+  CurrentVideoFullTextQaResult,
+} from '../src/shared/types/current-video-full-text-qa';
 import type { VideoKnowledgeNode, VideoKnowledgeResult } from '../src/shared/types/video-knowledge';
 import {
   asPriorGeneratedCurrentVideoSummaryHighlights,
@@ -1002,24 +1006,46 @@ function CurrentVideoAssistantStatus({
   const [segmentReturnAvailable, setSegmentReturnAvailable] = useState(false);
   const [segmentJumpLoading, setSegmentJumpLoading] = useState(false);
   const [segmentReturnLoading, setSegmentReturnLoading] = useState(false);
+  const [fullTextQaResult, setFullTextQaResult] = useState<CurrentVideoFullTextQaResult | null>(null);
+  const [fullTextQaLoading, setFullTextQaLoading] = useState(false);
+  const [fullTextQaError, setFullTextQaError] = useState<string | null>(null);
+  const [fullTextQaPreviewCitationId, setFullTextQaPreviewCitationId] = useState<string | null>(null);
+  const [fullTextQaJumpStatus, setFullTextQaJumpStatus] = useState<string | null>(null);
+  const [fullTextQaReturnAvailable, setFullTextQaReturnAvailable] = useState(false);
+  const [fullTextQaJumpLoading, setFullTextQaJumpLoading] = useState(false);
+  const [fullTextQaReturnLoading, setFullTextQaReturnLoading] = useState(false);
   const [highlightPreview, setHighlightPreview] = useState<CurrentVideoSummaryHighlightBinding | null>(null);
   const [highlightJumpStatus, setHighlightJumpStatus] = useState<string | null>(null);
   const [highlightReturnAvailable, setHighlightReturnAvailable] = useState(false);
   const [highlightJumpLoading, setHighlightJumpLoading] = useState(false);
   const [highlightReturnLoading, setHighlightReturnLoading] = useState(false);
   const segmentSearchRequestRef = useRef(0);
+  const fullTextQaRequestRef = useRef(0);
   const timestampRequestRef = useRef(0);
   const segmentSearchBusyRef = useRef(false);
   const timestampBusyRef = useRef(false);
+  const fullTextQaBusyRef = useRef(false);
+  const fullTextQaActiveRequestRef = useRef<{
+    requestId: string;
+    turnId: string;
+    params: Record<string, unknown>;
+  } | null>(null);
   const subtitleDiagnostics = buildCurrentVideoSubtitleDiagnostics(context, {
     refreshing: subtitleProbeLoading,
   });
 
   useEffect(() => {
+    const activeQaRequest = fullTextQaActiveRequestRef.current;
+    if (activeQaRequest) {
+      void requestSW('CANCEL_CURRENT_VIDEO_FULL_TEXT_QA', activeQaRequest.params).catch(() => undefined);
+      fullTextQaActiveRequestRef.current = null;
+    }
     segmentSearchRequestRef.current += 1;
+    fullTextQaRequestRef.current += 1;
     timestampRequestRef.current += 1;
     segmentSearchBusyRef.current = false;
     timestampBusyRef.current = false;
+    fullTextQaBusyRef.current = false;
     setSegmentLoading(false);
     setSegmentJumpLoading(false);
     setSegmentReturnLoading(false);
@@ -1030,6 +1056,14 @@ function CurrentVideoAssistantStatus({
     setSegmentPreviewCandidateId(null);
     setSegmentJumpStatus(null);
     setSegmentReturnAvailable(false);
+    setFullTextQaResult(null);
+    setFullTextQaLoading(false);
+    setFullTextQaError(null);
+    setFullTextQaPreviewCitationId(null);
+    setFullTextQaJumpStatus(null);
+    setFullTextQaReturnAvailable(false);
+    setFullTextQaJumpLoading(false);
+    setFullTextQaReturnLoading(false);
     setHighlightPreview(null);
     setHighlightJumpStatus(null);
     setHighlightReturnAvailable(false);
@@ -1124,6 +1158,163 @@ function CurrentVideoAssistantStatus({
       if (scopedActionIsCurrent(action, timestampRequestRef)) {
         timestampBusyRef.current = false;
         setHighlightReturnLoading(false);
+      }
+    }
+  }
+
+  async function askCurrentVideoFullText(retryTurnId?: string, retryQuestion?: string) {
+    const question = (retryQuestion ?? segmentQuery).replace(/\s+/g, ' ').trim();
+    if (!question) {
+      setFullTextQaError('请输入一个关于当前视频的问题。');
+      return;
+    }
+    if (subtitleProbeLoading || fullTextQaBusyRef.current || timestampBusyRef.current) return;
+
+    const action = beginScopedAction(fullTextQaRequestRef);
+    fullTextQaBusyRef.current = true;
+    setFullTextQaLoading(true);
+    setFullTextQaError(null);
+    setFullTextQaResult(null);
+    setFullTextQaPreviewCitationId(null);
+    setFullTextQaJumpStatus(null);
+    setFullTextQaReturnAvailable(false);
+    const requestId = createCurrentVideoFullTextRequestId('cvqa-popup');
+    const turnId = retryTurnId?.trim() || createCurrentVideoFullTextRequestId('cvqa-turn');
+    if (retryQuestion !== undefined) setSegmentQuery(question);
+    const baseParams = { requestId, turnId, question };
+    fullTextQaActiveRequestRef.current = { requestId, turnId, params: baseParams };
+    try {
+      const authorization = await popupCurrentVideoPrimaryTextAuthorization(context);
+      if (!scopedActionIsCurrent(action, fullTextQaRequestRef)) return;
+      if (!authorization.ready) {
+        setFullTextQaError(authorization.message);
+        return;
+      }
+      const params = { ...baseParams, ...authorization.params };
+      fullTextQaActiveRequestRef.current = { requestId, turnId, params };
+      const result = await requestSW<CurrentVideoFullTextQaResult>('ASK_CURRENT_VIDEO_FULL_TEXT', params);
+      if (
+        !scopedActionIsCurrent(action, fullTextQaRequestRef)
+        || fullTextQaActiveRequestRef.current?.requestId !== requestId
+        || result.requestId !== requestId
+        || result.turnId !== turnId
+      ) return;
+      setFullTextQaResult(result);
+    } catch {
+      if (!scopedActionIsCurrent(action, fullTextQaRequestRef)) return;
+      setFullTextQaError('回答失败，问题已保留。请确认当前视频页和 AI 设置后重试。');
+    } finally {
+      if (scopedActionIsCurrent(action, fullTextQaRequestRef)) {
+        fullTextQaBusyRef.current = false;
+        fullTextQaActiveRequestRef.current = null;
+        setFullTextQaLoading(false);
+      }
+    }
+  }
+
+  function cancelCurrentVideoFullTextQa() {
+    const active = fullTextQaActiveRequestRef.current;
+    if (!active) return;
+    fullTextQaRequestRef.current += 1;
+    fullTextQaActiveRequestRef.current = null;
+    fullTextQaBusyRef.current = false;
+    setFullTextQaLoading(false);
+    setFullTextQaResult(null);
+    setFullTextQaError('本次回答已取消，问题已保留。');
+    setFullTextQaPreviewCitationId(null);
+    setFullTextQaJumpStatus(null);
+    setFullTextQaReturnAvailable(false);
+    void requestSW('CANCEL_CURRENT_VIDEO_FULL_TEXT_QA', active.params).catch(() => undefined);
+  }
+
+  async function confirmFullTextQaCitationJump(citation: CurrentVideoFullTextQaCitation) {
+    if (
+      !fullTextQaResult
+      || fullTextQaPreviewCitationId !== citation.id
+      || subtitleProbeLoading
+      || fullTextQaBusyRef.current
+      || timestampBusyRef.current
+    ) return;
+    const currentCitation = fullTextQaResult.citations.find(item =>
+      item.binding.requestId === citation.binding.requestId
+      && item.binding.turnId === citation.binding.turnId
+      && item.binding.citationId === citation.binding.citationId
+    );
+    if (!currentCitation) {
+      setFullTextQaPreviewCitationId(null);
+      setFullTextQaJumpStatus('引用结果已变化，请重新预览后再跳转。');
+      return;
+    }
+    const action = beginScopedAction(timestampRequestRef);
+    timestampBusyRef.current = true;
+    setFullTextQaJumpLoading(true);
+    setFullTextQaReturnLoading(false);
+    setFullTextQaReturnAvailable(false);
+    setFullTextQaJumpStatus('正在确认跳转...');
+    try {
+      const authorization = await popupCurrentVideoPrimaryTextAuthorization(context);
+      if (!scopedActionIsCurrent(action, timestampRequestRef)) return;
+      if (!authorization.ready) {
+        setFullTextQaJumpStatus(authorization.message);
+        return;
+      }
+      const result = await requestSW<CurrentVideoTimestampJumpResponse>(
+        'REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP',
+        { ...citation.binding, confirmed: true, ...authorization.params },
+      );
+      if (!scopedActionIsCurrent(action, timestampRequestRef)) return;
+      setFullTextQaJumpStatus(result.ok
+        ? '已跳到引用位置，可返回原位置。'
+        : '引用结果或页面状态已变化，请重新提交问题后再试。');
+      setFullTextQaReturnAvailable(result.ok && result.returnPointSeconds !== null);
+      setFullTextQaPreviewCitationId(null);
+    } catch {
+      if (!scopedActionIsCurrent(action, timestampRequestRef)) return;
+      setFullTextQaJumpStatus('引用跳转失败，请确认当前 B 站视频页仍然打开后重试。');
+      setFullTextQaReturnAvailable(false);
+    } finally {
+      if (scopedActionIsCurrent(action, timestampRequestRef)) {
+        timestampBusyRef.current = false;
+        setFullTextQaJumpLoading(false);
+      }
+    }
+  }
+
+  async function returnFullTextQaCitationJump() {
+    if (
+      !fullTextQaReturnAvailable
+      || subtitleProbeLoading
+      || fullTextQaBusyRef.current
+      || timestampBusyRef.current
+    ) return;
+    const action = beginScopedAction(timestampRequestRef);
+    timestampBusyRef.current = true;
+    setFullTextQaReturnLoading(true);
+    setFullTextQaJumpStatus('正在返回原位置...');
+    try {
+      const authorization = await popupCurrentVideoPrimaryTextAuthorization(context);
+      if (!scopedActionIsCurrent(action, timestampRequestRef)) return;
+      if (!authorization.ready) {
+        setFullTextQaJumpStatus(authorization.message);
+        setFullTextQaReturnAvailable(false);
+        return;
+      }
+      const result = await requestSW<CurrentVideoTimestampReturnResponse>(
+        'RETURN_CURRENT_VIDEO_SEGMENT_JUMP',
+        authorization.params,
+      );
+      if (!scopedActionIsCurrent(action, timestampRequestRef)) return;
+      setFullTextQaJumpStatus(result.ok
+        ? '已返回原位置。'
+        : '未能返回原位置，请回到当前视频页确认页面和播放器状态后重试。');
+      if (result.ok) setFullTextQaReturnAvailable(false);
+    } catch {
+      if (!scopedActionIsCurrent(action, timestampRequestRef)) return;
+      setFullTextQaJumpStatus('返回原位置失败，请确认当前 B 站视频页仍然打开后重试。');
+    } finally {
+      if (scopedActionIsCurrent(action, timestampRequestRef)) {
+        timestampBusyRef.current = false;
+        setFullTextQaReturnLoading(false);
       }
     }
   }
@@ -1411,23 +1602,25 @@ function CurrentVideoAssistantStatus({
             loading={knowledgeLoading || subtitleProbeLoading}
             onRefresh={onRefreshKnowledge}
           />
-          <CurrentVideoSegmentRetrievalPanel
-            subtitleDiagnostics={subtitleDiagnostics}
+          <CurrentVideoFullTextQaPanel
+            context={context}
             query={segmentQuery}
-            result={segmentResult}
-            loading={segmentLoading}
-            error={segmentError}
-            previewCandidateId={segmentPreviewCandidateId}
-            jumpStatus={segmentJumpStatus}
-            returnAvailable={segmentReturnAvailable}
-            jumpLoading={segmentJumpLoading}
-            returnLoading={segmentReturnLoading}
+            result={fullTextQaResult}
+            loading={fullTextQaLoading}
+            error={fullTextQaError}
+            previewCitationId={fullTextQaPreviewCitationId}
+            jumpStatus={fullTextQaJumpStatus}
+            returnAvailable={fullTextQaReturnAvailable}
+            jumpLoading={fullTextQaJumpLoading}
+            returnLoading={fullTextQaReturnLoading}
             operationBlocked={subtitleProbeLoading}
             onQueryChange={setSegmentQuery}
-            onSearch={searchCurrentVideoSegments}
-            onPreviewCandidate={setSegmentPreviewCandidateId}
-            onConfirmJump={confirmSegmentJump}
-            onReturn={returnSegmentJump}
+            onSubmit={() => { void askCurrentVideoFullText(); }}
+            onCancel={cancelCurrentVideoFullTextQa}
+            onRetry={(turnId, question) => { void askCurrentVideoFullText(turnId, question); }}
+            onPreviewCitation={setFullTextQaPreviewCitationId}
+            onConfirmJump={confirmFullTextQaCitationJump}
+            onReturn={returnFullTextQaCitationJump}
             onOpenSettings={onOpenSettings}
           />
           <div style={{ display: 'flex', gap: '6px', marginTop: '8px' }}>
@@ -1755,6 +1948,360 @@ function HighlightJumpPreview({
           type="button"
           onClick={onCancel}
           disabled={disabled}
+          style={{
+            background: 'transparent',
+            color: '#C8C8D8',
+            border: '1px solid rgba(255,255,255,0.14)',
+            borderRadius: '6px',
+            cursor: disabled ? 'default' : 'pointer',
+            fontSize: '10px',
+            padding: '5px 7px',
+          }}
+        >
+          取消
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function CurrentVideoFullTextQaPanel({
+  context,
+  query,
+  result,
+  loading,
+  error,
+  previewCitationId,
+  jumpStatus,
+  returnAvailable,
+  jumpLoading,
+  returnLoading,
+  operationBlocked,
+  onQueryChange,
+  onSubmit,
+  onCancel,
+  onRetry,
+  onPreviewCitation,
+  onConfirmJump,
+  onReturn,
+  onOpenSettings,
+}: {
+  context: CurrentVideoContextResult | null;
+  query: string;
+  result: CurrentVideoFullTextQaResult | null;
+  loading: boolean;
+  error: string | null;
+  previewCitationId: string | null;
+  jumpStatus: string | null;
+  returnAvailable: boolean;
+  jumpLoading: boolean;
+  returnLoading: boolean;
+  operationBlocked: boolean;
+  onQueryChange: (query: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+  onRetry: (turnId: string, question: string) => void;
+  onPreviewCitation: (citationId: string | null) => void;
+  onConfirmJump: (citation: CurrentVideoFullTextQaCitation) => void;
+  onReturn: () => void;
+  onOpenSettings: () => void;
+}) {
+  const previewCitation = result?.citations.find(citation => citation.id === previewCitationId) ?? null;
+  const timestampLoading = jumpLoading || returnLoading;
+  const controlsDisabled = loading || timestampLoading || operationBlocked;
+  const hasAnswer = Boolean(result?.answer.trim());
+
+  return (
+    <div style={{
+      marginTop: '8px',
+      padding: '8px',
+      border: '1px solid rgba(251, 114, 153, 0.24)',
+      borderRadius: '6px',
+      background: 'rgba(251, 114, 153, 0.07)',
+    }}>
+      <div style={{ color: '#FFD6E2', fontSize: '10px', fontWeight: 700 }}>
+        问这个视频
+      </div>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          onSubmit();
+        }}
+      >
+        <textarea
+          value={query}
+          maxLength={500}
+          rows={3}
+          onInput={(event) => onQueryChange((event.currentTarget as HTMLTextAreaElement).value)}
+          placeholder="例如：作者为什么认为这个方法更可靠？"
+          style={{
+            boxSizing: 'border-box',
+            width: '100%',
+            marginTop: '6px',
+            resize: 'vertical',
+            minHeight: '58px',
+            maxHeight: '120px',
+            background: 'rgba(255,255,255,0.08)',
+            color: '#E8E8F2',
+            border: '1px solid rgba(255,255,255,0.14)',
+            borderRadius: '6px',
+            fontSize: '11px',
+            lineHeight: 1.45,
+            padding: '7px 8px',
+            outline: 'none',
+          }}
+        />
+        <div style={{ color: '#A0A0B0', fontSize: '9px', lineHeight: 1.45, marginTop: '4px' }}>
+          {currentVideoFullTextQaActionNotice(context, result)}
+        </div>
+        <div style={{ display: 'flex', gap: '6px', marginTop: '6px' }}>
+          <button
+            type="submit"
+            disabled={controlsDisabled || !query.trim()}
+            style={{
+              flex: 1,
+              background: controlsDisabled || !query.trim() ? 'rgba(251, 114, 153, 0.12)' : '#FB7299',
+              color: controlsDisabled || !query.trim() ? '#A0A0B0' : '#fff',
+              border: '1px solid rgba(251, 114, 153, 0.36)',
+              borderRadius: '6px',
+              cursor: controlsDisabled || !query.trim() ? 'default' : 'pointer',
+              fontSize: '10px',
+              fontWeight: 700,
+              padding: '6px 8px',
+            }}
+          >
+            {loading ? '回答中...' : '提问'}
+          </button>
+          {loading && (
+            <button
+              type="button"
+              onClick={onCancel}
+              style={{
+                background: 'transparent',
+                color: '#C8C8D8',
+                border: '1px solid rgba(255,255,255,0.14)',
+                borderRadius: '6px',
+                cursor: 'pointer',
+                fontSize: '10px',
+                padding: '6px 8px',
+              }}
+            >
+              取消
+            </button>
+          )}
+        </div>
+      </form>
+
+      {error && (
+        <div style={{ color: '#FFCF8A', fontSize: '10px', lineHeight: 1.45, marginTop: '7px' }}>
+          {error}
+        </div>
+      )}
+
+      {result && (
+        <div style={{ marginTop: '8px', borderTop: '1px solid rgba(255,255,255,0.09)', paddingTop: '7px' }}>
+          <div style={{ color: fullTextQaStatusColor(result.status), fontSize: '10px', lineHeight: 1.45, fontWeight: 700 }}>
+            {result.status === 'ready' ? '回答' : fullTextQaStatusLabel(result.status)}
+          </div>
+          {hasAnswer ? (
+            <div style={{ color: '#E8E8F2', fontSize: '10px', lineHeight: 1.55, marginTop: '4px', whiteSpace: 'pre-wrap' }}>
+              {safeFullTextQaVisibleText(result.answer)}
+            </div>
+          ) : (
+            <div style={{ color: '#C8C8D8', fontSize: '10px', lineHeight: 1.45, marginTop: '4px' }}>
+              {safeFullTextQaVisibleText(result.message)}
+            </div>
+          )}
+          {result.sourceLabel && (
+            <div style={{ color: '#A0A0B0', fontSize: '9px', lineHeight: 1.45, marginTop: '5px' }}>
+              {fullTextQaSourceLine(result)}
+            </div>
+          )}
+          {result.status === 'ready' && result.citations.length > 0 && (
+            <div style={{ marginTop: '7px' }}>
+              <div style={{ color: '#C8E6FF', fontSize: '10px', lineHeight: 1.45, fontWeight: 700 }}>
+                引用片段
+              </div>
+              {result.citations.slice(0, 3).map((citation, index) => (
+                <CurrentVideoFullTextQaCitationRow
+                  key={citation.id}
+                  citation={citation}
+                  index={index}
+                  selected={citation.id === previewCitationId}
+                  disabled={controlsDisabled}
+                  onPreview={onPreviewCitation}
+                />
+              ))}
+            </div>
+          )}
+          {previewCitation && (
+            <CurrentVideoFullTextQaCitationPreview
+              citation={previewCitation}
+              disabled={controlsDisabled}
+              loading={jumpLoading}
+              onConfirm={() => onConfirmJump(previewCitation)}
+              onCancel={() => onPreviewCitation(null)}
+            />
+          )}
+          {jumpStatus && (
+            <div style={{ color: jumpStatus.includes('失败') || jumpStatus.includes('不可') || jumpStatus.includes('变化') ? '#FFCF8A' : '#A0E7A0', fontSize: '10px', lineHeight: 1.45, marginTop: '6px' }}>
+              {jumpStatus}
+            </div>
+          )}
+          {returnAvailable && (
+            <button
+              type="button"
+              onClick={onReturn}
+              disabled={controlsDisabled}
+              style={{
+                marginTop: '6px',
+                width: '100%',
+                background: 'rgba(255, 179, 71, 0.18)',
+                color: '#FFCF8A',
+                border: '1px solid rgba(255, 179, 71, 0.34)',
+                borderRadius: '6px',
+                cursor: controlsDisabled ? 'default' : 'pointer',
+                fontSize: '10px',
+                fontWeight: 700,
+                padding: '5px 7px',
+              }}
+            >
+              {returnLoading ? '返回中...' : '返回原位置'}
+            </button>
+          )}
+          {result.canRetry && result.status !== 'ready' && (
+            <button
+              type="button"
+              onClick={() => onRetry(result.turnId, result.question)}
+              disabled={controlsDisabled}
+              style={{
+                marginTop: '6px',
+                width: '100%',
+                background: 'rgba(251, 114, 153, 0.16)',
+                color: '#FFD6E2',
+                border: '1px solid rgba(251, 114, 153, 0.30)',
+                borderRadius: '6px',
+                cursor: controlsDisabled ? 'default' : 'pointer',
+                fontSize: '10px',
+                fontWeight: 700,
+                padding: '5px 7px',
+              }}
+            >
+              重新提交
+            </button>
+          )}
+          {needsAiSettingsLink(result.status) && (
+            <SettingsInlineButton onClick={onOpenSettings} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CurrentVideoFullTextQaCitationRow({
+  citation,
+  index,
+  selected,
+  disabled,
+  onPreview,
+}: {
+  citation: CurrentVideoFullTextQaCitation;
+  index: number;
+  selected: boolean;
+  disabled: boolean;
+  onPreview: (citationId: string | null) => void;
+}) {
+  return (
+    <div style={{ marginTop: '6px', paddingTop: '6px', borderTop: '1px solid rgba(255,255,255,0.08)' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '8px', alignItems: 'flex-start' }}>
+        <div style={{ color: '#E8E8F2', fontSize: '10px', lineHeight: 1.4, fontWeight: 650 }}>
+          引用 {index + 1}
+        </div>
+        <div style={{ color: '#C8E6FF', fontSize: '9px', lineHeight: 1.4, flex: '0 0 auto' }}>
+          {citation.timeRangeLabel}
+        </div>
+      </div>
+      <div style={{ color: '#C8C8D8', fontSize: '9px', lineHeight: 1.45, marginTop: '3px' }}>
+        {safeFullTextQaVisibleText(citation.evidenceText)}
+      </div>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => onPreview(selected ? null : citation.id)}
+        style={{
+          marginTop: '5px',
+          background: 'rgba(0, 161, 214, 0.20)',
+          color: '#C8E6FF',
+          border: '1px solid rgba(127, 219, 255, 0.32)',
+          borderRadius: '6px',
+          cursor: disabled ? 'default' : 'pointer',
+          fontSize: '10px',
+          padding: '4px 7px',
+        }}
+      >
+        {selected ? '收起预览' : '预览跳转'}
+      </button>
+    </div>
+  );
+}
+
+function CurrentVideoFullTextQaCitationPreview({
+  citation,
+  disabled,
+  loading,
+  onConfirm,
+  onCancel,
+}: {
+  citation: CurrentVideoFullTextQaCitation;
+  disabled: boolean;
+  loading: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div style={{
+      marginTop: '8px',
+      padding: '8px',
+      border: '1px solid rgba(255,179,71,0.28)',
+      borderRadius: '6px',
+      background: 'rgba(255,179,71,0.08)',
+    }}>
+      <div style={{ color: '#FFCF8A', fontSize: '10px', lineHeight: 1.45, fontWeight: 700 }}>
+        确认跳转前预览
+      </div>
+      <div style={{ color: '#E8E8F2', fontSize: '10px', lineHeight: 1.45, marginTop: '4px' }}>
+        目标时间：{citation.timeRangeLabel}
+      </div>
+      <div style={{ color: '#C8E6FF', fontSize: '9px', lineHeight: 1.45, marginTop: '3px' }}>
+        片段内容：{safeFullTextQaVisibleText(citation.evidenceText)}
+      </div>
+      <div style={{ color: '#A0E7A0', fontSize: '9px', lineHeight: 1.45, marginTop: '3px' }}>
+        确认后才会跳转，可再返回原位置。
+      </div>
+      <div style={{ display: 'flex', gap: '6px', marginTop: '6px' }}>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onConfirm}
+          style={{
+            flex: 1,
+            background: disabled ? 'rgba(255,255,255,0.08)' : '#FFB347',
+            color: disabled ? '#9090A0' : '#1A1A2E',
+            border: 'none',
+            borderRadius: '6px',
+            cursor: disabled ? 'default' : 'pointer',
+            fontSize: '10px',
+            fontWeight: 700,
+            padding: '5px 7px',
+          }}
+        >
+          {loading ? '确认中...' : '确认跳转'}
+        </button>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onCancel}
           style={{
             background: 'transparent',
             color: '#C8C8D8',
@@ -2455,6 +3002,95 @@ function currentVideoSummaryActionNotice(
     return `可发送正文规模：${lineCount} 行，约 ${formatBytes(bytes)}。只有点击生成才会发送；等待时间和费用由你配置的 AI 服务决定。`;
   }
   return '当前没有可发送的正文。只有在视频页选择主要文本来源后，才可以手动生成。';
+}
+
+function currentVideoFullTextQaActionNotice(
+  context: CurrentVideoContextResult | null,
+  result: CurrentVideoFullTextQaResult | null,
+): string {
+  const durationSeconds = context?.kind === 'video'
+    ? context.currentPart.page > 0
+      ? context.parts.find(part => part.page === context.currentPart.page)?.durationSeconds ?? context.durationSeconds
+      : context.durationSeconds
+    : null;
+  const durationLabel = typeof durationSeconds === 'number' && durationSeconds > 0
+    ? `，视频约 ${formatPopupDuration(durationSeconds)}`
+    : '';
+  if (result) {
+    return `每次提交都会发送当前分 P 的完整主要文本（${formatTextSize(result.textSize)}${durationLabel}）。长文本可能等待更久并产生更多费用，系统不会静默截短。`;
+  }
+  if (context?.kind === 'video') {
+    const lineCount = context.transcriptEvidence?.segmentCount ?? 0;
+    const bytes = context.transcriptEvidence?.serializedBytes ?? 0;
+    return `每次提交都会发送当前分 P 的完整主要文本（${lineCount} 行，约 ${formatBytes(bytes)}${durationLabel}）。长文本可能等待更久并产生更多费用，系统不会静默截短。`;
+  }
+  return '当前没有可发送的主要文本。进入 B 站视频页并确认文本来源后再提交。';
+}
+
+function fullTextQaStatusLabel(status: CurrentVideoFullTextQaResult['status']): string {
+  switch (status) {
+    case 'unsupported':
+      return '文本依据不足';
+    case 'no_context':
+      return '当前视频不可用';
+    case 'no_text':
+      return '当前文本不可用';
+    case 'disabled':
+      return '功能未开启';
+    case 'not_configured':
+      return 'AI 服务未配置';
+    case 'context_too_long':
+      return '正文超出所选模型限制';
+    case 'cancelled':
+      return '已取消';
+    case 'invalid_output':
+      return '回答未通过校验';
+    case 'error':
+      return '回答失败';
+    case 'ready':
+      return '回答';
+    default:
+      return '未完成';
+  }
+}
+
+function fullTextQaStatusColor(status: CurrentVideoFullTextQaResult['status']): string {
+  if (status === 'ready') return '#A0E7A0';
+  if (status === 'unsupported') return '#C8E6FF';
+  return '#FFCF8A';
+}
+
+function safeFullTextQaVisibleText(value: string): string {
+  return value
+    .replace(/document is not defined/gi, '运行状态不可用')
+    .replace(
+      /\b(?:subtitle_url|sourceHash|segmentIds?|candidateId|nodeId|sourceId|BVID|CID)\s*[:=]\s*[^\s,;，；。！？!?]+/gi,
+      '内部信息已隐藏',
+    )
+    .replace(/\bBV[0-9A-Za-z]{10}\b/gi, '视频编号已隐藏')
+    .replace(
+      /\b(?:fallback|transcript|confidence|sourceHash|segmentIds?|subtitle_url|BVID|CID)\b/gi,
+      (term) => {
+        switch (term.toLowerCase()) {
+          case 'fallback': return '本地兜底';
+          case 'transcript': return '字幕正文';
+          case 'confidence': return '匹配度';
+          case 'sourcehash': return '来源标识';
+          case 'segmentid':
+          case 'segmentids': return '片段标识';
+          case 'subtitle_url': return '字幕链接';
+          case 'bvid': return '视频编号';
+          case 'cid': return '分 P 信息';
+          default: return '内部字段';
+        }
+      },
+    );
+}
+
+function fullTextQaSourceLine(result: CurrentVideoFullTextQaResult): string {
+  const title = safeFullTextQaVisibleText(result.title || '当前视频');
+  const part = result.partTitle ? ` · ${safeFullTextQaVisibleText(result.partTitle)}` : '';
+  return `依据《${title}》${part} · ${result.sourceLabel}，${formatTextSize(result.textSize)}。`;
 }
 
 function summaryHighlightsStatusLabel(status: CurrentVideoSummaryHighlightsResult['status']): string {

--- a/src/background/current-video-full-text-qa.ts
+++ b/src/background/current-video-full-text-qa.ts
@@ -1,0 +1,722 @@
+import type { CurrentVideoContextResult } from '../shared/types/current-video-context.ts';
+import type { CurrentVideoTranscriptSegment } from '../shared/types/current-video-transcript.ts';
+import type { UserConfig } from '../shared/types/config.ts';
+import type {
+  CurrentVideoFullTextQaCitation,
+  CurrentVideoFullTextQaResult,
+  CurrentVideoFullTextQaTextSize,
+} from '../shared/types/current-video-full-text-qa.ts';
+import {
+  buildCurrentVideoFullTextRequestEnvelope,
+  CurrentVideoFullTextRequestGuard,
+  type CurrentVideoFullTextRequestEnvelope,
+} from '../shared/current-video-primary-text.ts';
+import {
+  buildCurrentVideoFullTextQaAiPayload,
+  requestCurrentVideoFullTextQaAi,
+  validateCurrentVideoFullTextQaAiOutput,
+  type CurrentVideoFullTextQaChat,
+} from '../shared/current-video-full-text-qa.ts';
+import { loadConfig } from './storage/config-store.ts';
+import { chatJson } from './ai/openai-compatible.ts';
+
+export interface GenerateCurrentVideoFullTextQaOptions {
+  requestId: string;
+  turnId: string;
+  question: string;
+  transcriptSegments: CurrentVideoTranscriptSegment[];
+  config?: UserConfig;
+  configGeneration?: number;
+  chat?: CurrentVideoFullTextQaChat;
+  now?: number;
+  resolveLiveConfig?: () => Promise<UserConfig>;
+  sourceDataStillCurrent?: () => boolean | Promise<boolean>;
+  authorizationStillEnabled?: () => boolean | Promise<boolean>;
+  resolveCurrentIdentity?: () => Promise<{ sourceIdentityKey: string } | null>;
+}
+
+interface ActiveQaRequest {
+  envelope: CurrentVideoFullTextRequestEnvelope;
+  controller: AbortController;
+  requestScopeId: string | null;
+}
+
+interface PreflightQaRequest {
+  requestId: string;
+  turnId: string;
+  sourceIdentityKey: string | null;
+  requestScopeId: string | null;
+  bvid: string | null;
+  cid: number | null;
+  page: number | null;
+  configGeneration: number;
+  cancelled: boolean;
+}
+
+interface CompletedQaRequest {
+  requestId: string;
+  turnId: string;
+  sourceIdentityKey: string;
+  bvid: string;
+  cid: number;
+  page: number;
+  generatedAt: number;
+  citations: CurrentVideoFullTextQaCitation[];
+}
+
+export interface CurrentVideoFullTextQaCitationLookup {
+  requestId: string;
+  turnId: string;
+  citationId: string;
+  sourceIdentityKey: string;
+}
+
+export interface CurrentVideoFullTextQaCitationRecord {
+  citation: CurrentVideoFullTextQaCitation;
+  bvid: string;
+  cid: number;
+  page: number;
+  sourceIdentityKey: string;
+  generatedAt: number;
+}
+
+const requestGuard = new CurrentVideoFullTextRequestGuard();
+const preflightRequests = new Map<string, PreflightQaRequest>();
+const activeRequests = new Map<string, ActiveQaRequest>();
+const activeRequestByTurn = new Map<string, string>();
+const activeRequestByScope = new Map<string, string>();
+const completedRequests = new Map<string, CompletedQaRequest>();
+const completedRequestByTurn = new Map<string, string>();
+const MAX_COMPLETED_REQUESTS = 20;
+let configGeneration = 0;
+
+export function registerCurrentVideoFullTextQaPreflightRequest(input: {
+  requestId: string;
+  turnId: string;
+  sourceIdentityKey?: string | null;
+  requestScopeId?: string | null;
+  bvid?: string | null;
+  cid?: number | null;
+  page?: number | null;
+}): { requestId: string; turnId: string; configGeneration: number } {
+  const requestId = input.requestId.trim();
+  const turnId = input.turnId.trim();
+  const sourceIdentityKey = input.sourceIdentityKey?.trim() || null;
+  const requestScopeId = input.requestScopeId?.trim() || null;
+  const bvid = input.bvid?.trim() || null;
+  const cid = Number.isInteger(input.cid) && Number(input.cid) > 0 ? Number(input.cid) : null;
+  const page = Number.isInteger(input.page) && Number(input.page) > 0 ? Number(input.page) : null;
+  if (!requestId || !turnId) return { requestId, turnId, configGeneration };
+
+  for (const preflight of preflightRequests.values()) {
+    if (
+      preflight.requestId !== requestId
+      && (preflight.turnId === turnId || (requestScopeId && preflight.requestScopeId === requestScopeId))
+    ) {
+      preflight.cancelled = true;
+      cancelCurrentVideoFullTextQaRequest(preflight.requestId);
+    }
+  }
+  if (requestScopeId) {
+    const activeRequestId = activeRequestByScope.get(requestScopeId);
+    if (activeRequestId && activeRequestId !== requestId) cancelCurrentVideoFullTextQaRequest(activeRequestId);
+  }
+  const completedRequestId = completedRequestByTurn.get(turnId);
+  if (completedRequestId && completedRequestId !== requestId) {
+    removeCompletedRequest(completedRequestId);
+  }
+  preflightRequests.set(requestId, {
+    requestId,
+    turnId,
+    sourceIdentityKey,
+    requestScopeId,
+    bvid,
+    cid,
+    page,
+    configGeneration,
+    cancelled: false,
+  });
+  return { requestId, turnId, configGeneration };
+}
+
+export function settleCurrentVideoFullTextQaPreflightRequest(requestId: string): void {
+  preflightRequests.delete(requestId.trim());
+}
+
+export function bindCurrentVideoFullTextQaPreflightPart(
+  requestId: string,
+  input: { bvid: string; cid: number; page: number; requestScopeId?: string | null },
+): boolean {
+  const preflight = preflightRequests.get(requestId.trim());
+  if (
+    !preflight
+    || preflight.cancelled
+    || !input.bvid.trim()
+    || !Number.isInteger(input.cid)
+    || input.cid <= 0
+    || !Number.isInteger(input.page)
+    || input.page <= 0
+  ) {
+    return false;
+  }
+  preflight.bvid = input.bvid.trim();
+  preflight.cid = input.cid;
+  preflight.page = input.page;
+  const requestScopeId = input.requestScopeId?.trim() || null;
+  if (requestScopeId) {
+    for (const other of preflightRequests.values()) {
+      if (other.requestId !== preflight.requestId && other.requestScopeId === requestScopeId) {
+        other.cancelled = true;
+        cancelCurrentVideoFullTextQaRequest(other.requestId);
+      }
+    }
+    const activeRequestId = activeRequestByScope.get(requestScopeId);
+    if (activeRequestId && activeRequestId !== preflight.requestId) {
+      cancelCurrentVideoFullTextQaRequest(activeRequestId);
+    }
+    preflight.requestScopeId = requestScopeId;
+  }
+  return true;
+}
+
+export function unavailableCurrentVideoFullTextQa(input: {
+  status: 'no_context' | 'no_text' | 'disabled' | 'not_configured' | 'cancelled' | 'error';
+  requestId: string;
+  turnId: string;
+  question: string;
+  message: string;
+  title?: string | null;
+  partTitle?: string | null;
+  model?: string | null;
+  textSize?: CurrentVideoFullTextQaTextSize;
+  now?: number;
+}): CurrentVideoFullTextQaResult {
+  const statusToAi = {
+    no_context: 'failed',
+    no_text: 'failed',
+    disabled: 'disabled',
+    not_configured: 'not_configured',
+    cancelled: 'cancelled',
+    error: 'failed',
+  } as const;
+  return baseResult({
+    status: input.status,
+    requestId: input.requestId.trim(),
+    turnId: input.turnId.trim(),
+    question: normalizeQuestion(input.question),
+    title: input.title?.trim() || '当前视频',
+    partTitle: input.partTitle?.trim() || null,
+    textSize: input.textSize ?? { lineCount: 0, charCount: null, utf8Bytes: 0 },
+    message: input.message,
+    aiStatus: statusToAi[input.status],
+    model: input.model?.trim() || null,
+    errorCode: input.status === 'cancelled' ? null : input.status,
+    canRetry: true,
+    now: input.now ?? Date.now(),
+  });
+}
+
+export async function generateCurrentVideoFullTextQa(
+  context: CurrentVideoContextResult,
+  options: GenerateCurrentVideoFullTextQaOptions,
+): Promise<CurrentVideoFullTextQaResult> {
+  const now = options.now ?? Date.now();
+  const question = normalizeQuestion(options.question);
+  const requestId = options.requestId.trim();
+  const turnId = options.turnId.trim();
+  const config = options.config ?? await loadConfig();
+  const model = config.ai.chatModel.trim() || null;
+  const title = context.kind === 'video' ? context.title?.trim() || '当前视频' : '当前视频';
+  const partTitle = context.kind === 'video' ? context.currentPart.title?.trim() || null : null;
+  const approximateSize = approximateTextSize(context);
+
+  if (!requestId || !turnId || !question) {
+    return baseResult({
+      status: 'error', requestId, turnId, question, title, partTitle, textSize: approximateSize,
+      message: '问题没有提交成功，请保留当前问题并重试。',
+      aiStatus: 'failed', model, errorCode: 'request_invalid', canRetry: true, now,
+    });
+  }
+  if (context.kind !== 'video') {
+    return baseResult({
+      status: 'no_context', requestId, turnId, question, title, partTitle, textSize: approximateSize,
+      message: '当前没有可用的视频上下文，请在 B 站视频页内重新提交。',
+      aiStatus: 'failed', model, errorCode: 'no_context', canRetry: true, now,
+    });
+  }
+  if (!config.assistant.currentVideoAiAssistantEnabled) {
+    return baseResult({
+      status: 'disabled', requestId, turnId, question, title, partTitle, textSize: approximateSize,
+      message: '当前视频 AI 助手已关闭，问题已保留。开启后可重新提交。',
+      aiStatus: 'disabled', model, errorCode: null, canRetry: true, now,
+    });
+  }
+  if (!aiConfigured(config)) {
+    return baseResult({
+      status: 'not_configured', requestId, turnId, question, title, partTitle, textSize: approximateSize,
+      message: 'AI 服务尚未配置完成，问题已保留。完成设置后可重新提交。',
+      aiStatus: 'not_configured', model, errorCode: null, canRetry: true, now,
+    });
+  }
+  if (
+    !model
+    || !context.cid
+    || options.transcriptSegments.length === 0
+    || !context.transcriptEvidence?.active
+    || !context.transcriptEvidence.sourceIdentityKey
+    || !context.transcriptEvidence.sourceType
+  ) {
+    return baseResult({
+      status: 'no_text', requestId, turnId, question, title, partTitle, textSize: approximateSize,
+      message: '当前分 P 没有可用的主要文本，无法回答。问题已保留。',
+      aiStatus: 'failed', model, errorCode: 'no_text', canRetry: true, now,
+    });
+  }
+
+  const envelope = buildCurrentVideoFullTextRequestEnvelope({
+    requestId,
+    operation: 'qa',
+    submittedAt: now,
+    model,
+    video: {
+      bvid: context.bvid,
+      cid: context.cid,
+      page: context.currentPart.page,
+      title: context.title,
+      partTitle: context.currentPart.title,
+      durationSeconds: context.durationSeconds,
+    },
+    source: 'bilibili_subtitle',
+    sourceType: context.transcriptEvidence.sourceType,
+    sourceLabel: 'B站字幕',
+    language: context.transcriptEvidence.language,
+    lines: options.transcriptSegments.map(segment => ({
+      startSeconds: segment.startSeconds,
+      endSeconds: segment.endSeconds,
+      text: segment.text,
+    })),
+    turnId,
+  });
+  const textSize = textSizeFromEnvelope(envelope);
+  if (context.transcriptEvidence.sourceIdentityKey !== envelope.primaryTextIdentity.sourceIdentityKey) {
+    return baseResult({
+      status: 'no_text', requestId, turnId, question, title, partTitle, textSize,
+      message: '当前主要文本已变化，请重新确认来源后提交。',
+      aiStatus: 'failed', model, errorCode: 'source_mismatch', canRetry: true, now,
+    });
+  }
+
+  const capturedGeneration = options.configGeneration ?? configGeneration;
+  const liveConfig = options.resolveLiveConfig ? await options.resolveLiveConfig() : config;
+  if (!liveConfig.assistant.currentVideoAiAssistantEnabled) {
+    return baseResult({
+      status: 'disabled', requestId, turnId, question, title, partTitle, textSize,
+      message: '当前视频 AI 助手已关闭，问题已保留。开启后可重新提交。',
+      aiStatus: 'disabled', model: liveConfig.ai.chatModel.trim() || model, errorCode: null, canRetry: true, now,
+    });
+  }
+  if (!aiConfigured(liveConfig)) {
+    return baseResult({
+      status: 'not_configured', requestId, turnId, question, title, partTitle, textSize,
+      message: 'AI 服务尚未配置完成，问题已保留。完成设置后可重新提交。',
+      aiStatus: 'not_configured', model: liveConfig.ai.chatModel.trim() || model, errorCode: null, canRetry: true, now,
+    });
+  }
+  if (!await preflightStillValid(envelope, capturedGeneration, options)) {
+    return cancelledResult(envelope, question, title, partTitle, textSize, model, now);
+  }
+
+  const active = startNetworkRequest(envelope);
+  try {
+    let output: unknown;
+    try {
+      const payload = buildCurrentVideoFullTextQaAiPayload(envelope, question);
+      output = await requestCurrentVideoFullTextQaAi(
+        liveConfig.ai,
+        payload,
+        envelope,
+        options.chat ?? chatJson,
+        { signal: active.controller.signal },
+      );
+    } catch (error) {
+      if (!await requestStillValid(envelope, active, capturedGeneration, options)) {
+        return cancelledResult(envelope, question, title, partTitle, textSize, model, Date.now());
+      }
+      if (isContextTooLongError(error)) {
+        return baseResult({
+          status: 'context_too_long', requestId, turnId, question, title, partTitle, textSize,
+          message: '当前正文过长，所选模型没有接受本次完整请求；系统不会截断或分段发送。问题已保留，可更换模型后重试。',
+          aiStatus: 'context_too_long', model, errorCode: 'context_too_long', canRetry: true, now: Date.now(),
+        });
+      }
+      return baseResult({
+        status: 'error', requestId, turnId, question, title, partTitle, textSize,
+        message: '本次回答失败，问题已保留，请检查 AI 设置后重试。',
+        aiStatus: 'failed', model, errorCode: 'request_failed', canRetry: true, now: Date.now(),
+      });
+    }
+
+    if (!await requestStillValid(envelope, active, capturedGeneration, options)) {
+      return cancelledResult(envelope, question, title, partTitle, textSize, model, Date.now());
+    }
+    const validation = validateCurrentVideoFullTextQaAiOutput(output, envelope);
+    if (!validation.ok) {
+      return baseResult({
+        status: 'invalid_output', requestId, turnId, question, title, partTitle, textSize,
+        message: '模型返回的回答没有通过证据校验，本次结果已拒绝。问题已保留，可重新提交。',
+        aiStatus: 'invalid_output', model, errorCode: 'invalid_output', canRetry: true, now: Date.now(),
+      });
+    }
+
+    if (validation.kind === 'unsupported') {
+      return baseResult({
+        status: 'unsupported', requestId, turnId, question, title, partTitle, textSize,
+        message: '当前视频文本没有足够内容支持回答。',
+        answer: validation.answer,
+        answerEvidenceLineNumbers: [],
+        citations: [],
+        sourceLabel: envelope.sourceLabel,
+        aiStatus: 'unsupported', model, errorCode: null, canRetry: false, now: Date.now(),
+      });
+    }
+
+    const citations: CurrentVideoFullTextQaCitation[] = validation.citations.map(citation => ({
+      ...citation,
+      sourceLabel: envelope.sourceLabel,
+      binding: {
+        requestId,
+        turnId,
+        citationId: citation.id,
+      },
+    }));
+    const generatedAt = Date.now();
+    const result = baseResult({
+      status: 'ready', requestId, turnId, question, title, partTitle, textSize,
+      message: '回答已基于当前分 P 的完整主要文本生成。',
+      answer: validation.answer,
+      answerEvidenceLineNumbers: validation.answerEvidenceLineNumbers,
+      citations,
+      sourceLabel: envelope.sourceLabel,
+      aiStatus: 'generated', model, errorCode: null, canRetry: true, now: generatedAt,
+    });
+    rememberCompletedRequest(envelope, result);
+    return result;
+  } finally {
+    settleNetworkRequest(envelope, active);
+  }
+}
+
+export function cancelCurrentVideoFullTextQaRequest(requestId: string): void {
+  const normalized = requestId.trim();
+  if (!normalized) return;
+  const preflight = preflightRequests.get(normalized);
+  if (preflight) preflight.cancelled = true;
+  requestGuard.cancel(normalized);
+  activeRequests.get(normalized)?.controller.abort();
+}
+
+export function cancelCurrentVideoFullTextQaForSource(sourceIdentityKey: string): void {
+  const normalized = sourceIdentityKey.trim();
+  if (!normalized) return;
+  for (const preflight of preflightRequests.values()) {
+    if (preflight.sourceIdentityKey === normalized) preflight.cancelled = true;
+  }
+  requestGuard.clearPrimaryText({ sourceIdentityKey: normalized });
+  for (const request of activeRequests.values()) {
+    if (request.envelope.primaryTextIdentity.sourceIdentityKey === normalized) {
+      request.controller.abort();
+    }
+  }
+  for (const [requestId, request] of completedRequests.entries()) {
+    if (request.sourceIdentityKey === normalized) removeCompletedRequest(requestId);
+  }
+}
+
+export function cancelCurrentVideoFullTextQaForScope(requestScopeId: string): void {
+  const normalized = requestScopeId.trim();
+  if (!normalized) return;
+  for (const preflight of preflightRequests.values()) {
+    if (preflight.requestScopeId === normalized) {
+      preflight.cancelled = true;
+      cancelCurrentVideoFullTextQaRequest(preflight.requestId);
+    }
+  }
+  const activeRequestId = activeRequestByScope.get(normalized);
+  if (activeRequestId) cancelCurrentVideoFullTextQaRequest(activeRequestId);
+}
+
+export function invalidateCurrentVideoFullTextQaConfig(): void {
+  configGeneration += 1;
+  for (const preflight of preflightRequests.values()) preflight.cancelled = true;
+  for (const request of activeRequests.values()) {
+    requestGuard.cancel(request.envelope.requestId);
+    request.controller.abort();
+  }
+}
+
+export function invalidateCurrentVideoFullTextQaSources(): void {
+  for (const preflight of preflightRequests.values()) preflight.cancelled = true;
+  for (const request of activeRequests.values()) {
+    requestGuard.cancel(request.envelope.requestId);
+    request.controller.abort();
+  }
+  completedRequests.clear();
+  completedRequestByTurn.clear();
+}
+
+export function invalidateCurrentVideoFullTextQaPart(input: {
+  bvid: string;
+  cid: number;
+  page: number;
+}): void {
+  const bvid = input.bvid.trim();
+  if (!bvid || !Number.isInteger(input.cid) || input.cid <= 0 || !Number.isInteger(input.page) || input.page <= 0) {
+    return;
+  }
+  for (const preflight of preflightRequests.values()) {
+    if (preflight.bvid === bvid && preflight.cid === input.cid && preflight.page === input.page) {
+      preflight.cancelled = true;
+      cancelCurrentVideoFullTextQaRequest(preflight.requestId);
+    }
+  }
+  for (const request of activeRequests.values()) {
+    if (
+      request.envelope.video.bvid === bvid
+      && request.envelope.video.cid === input.cid
+      && request.envelope.video.page === input.page
+    ) {
+      cancelCurrentVideoFullTextQaRequest(request.envelope.requestId);
+    }
+  }
+  for (const [requestId, request] of completedRequests.entries()) {
+    if (request.bvid === bvid && request.cid === input.cid && request.page === input.page) {
+      removeCompletedRequest(requestId);
+    }
+  }
+}
+
+export function getCurrentVideoFullTextQaCitation(
+  lookup: CurrentVideoFullTextQaCitationLookup,
+): CurrentVideoFullTextQaCitationRecord | null {
+  const request = completedRequests.get(lookup.requestId);
+  if (
+    !request
+    || request.turnId !== lookup.turnId
+    || request.sourceIdentityKey !== lookup.sourceIdentityKey
+  ) return null;
+  const citation = request.citations.find(item => item.id === lookup.citationId);
+  if (!citation) return null;
+  return {
+    citation,
+    bvid: request.bvid,
+    cid: request.cid,
+    page: request.page,
+    sourceIdentityKey: request.sourceIdentityKey,
+    generatedAt: request.generatedAt,
+  };
+}
+
+function startNetworkRequest(
+  envelope: CurrentVideoFullTextRequestEnvelope,
+  requestScopeId = preflightRequests.get(envelope.requestId)?.requestScopeId ?? null,
+): ActiveQaRequest {
+  const turnId = envelope.turnId!;
+  const previousRequestId = activeRequestByTurn.get(turnId);
+  if (previousRequestId && previousRequestId !== envelope.requestId) {
+    cancelCurrentVideoFullTextQaRequest(previousRequestId);
+  }
+  const previousCompleted = completedRequestByTurn.get(turnId);
+  if (previousCompleted && previousCompleted !== envelope.requestId) {
+    removeCompletedRequest(previousCompleted);
+  }
+  if (requestScopeId) {
+    const previousScopeRequestId = activeRequestByScope.get(requestScopeId);
+    if (previousScopeRequestId && previousScopeRequestId !== envelope.requestId) {
+      cancelCurrentVideoFullTextQaRequest(previousScopeRequestId);
+    }
+  }
+  requestGuard.start(envelope);
+  const active = { envelope, controller: new AbortController(), requestScopeId };
+  activeRequests.set(envelope.requestId, active);
+  activeRequestByTurn.set(turnId, envelope.requestId);
+  if (requestScopeId) activeRequestByScope.set(requestScopeId, envelope.requestId);
+  return active;
+}
+
+function settleNetworkRequest(envelope: CurrentVideoFullTextRequestEnvelope, active: ActiveQaRequest): void {
+  if (activeRequests.get(envelope.requestId) === active) activeRequests.delete(envelope.requestId);
+  if (activeRequestByTurn.get(envelope.turnId!) === envelope.requestId) {
+    activeRequestByTurn.delete(envelope.turnId!);
+  }
+  if (active.requestScopeId && activeRequestByScope.get(active.requestScopeId) === envelope.requestId) {
+    activeRequestByScope.delete(active.requestScopeId);
+  }
+  requestGuard.settle(envelope);
+}
+
+async function preflightStillValid(
+  envelope: CurrentVideoFullTextRequestEnvelope,
+  capturedGeneration: number,
+  options: GenerateCurrentVideoFullTextQaOptions,
+): Promise<boolean> {
+  if (capturedGeneration !== configGeneration) return false;
+  const preflight = preflightRequests.get(envelope.requestId);
+  if (preflight?.cancelled || (preflight && preflight.configGeneration !== capturedGeneration)) return false;
+  if (options.sourceDataStillCurrent && !await options.sourceDataStillCurrent()) return false;
+  if (options.authorizationStillEnabled && !await options.authorizationStillEnabled()) return false;
+  return envelope.primaryTextIdentity.sourceIdentityKey.length > 0;
+}
+
+async function requestStillValid(
+  envelope: CurrentVideoFullTextRequestEnvelope,
+  active: ActiveQaRequest,
+  capturedGeneration: number,
+  options: GenerateCurrentVideoFullTextQaOptions,
+): Promise<boolean> {
+  if (active.controller.signal.aborted) return false;
+  if (!await preflightStillValid(envelope, capturedGeneration, options)) return false;
+  if (options.resolveLiveConfig) {
+    const liveConfig = await options.resolveLiveConfig();
+    if (!liveConfig.assistant.currentVideoAiAssistantEnabled || !aiConfigured(liveConfig)) return false;
+  }
+  const currentIdentity = options.resolveCurrentIdentity
+    ? await options.resolveCurrentIdentity()
+    : { sourceIdentityKey: envelope.primaryTextIdentity.sourceIdentityKey };
+  const commit = requestGuard.canCommit(envelope, currentIdentity);
+  return commit.ok && commit.current;
+}
+
+function rememberCompletedRequest(
+  envelope: CurrentVideoFullTextRequestEnvelope,
+  result: CurrentVideoFullTextQaResult,
+): void {
+  const previous = completedRequestByTurn.get(result.turnId);
+  if (previous && previous !== result.requestId) removeCompletedRequest(previous);
+  completedRequests.set(result.requestId, {
+    requestId: result.requestId,
+    turnId: result.turnId,
+    sourceIdentityKey: envelope.primaryTextIdentity.sourceIdentityKey,
+    bvid: envelope.video.bvid,
+    cid: envelope.video.cid,
+    page: envelope.video.page,
+    generatedAt: result.generatedAt,
+    citations: result.citations,
+  });
+  completedRequestByTurn.set(result.turnId, result.requestId);
+  while (completedRequests.size > MAX_COMPLETED_REQUESTS) {
+    const oldest = completedRequests.keys().next().value as string | undefined;
+    if (!oldest) break;
+    removeCompletedRequest(oldest);
+  }
+}
+
+function removeCompletedRequest(requestId: string): void {
+  const request = completedRequests.get(requestId);
+  completedRequests.delete(requestId);
+  if (request && completedRequestByTurn.get(request.turnId) === requestId) {
+    completedRequestByTurn.delete(request.turnId);
+  }
+}
+
+function cancelledResult(
+  envelope: CurrentVideoFullTextRequestEnvelope,
+  question: string,
+  title: string,
+  partTitle: string | null,
+  textSize: CurrentVideoFullTextQaTextSize,
+  model: string | null,
+  now: number,
+): CurrentVideoFullTextQaResult {
+  return baseResult({
+    status: 'cancelled',
+    requestId: envelope.requestId,
+    turnId: envelope.turnId ?? '',
+    question,
+    title,
+    partTitle,
+    textSize,
+    message: '本次回答已取消，问题已保留，可重新提交。',
+    aiStatus: 'cancelled',
+    model,
+    errorCode: null,
+    canRetry: true,
+    now,
+  });
+}
+
+function baseResult(input: {
+  status: CurrentVideoFullTextQaResult['status'];
+  requestId: string;
+  turnId: string;
+  question: string;
+  title: string;
+  partTitle: string | null;
+  textSize: CurrentVideoFullTextQaTextSize;
+  message: string;
+  aiStatus: CurrentVideoFullTextQaResult['ai']['status'];
+  model: string | null;
+  errorCode: string | null;
+  canRetry: boolean;
+  now: number;
+  answer?: string;
+  answerEvidenceLineNumbers?: number[];
+  citations?: CurrentVideoFullTextQaCitation[];
+  sourceLabel?: 'B站字幕' | '本地转录' | null;
+}): CurrentVideoFullTextQaResult {
+  return {
+    status: input.status,
+    requestId: input.requestId,
+    turnId: input.turnId,
+    question: input.question,
+    title: input.title,
+    partTitle: input.partTitle,
+    sourceLabel: input.sourceLabel ?? null,
+    textSize: input.textSize,
+    answer: input.answer ?? '',
+    answerEvidenceLineNumbers: input.answerEvidenceLineNumbers ?? [],
+    citations: input.citations ?? [],
+    message: input.message,
+    limitations: input.status === 'ready'
+      ? ['回答和引用只基于当前分 P 本次提交的完整主要文本。']
+      : input.status === 'unsupported'
+        ? ['没有使用标题、简介、通用知识或其他视频内容补答。']
+        : ['本次没有采用不完整文本生成回答。'],
+    ai: {
+      status: input.aiStatus,
+      model: input.model,
+      note: input.message,
+      errorCode: input.errorCode,
+    },
+    generatedAt: input.now,
+    canRetry: input.canRetry,
+  };
+}
+
+function approximateTextSize(context: CurrentVideoContextResult): CurrentVideoFullTextQaTextSize {
+  if (context.kind !== 'video') return { lineCount: 0, charCount: null, utf8Bytes: 0 };
+  return {
+    lineCount: context.transcriptEvidence?.segmentCount ?? 0,
+    charCount: null,
+    utf8Bytes: context.transcriptEvidence?.serializedBytes ?? 0,
+  };
+}
+
+function textSizeFromEnvelope(envelope: CurrentVideoFullTextRequestEnvelope): CurrentVideoFullTextQaTextSize {
+  return {
+    lineCount: envelope.text.lineCount,
+    charCount: envelope.text.charCount,
+    utf8Bytes: envelope.text.utf8Bytes,
+  };
+}
+
+function aiConfigured(config: UserConfig): boolean {
+  return Boolean(config.ai.baseURL.trim() && config.ai.apiKey.trim() && config.ai.chatModel.trim());
+}
+
+function normalizeQuestion(question: string): string {
+  return String(question ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function isContextTooLongError(error: unknown): boolean {
+  return error instanceof Error && /^AI_REQUEST_FAILED_(413|422)(?:\s|$)/.test(error.message.trim());
+}

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -21,6 +21,7 @@ import type {
 } from '../../shared/current-video-subtitle-view.ts';
 import type { CurrentVideoRelatedFavoritesResponse } from '../../shared/types/current-video-related-favorites';
 import type { CurrentVideoSummaryHighlightsResult } from '../../shared/types/current-video-summary';
+import type { CurrentVideoFullTextQaResult } from '../../shared/types/current-video-full-text-qa';
 import type { VideoKnowledgeResult } from '../../shared/types/video-knowledge';
 import type { DynamicBillFeedbackScope, DynamicBillStatusFilter } from '../../shared/types/dynamic-bill';
 import type { SmartIndexResult } from '../../shared/types/favorite';
@@ -53,6 +54,20 @@ import {
   registerCurrentVideoSummaryHighlightsPreflightRequest,
   settleCurrentVideoSummaryHighlightsPreflightRequest,
 } from '../current-video-summary-highlights';
+import {
+  bindCurrentVideoFullTextQaPreflightPart,
+  cancelCurrentVideoFullTextQaForSource,
+  cancelCurrentVideoFullTextQaForScope,
+  cancelCurrentVideoFullTextQaRequest,
+  generateCurrentVideoFullTextQa,
+  getCurrentVideoFullTextQaCitation,
+  invalidateCurrentVideoFullTextQaConfig,
+  invalidateCurrentVideoFullTextQaPart,
+  invalidateCurrentVideoFullTextQaSources,
+  registerCurrentVideoFullTextQaPreflightRequest,
+  settleCurrentVideoFullTextQaPreflightRequest,
+  unavailableCurrentVideoFullTextQa,
+} from '../current-video-full-text-qa';
 import {
   cancelledCurrentVideoSummaryHighlights,
   currentVideoSummaryHighlightBindingMatchesRecord,
@@ -247,6 +262,7 @@ type CurrentVideoPrimaryTextGuardTestPhase =
   | 'before_evidence_bind'
   | 'before_segment_body_read'
   | 'after_segment_body_read'
+  | 'before_full_text_qa_network'
   | 'before_timestamp_message';
 
 export function setupMessageHandlers(): void {
@@ -477,6 +493,7 @@ export async function handleRequest<T>(
       const nextConfig = await loadConfig();
       if (currentVideoSummaryHighlightsConfigChanged(previousConfig, nextConfig)) {
         invalidateCurrentVideoSummaryHighlightsConfig();
+        invalidateCurrentVideoFullTextQaConfig();
       }
       return { success: true };
     }
@@ -541,29 +558,35 @@ export async function handleRequest<T>(
     case 'GET_LOCAL_DATA_PRIVACY_SUMMARY':
       return { success: true, data: await getLocalDataPrivacySummary() as T };
     case 'CLEAR_CURRENT_VIDEO_SUBTITLE_CACHE':
+      invalidateCurrentVideoFullTextQaSources();
       return { success: true, data: await clearCurrentVideoSubtitleCache() as T };
     case 'CLEAR_CURRENT_VIDEO_SUMMARY_HIGHLIGHT_CACHE':
       return { success: true, data: await clearCurrentVideoSummaryHighlightCache() as T };
     case 'REBUILD_SMART_FAVORITE_INDEX':
       return { success: true, data: await rebuildSmartFavoriteIndex(request.params) as T };
     case 'CLEAR_ALL_LOCAL_DATA':
+      invalidateCurrentVideoFullTextQaSources();
       return { success: true, data: await clearAllLocalData(request.params?.confirmation) as T };
     case 'GET_CURRENT_VIDEO_CONTEXT':
       return { success: true, data: await getCurrentVideoContextForActiveTab(currentVideoLookupOptions(request.params), requestTabId) as T };
     case 'SAVE_CURRENT_VIDEO_PRIMARY_TEXT_SELECTION': {
+      const bvid = requireStringParam(request.params?.bvid, 'bvid');
       const cid = requirePositiveIntegerParam(request.params?.cid, 'cid');
       const page = requirePositiveIntegerParam(request.params?.page, 'page');
+      if (requestTabId) cancelCurrentVideoFullTextQaForScope(`tab-${requestTabId}`);
+      const saved = await saveCurrentVideoPrimaryTextSelection({
+        bvid,
+        cid,
+        page,
+        selectedSourceIdentityKey: requireStringParam(
+          request.params?.selectedSourceIdentityKey,
+          'selectedSourceIdentityKey',
+        ),
+      });
+      invalidateCurrentVideoFullTextQaPart({ bvid, cid, page });
       return {
         success: true,
-        data: await saveCurrentVideoPrimaryTextSelection({
-          bvid: requireStringParam(request.params?.bvid, 'bvid'),
-          cid,
-          page,
-          selectedSourceIdentityKey: requireStringParam(
-            request.params?.selectedSourceIdentityKey,
-            'selectedSourceIdentityKey',
-          ),
-        }) as T,
+        data: saved as T,
       };
     }
     case 'PROBE_CURRENT_VIDEO_SUBTITLE_SOURCE':
@@ -671,6 +694,120 @@ export async function handleRequest<T>(
       }
       return { success: true, data: { cancelled: true } as T };
     }
+    case 'ASK_CURRENT_VIDEO_FULL_TEXT': {
+      const requestId = requireStringParam(request.params?.requestId, 'requestId');
+      const turnId = requireStringParam(request.params?.turnId, 'turnId');
+      const question = requireStringParam(request.params?.question, 'question');
+      const sourceIdentityKey = selectedSourceIdentityKey(request.params);
+      const preflight = registerCurrentVideoFullTextQaPreflightRequest({
+        requestId,
+        turnId,
+        sourceIdentityKey,
+        requestScopeId: requestTabId ? `tab-${requestTabId}` : null,
+        bvid: optionalStringParam(request.params?.bvid),
+        cid: optionalPositiveIntegerParam(request.params?.cid),
+        page: optionalPositiveIntegerParam(request.params?.page),
+      });
+      try {
+        if (!primaryTextSelectionsReady(request.params)) {
+          return {
+            success: true,
+            data: unavailableCurrentVideoFullTextQa({
+              status: 'no_text',
+              requestId,
+              turnId,
+              question,
+              message: PRIMARY_TEXT_SELECTION_NOT_READY_MESSAGE,
+            }) as T,
+          };
+        }
+        const lookup = await getCurrentVideoContextLookupWithSelection(request.params, requestTabId);
+        if (!lookup.primaryTextAuthorized || !lookup.primaryTextGuard) {
+          return {
+            success: true,
+            data: unavailableCurrentVideoFullTextQa({
+              status: 'no_text',
+              requestId,
+              turnId,
+              question,
+              title: lookup.context.kind === 'video' ? lookup.context.title : null,
+              partTitle: lookup.context.kind === 'video' ? lookup.context.currentPart.title : null,
+              message: PRIMARY_TEXT_SELECTION_NOT_READY_MESSAGE,
+            }) as T,
+          };
+        }
+        if (!bindCurrentVideoFullTextQaPreflightPart(requestId, {
+          bvid: lookup.primaryTextGuard.bvid,
+          cid: lookup.primaryTextGuard.cid,
+          page: lookup.primaryTextGuard.page,
+          requestScopeId: lookup.tab?.id ? `tab-${lookup.tab.id}` : null,
+        })) {
+          return {
+            success: true,
+            data: unavailableCurrentVideoFullTextQa({
+              status: 'cancelled',
+              requestId,
+              turnId,
+              question,
+              title: lookup.context.kind === 'video' ? lookup.context.title : null,
+              partTitle: lookup.context.kind === 'video' ? lookup.context.currentPart.title : null,
+              message: '本次回答已取消，问题已保留。',
+            }) as T,
+          };
+        }
+        const transcriptSegments = await getAuthorizedCurrentVideoTranscriptSegments(lookup);
+        if (!transcriptSegments) {
+          const cancelled = !currentVideoSummaryHighlightsSourceDataStillCurrent(lookup);
+          return {
+            success: true,
+            data: unavailableCurrentVideoFullTextQa({
+              status: cancelled ? 'cancelled' : 'no_text',
+              requestId,
+              turnId,
+              question,
+              title: lookup.context.kind === 'video' ? lookup.context.title : null,
+              partTitle: lookup.context.kind === 'video' ? lookup.context.currentPart.title : null,
+              message: cancelled
+                ? '当前主要文本已变化，本次回答已取消，问题已保留。'
+                : '当前分 P 没有可用的主要文本，无法回答。问题已保留。',
+            }) as T,
+          };
+        }
+        await currentVideoPrimaryTextGuardTestHook('before_full_text_qa_network');
+        const config = await loadConfig();
+        return {
+          success: true,
+          data: await generateCurrentVideoFullTextQa(lookup.context, {
+            requestId,
+            turnId,
+            question,
+            transcriptSegments,
+            config,
+            configGeneration: preflight.configGeneration,
+            resolveLiveConfig: loadConfig,
+            resolveCurrentIdentity: () => resolveCurrentVideoSummaryHighlightCommitIdentity(request.params, requestTabId),
+            sourceDataStillCurrent: () => currentVideoSummaryHighlightsSourceDataStillCurrent(lookup),
+            authorizationStillEnabled: async () => {
+              const liveConfig = await loadConfig();
+              return liveConfig.assistant.currentVideoAiAssistantEnabled
+                && await currentVideoPrimaryTextGuardStillAuthorized(lookup);
+            },
+          }) as T,
+        };
+      } finally {
+        settleCurrentVideoFullTextQaPreflightRequest(requestId);
+      }
+    }
+    case 'CANCEL_CURRENT_VIDEO_FULL_TEXT_QA': {
+      const requestId = optionalStringParam(request.params?.requestId);
+      if (requestId) {
+        cancelCurrentVideoFullTextQaRequest(requestId);
+      } else {
+        const sourceIdentityKey = selectedSourceIdentityKey(request.params);
+        if (sourceIdentityKey) cancelCurrentVideoFullTextQaForSource(sourceIdentityKey);
+      }
+      return { success: true, data: { cancelled: true } as T };
+    }
     case 'GET_VIDEO_KNOWLEDGE': {
       if (!primaryTextSelectionsReady(request.params)) {
         return { success: true, data: primaryTextSelectionNotReadyKnowledge() as T };
@@ -721,6 +858,8 @@ export async function handleRequest<T>(
       return { success: true, data: await requestCurrentVideoSegmentJump(request.params, requestTabId) as T };
     case 'REQUEST_CURRENT_VIDEO_HIGHLIGHT_JUMP':
       return { success: true, data: await requestCurrentVideoHighlightJump(request.params, requestTabId) as T };
+    case 'REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP':
+      return { success: true, data: await requestCurrentVideoQaCitationJump(request.params, requestTabId) as T };
     case 'REQUEST_CURRENT_VIDEO_SUBTITLE_JUMP':
       return { success: true, data: await requestCurrentVideoSubtitleJump(request.params, requestTabId) as T };
     case 'RETURN_CURRENT_VIDEO_SEGMENT_JUMP':
@@ -1359,6 +1498,129 @@ async function requestCurrentVideoHighlightJump(
   } catch {
     return blockedTimestampJumpResponse(
       highlightId,
+      'player_unavailable',
+      formatTimestampJumpFailureReason('player_unavailable'),
+    );
+  } finally {
+    retireCurrentVideoTimestampOperationLease(operationLeaseId);
+  }
+}
+
+async function requestCurrentVideoQaCitationJump(
+  params: Record<string, unknown> | undefined,
+  requestTabId: number | null,
+): Promise<CurrentVideoTimestampJumpResponse> {
+  const requestId = requireStringParam(params?.requestId, 'requestId');
+  const turnId = requireStringParam(params?.turnId, 'turnId');
+  const citationId = requireStringParam(params?.citationId ?? params?.candidateId, 'citationId');
+  if (params?.confirmed !== true) {
+    return blockedTimestampJumpResponse(
+      citationId,
+      'confirmation_required',
+      formatTimestampJumpFailureReason('confirmation_required'),
+    );
+  }
+  if (!primaryTextSelectionsReady(params)) {
+    return blockedTimestampJumpResponse(citationId, 'no_context', PRIMARY_TEXT_SELECTION_NOT_READY_MESSAGE);
+  }
+
+  const lookup = await getCurrentVideoContextLookupWithSelection(params, requestTabId);
+  if (!lookup.primaryTextAuthorized || !lookup.primaryTextGuard) {
+    return blockedTimestampJumpResponse(citationId, 'no_context', PRIMARY_TEXT_SELECTION_NOT_READY_MESSAGE);
+  }
+  const tabId = lookup.tab?.id ?? 0;
+  const context = lookup.context;
+  if (
+    !lookup.tab?.url
+    || tabId <= 0
+    || !isBilibiliVideoUrl(lookup.tab.url)
+    || context.kind !== 'video'
+  ) {
+    return blockedTimestampJumpResponse(
+      citationId,
+      'no_context',
+      formatTimestampJumpFailureReason('no_context'),
+    );
+  }
+
+  const operationGuard = lookup.primaryTextGuard;
+  let record = getCurrentVideoFullTextQaCitation({
+    requestId,
+    turnId,
+    citationId,
+    sourceIdentityKey: operationGuard.sourceIdentityKey,
+  });
+  if (
+    !record
+    || record.bvid !== context.bvid
+    || record.cid !== context.cid
+    || record.page !== context.currentPart.page
+  ) {
+    return blockedTimestampJumpResponse(
+      citationId,
+      'candidate_not_found',
+      '当前引用已过期，请重新提交问题后再跳转。',
+    );
+  }
+
+  await currentVideoPrimaryTextGuardTestHook('before_timestamp_message');
+  if (!await currentVideoPrimaryTextGuardStillAuthorized(lookup)) {
+    return blockedTimestampJumpResponse(citationId, 'no_context', PRIMARY_TEXT_SELECTION_NOT_READY_MESSAGE);
+  }
+  record = getCurrentVideoFullTextQaCitation({
+    requestId,
+    turnId,
+    citationId,
+    sourceIdentityKey: operationGuard.sourceIdentityKey,
+  });
+  if (
+    !record
+    || record.bvid !== context.bvid
+    || record.cid !== context.cid
+    || record.page !== context.currentPart.page
+  ) {
+    return blockedTimestampJumpResponse(
+      citationId,
+      'candidate_not_found',
+      '当前引用已过期，请重新提交问题后再跳转。',
+    );
+  }
+  const operationLeaseId = issueCurrentVideoTimestampOperationLease({
+    tabId,
+    operationKind: 'jump',
+    bvid: operationGuard.bvid,
+    cid: operationGuard.cid,
+    page: operationGuard.page,
+    sourceIdentityKey: operationGuard.sourceIdentityKey,
+    selectionGeneration: operationGuard.selectionGeneration,
+    transcriptClearGeneration: operationGuard.transcriptClearGeneration,
+  });
+
+  try {
+    return await chrome.tabs.sendMessage(tabId, {
+      action: 'CURRENT_VIDEO_TIMESTAMP_JUMP',
+      payload: {
+        candidateId: citationId,
+        confirmed: true,
+        contextBvid: context.bvid,
+        contextCid: context.cid,
+        contextPage: context.currentPart.page,
+        contextUrl: context.url,
+        contextCollectedAt: context.collectedAt,
+        targetSeconds: record.citation.startSeconds,
+        targetTimeLabel: formatTimestampLabel(record.citation.startSeconds),
+        sourceLabel: '引用片段',
+        confidence: 1,
+        confidenceLabel: '高',
+        evidencePreview: record.citation.evidenceText,
+        sourceIdentityKey: operationGuard.sourceIdentityKey,
+        operationLeaseId,
+        returnAuthorizationKind: 'primary_text',
+      },
+    }) as CurrentVideoTimestampJumpResponse;
+  } catch {
+    return blockedTimestampJumpResponse(
+      citationId,
       'player_unavailable',
       formatTimestampJumpFailureReason('player_unavailable'),
     );
@@ -2501,6 +2763,11 @@ function timestampOperationKind(value: unknown): CurrentVideoTimestampOperationK
 
 function optionalStringParam(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function optionalPositiveIntegerParam(value: unknown): number | undefined {
+  const numeric = Number(value);
+  return Number.isInteger(numeric) && numeric > 0 ? numeric : undefined;
 }
 
 function normalizeAiConfigParam(value: unknown): UserConfig['ai'] {

--- a/src/content/player-monitor/assistant-status.ts
+++ b/src/content/player-monitor/assistant-status.ts
@@ -24,6 +24,11 @@ import type {
 } from '../../shared/current-video-subtitle-view.ts';
 import type { CurrentVideoRelatedFavoritesResponse } from '../../shared/types/current-video-related-favorites';
 import type {
+  CurrentVideoFullTextQaCitation,
+  CurrentVideoFullTextQaCitationBinding,
+  CurrentVideoFullTextQaResult,
+} from '../../shared/types/current-video-full-text-qa';
+import type {
   SmartFavoriteQaCitedVideo,
   SmartFavoriteQaResponse,
   SmartFavoriteQaSynthesisStatus,
@@ -108,6 +113,8 @@ const PLAYER_ENDPOINT_PATTERN = new RegExp(
   'gi',
 );
 const ENGINEERING_VISIBLE_TERM_PATTERN = /\b(?:fallback|transcript|confidence)\b/gi;
+const RAW_FIELD_VALUE_PATTERN = /\b(?:subtitle_url|sourceHash|segmentIds?|candidateId|nodeId|sourceId|BVID|CID)\s*[:=]\s*[^\s,;，；。！？!?]+/gi;
+const BILIBILI_VIDEO_ID_PATTERN = /\bBV[0-9A-Za-z]{10}\b/gi;
 const PAGE_BODY_TEXT_PATTERN = new RegExp(['正文', '文本'].join(''), 'g');
 
 const CSS = `
@@ -552,6 +559,7 @@ const CSS = `
   color: #f1f5ff;
   font-size: 12px;
   line-height: 1.55;
+  white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
 #${CARD_ID} .bdc-assistant-citation-title {
@@ -776,6 +784,18 @@ interface AssistantState {
   segmentReturnAvailable: boolean;
   segmentReturnLoading: boolean;
   segmentTimestampRequestId: number;
+  fullTextQaResult: CurrentVideoFullTextQaResult | null;
+  fullTextQaContextKey: string;
+  fullTextQaLoading: boolean;
+  fullTextQaError: string | null;
+  fullTextQaRequestId: number;
+  fullTextQaActiveRequest: InPageFullTextQaRequest | null;
+  fullTextQaPreviewCitationId: string | null;
+  fullTextQaJumpStatus: string | null;
+  fullTextQaJumpLoading: boolean;
+  fullTextQaReturnAvailable: boolean;
+  fullTextQaReturnLoading: boolean;
+  fullTextQaTimestampRequestId: number;
   relatedFavorites: CurrentVideoRelatedFavoritesResponse | null;
   relatedFavoritesContextKey: string;
   relatedFavoritesLoading: boolean;
@@ -814,6 +834,16 @@ interface InPageSummaryHighlightsRequest {
   title: string;
   textSize: CurrentVideoSummaryHighlightsResult['textSize'];
   previousReady: CurrentVideoSummaryHighlightsResult | null;
+}
+
+interface InPageFullTextQaRequest {
+  requestId: string;
+  turnId: string;
+  params: Record<string, unknown>;
+  contextKey: string;
+  selectionRevision: number;
+  selectedSourceIdentityKey: string | null;
+  question: string;
 }
 
 const primaryTextSelections = new Map<string, string>();
@@ -860,6 +890,18 @@ const assistantState: AssistantState = {
   segmentReturnAvailable: false,
   segmentReturnLoading: false,
   segmentTimestampRequestId: 0,
+  fullTextQaResult: null,
+  fullTextQaContextKey: '',
+  fullTextQaLoading: false,
+  fullTextQaError: null,
+  fullTextQaRequestId: 0,
+  fullTextQaActiveRequest: null,
+  fullTextQaPreviewCitationId: null,
+  fullTextQaJumpStatus: null,
+  fullTextQaJumpLoading: false,
+  fullTextQaReturnAvailable: false,
+  fullTextQaReturnLoading: false,
+  fullTextQaTimestampRequestId: 0,
   relatedFavorites: null,
   relatedFavoritesContextKey: '',
   relatedFavoritesLoading: false,
@@ -913,6 +955,10 @@ function updateAssistantContext(context: CurrentVideoContextResult): void {
   const nextSubtitleKey = subtitleContextKeyForContext(context);
   const subtitleKeyChanged = previousSubtitleKey !== nextSubtitleKey;
   if (assistantState.contextKey !== nextKey) {
+    const activeQaRequest = assistantState.fullTextQaActiveRequest;
+    if (activeQaRequest) {
+      void sendRuntimeRequest('CANCEL_CURRENT_VIDEO_FULL_TEXT_QA', activeQaRequest.params).catch(() => undefined);
+    }
     invalidateSegmentTimestampRequests();
     assistantState.summary = null;
     assistantState.summaryContextKey = '';
@@ -936,6 +982,18 @@ function updateAssistantContext(context: CurrentVideoContextResult): void {
     assistantState.segmentJumpLoading = false;
     assistantState.segmentReturnAvailable = false;
     assistantState.segmentReturnLoading = false;
+    assistantState.fullTextQaRequestId += 1;
+    assistantState.fullTextQaActiveRequest = null;
+    assistantState.fullTextQaResult = null;
+    assistantState.fullTextQaContextKey = '';
+    assistantState.fullTextQaLoading = false;
+    assistantState.fullTextQaError = null;
+    assistantState.fullTextQaPreviewCitationId = null;
+    assistantState.fullTextQaJumpStatus = null;
+    assistantState.fullTextQaJumpLoading = false;
+    assistantState.fullTextQaReturnAvailable = false;
+    assistantState.fullTextQaReturnLoading = false;
+    assistantState.fullTextQaTimestampRequestId += 1;
     assistantState.relatedFavorites = null;
     assistantState.relatedFavoritesContextKey = '';
     assistantState.relatedFavoritesError = null;
@@ -1777,7 +1835,7 @@ function appendSegmentSearch(parent: HTMLElement, context: CurrentVideoContext):
     block,
     'div',
     'bdc-assistant-muted',
-    '问这个视频，或描述想跳到的片段。助手会先回答，再列出引用片段和手动跳转操作。',
+    '提交后会用当前分 P 的完整主要文本回答；先给直接答案，再列出可核对和跳转的引用片段。',
   );
 
   const primaryTextBlockReason = primaryTextSubmissionBlockMessage(buildPrimaryTextStateForContext(context));
@@ -1787,31 +1845,38 @@ function appendSegmentSearch(parent: HTMLElement, context: CurrentVideoContext):
 
   const input = document.createElement('textarea');
   input.className = 'bdc-assistant-search-input';
-  input.rows = 2;
-  input.maxLength = 120;
-  input.placeholder = '问这个视频，或描述想跳到的片段';
+  input.rows = 3;
+  input.maxLength = 500;
+  input.placeholder = '向当前视频提问';
   input.value = assistantState.segmentQuery;
-  input.disabled = Boolean(primaryTextBlockReason);
-  input.setAttribute('aria-label', '问这个视频，或描述想跳到的片段');
+  input.disabled = Boolean(primaryTextBlockReason) || assistantState.fullTextQaLoading;
+  input.setAttribute('aria-label', '向当前视频提问');
   input.addEventListener('input', () => {
     assistantState.segmentQuery = input.value;
   });
   input.addEventListener('keydown', (event) => {
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
-      void searchCurrentVideoSegmentsFromPage();
+      void askCurrentVideoFullTextFromPage();
     }
   });
   form.appendChild(input);
 
   form.appendChild(button(
-    assistantState.segmentLoading ? '回答中...' : '提问',
+    assistantState.fullTextQaLoading ? '回答中...' : '提问',
     'bdc-assistant-button bdc-assistant-button-primary',
     () => {
-      void searchCurrentVideoSegmentsFromPage();
+      void askCurrentVideoFullTextFromPage();
     },
-    assistantState.segmentLoading || !context.bvid || Boolean(primaryTextBlockReason),
+    assistantState.fullTextQaLoading || !context.bvid || Boolean(primaryTextBlockReason),
   ));
+  if (assistantState.fullTextQaLoading) {
+    form.appendChild(button(
+      '取消',
+      'bdc-assistant-button bdc-assistant-button-quiet',
+      cancelCurrentVideoFullTextQaFromPage,
+    ));
+  }
   block.appendChild(form);
 
   if (primaryTextBlockReason) {
@@ -1821,30 +1886,30 @@ function appendSegmentSearch(parent: HTMLElement, context: CurrentVideoContext):
       'bdc-assistant-subtitle-detail',
       primaryTextBlockReason,
     );
-  } else if (!context.transcriptEvidence?.active) {
+  } else {
     appendText(
       block,
       'div',
       'bdc-assistant-subtitle-detail',
-      '提示：完整回答通常需要字幕正文；没有当前视频本地证据时，不会猜答案或时间点。',
+      fullTextQaSubmissionNotice(context),
     );
   }
 
-  if (assistantState.segmentError) {
-    const error = appendText(block, 'div', 'bdc-assistant-retrieval-status', assistantState.segmentError);
+  if (assistantState.fullTextQaError) {
+    const error = appendText(block, 'div', 'bdc-assistant-retrieval-status', assistantState.fullTextQaError);
     error.style.color = '#ffcf8a';
   }
 
-  if (assistantState.segmentLoading) {
-    const loading = appendText(block, 'div', 'bdc-assistant-retrieval-status', '正在基于当前视频证据回答...');
+  if (assistantState.fullTextQaLoading) {
+    const loading = appendText(block, 'div', 'bdc-assistant-retrieval-status', '正在核对全片内容...');
     loading.style.color = '#c8e6ff';
   }
 
   if (
-    assistantState.segmentResult
-    && assistantState.segmentContextKey === assistantState.contextKey
+    assistantState.fullTextQaResult
+    && assistantState.fullTextQaContextKey === assistantState.contextKey
   ) {
-    appendSegmentRetrievalResult(block, assistantState.segmentResult, context);
+    appendFullTextQaResult(block, assistantState.fullTextQaResult);
   }
 
   parent.appendChild(block);
@@ -2021,6 +2086,160 @@ function appendRelatedFavoritesSettingsLink(parent: HTMLElement, qa: SmartFavori
   if (needsAiSettingsLink(qa.synthesis?.status ?? '')) {
     parent.appendChild(dashboardLink('前往设置', '#settings'));
   }
+}
+
+function appendFullTextQaResult(
+  parent: HTMLElement,
+  result: CurrentVideoFullTextQaResult,
+): void {
+  const answerCard = document.createElement('div');
+  answerCard.className = 'bdc-assistant-answer-card';
+  answerCard.style.borderColor = fullTextQaStatusColor(result.status);
+
+  const head = document.createElement('div');
+  head.className = 'bdc-assistant-answer-head';
+  head.style.color = fullTextQaStatusColor(result.status);
+  appendText(
+    head,
+    'span',
+    '',
+    `${result.status === 'ready' || result.status === 'unsupported' ? '回答' : '状态'}：${fullTextQaStatusLabel(result.status)}`,
+  );
+  if (result.status === 'ready') {
+    appendText(head, 'span', '', `引用 ${result.citations.length} 条`);
+  }
+  answerCard.appendChild(head);
+
+  appendText(
+    answerCard,
+    'div',
+    'bdc-assistant-answer-text',
+    safeVisibleText(result.answer || result.message),
+  );
+  if (result.sourceLabel) {
+    appendText(
+      answerCard,
+      'div',
+      'bdc-assistant-subtitle-detail',
+      safeVisibleText(fullTextQaSourceLine(result)),
+    );
+  }
+  parent.appendChild(answerCard);
+
+  if (result.citations.length > 0) {
+    appendText(parent, 'div', 'bdc-assistant-citation-title', '引用片段');
+    const list = document.createElement('div');
+    list.className = 'bdc-assistant-candidate-list';
+    for (const [index, citation] of result.citations.slice(0, 3).entries()) {
+      list.appendChild(fullTextQaCitationCard(citation, index));
+    }
+    parent.appendChild(list);
+  }
+
+  if (assistantState.fullTextQaJumpStatus) {
+    appendText(
+      parent,
+      'div',
+      'bdc-assistant-retrieval-status',
+      safeVisibleText(assistantState.fullTextQaJumpStatus),
+    );
+  }
+  if (assistantState.fullTextQaReturnAvailable) {
+    parent.appendChild(button(
+      assistantState.fullTextQaReturnLoading ? '正在返回...' : '返回原位置',
+      'bdc-assistant-button bdc-assistant-button-quiet',
+      () => { void returnCurrentVideoFullTextQaJumpFromPage(); },
+      assistantState.fullTextQaReturnLoading || assistantState.fullTextQaJumpLoading,
+    ));
+  }
+
+  if (result.status !== 'ready' && result.status !== 'unsupported') {
+    if (result.canRetry) {
+      parent.appendChild(button(
+        '重试本题',
+        'bdc-assistant-button bdc-assistant-button-quiet',
+        () => { void askCurrentVideoFullTextFromPage(result.turnId, result.question); },
+        assistantState.fullTextQaLoading,
+      ));
+    }
+    if (result.status === 'disabled' || result.status === 'not_configured') {
+      parent.appendChild(dashboardLink('前往设置', '#settings'));
+    }
+  }
+}
+
+function fullTextQaCitationCard(
+  citation: CurrentVideoFullTextQaCitation,
+  index: number,
+): HTMLElement {
+  const primaryTextBlockReason = assistantState.context?.kind === 'video'
+    ? primaryTextSubmissionBlockMessage(buildPrimaryTextStateForContext(assistantState.context))
+    : '当前没有可用的视频上下文。';
+  const card = document.createElement('article');
+  card.className = 'bdc-assistant-candidate-card';
+
+  const head = document.createElement('div');
+  head.className = 'bdc-assistant-candidate-head';
+  appendText(head, 'div', 'bdc-assistant-candidate-title', `引用 ${index + 1} · ${citation.timeRangeLabel}`);
+  appendText(head, 'div', 'bdc-assistant-candidate-strength', citation.sourceLabel);
+  card.appendChild(head);
+  appendText(card, 'div', 'bdc-assistant-candidate-evidence', safeVisibleText(citation.evidenceText));
+
+  const previewed = assistantState.fullTextQaPreviewCitationId === citation.id;
+  const actions = document.createElement('div');
+  actions.className = 'bdc-assistant-candidate-actions';
+  actions.appendChild(button(
+    previewed ? '已预览' : '预览跳转',
+    'bdc-assistant-button bdc-assistant-button-quiet',
+    () => {
+      assistantState.fullTextQaPreviewCitationId = citation.id;
+      assistantState.fullTextQaJumpStatus = `确认跳转前预览：${citation.timeRangeLabel}；确认后才会改变播放位置。`;
+      renderAssistantShell();
+    },
+    Boolean(primaryTextBlockReason)
+      || previewed
+      || assistantState.fullTextQaJumpLoading
+      || assistantState.fullTextQaReturnLoading,
+  ));
+  if (previewed) {
+    actions.appendChild(button(
+      assistantState.fullTextQaJumpLoading ? '正在跳转...' : '确认跳转',
+      'bdc-assistant-button bdc-assistant-button-primary',
+      () => { void confirmCurrentVideoFullTextQaJumpFromPage(citation.binding); },
+      Boolean(primaryTextBlockReason)
+        || assistantState.fullTextQaJumpLoading
+        || assistantState.fullTextQaReturnLoading,
+    ));
+  }
+  card.appendChild(actions);
+  return card;
+}
+
+function fullTextQaStatusLabel(status: CurrentVideoFullTextQaResult['status']): string {
+  switch (status) {
+    case 'ready': return '有证据';
+    case 'unsupported': return '证据不足';
+    case 'context_too_long': return '正文过长';
+    case 'cancelled': return '已取消';
+    case 'disabled': return '功能未开启';
+    case 'not_configured': return '服务未配置';
+    case 'no_context': return '未识别视频';
+    case 'no_text': return '主要文本不可用';
+    case 'invalid_output': return '结果未通过校验';
+    case 'error':
+    default: return '回答失败';
+  }
+}
+
+function fullTextQaStatusColor(status: CurrentVideoFullTextQaResult['status']): string {
+  if (status === 'ready') return '#9be7b0';
+  if (status === 'unsupported') return '#ffd27a';
+  return '#ffcf8a';
+}
+
+function fullTextQaSourceLine(result: CurrentVideoFullTextQaResult): string {
+  const part = result.partTitle ? ` · ${result.partTitle}` : '';
+  return `来源：《${result.title}》${part} · ${result.sourceLabel}`;
 }
 
 function appendSegmentRetrievalResult(
@@ -3202,6 +3421,208 @@ async function loadCurrentVideoRelatedFavoritesFromPage(force: boolean): Promise
   }
 }
 
+async function askCurrentVideoFullTextFromPage(
+  retryTurnId?: string,
+  retryQuestion?: string,
+): Promise<void> {
+  if (assistantState.fullTextQaLoading) return;
+  const question = (retryQuestion ?? assistantState.segmentQuery).replace(/\s+/g, ' ').trim();
+  if (!question) {
+    assistantState.fullTextQaError = '请输入一个关于当前视频的问题。';
+    renderAssistantShell();
+    return;
+  }
+  if (assistantState.context?.kind !== 'video') {
+    assistantState.fullTextQaError = '当前没有可用视频上下文，请在 B 站视频页内使用。';
+    renderAssistantShell();
+    return;
+  }
+  const primaryTextBlockReason = primaryTextSubmissionBlockMessage(
+    buildPrimaryTextStateForContext(assistantState.context),
+  );
+  if (primaryTextBlockReason) {
+    assistantState.fullTextQaError = primaryTextBlockReason;
+    renderAssistantShell();
+    return;
+  }
+
+  const operationId = assistantState.fullTextQaRequestId + 1;
+  const contextKey = assistantState.contextKey;
+  const requestId = createCurrentVideoFullTextRequestId('cvqa-page');
+  const turnId = retryTurnId?.trim() || createCurrentVideoFullTextRequestId('cvqa-turn');
+  if (retryQuestion !== undefined) assistantState.segmentQuery = question;
+  const params = {
+    ...currentPrimaryTextRequestParams(),
+    requestId,
+    turnId,
+    question,
+  };
+  const activeRequest: InPageFullTextQaRequest = {
+    requestId,
+    turnId,
+    params,
+    contextKey,
+    selectionRevision: primaryTextSelectionsRevision,
+    selectedSourceIdentityKey: selectedSourceIdentityKeyFromParams(params),
+    question,
+  };
+  assistantState.fullTextQaRequestId = operationId;
+  assistantState.fullTextQaActiveRequest = activeRequest;
+  assistantState.fullTextQaLoading = true;
+  assistantState.fullTextQaError = null;
+  assistantState.fullTextQaResult = null;
+  assistantState.fullTextQaContextKey = contextKey;
+  assistantState.fullTextQaPreviewCitationId = null;
+  assistantState.fullTextQaJumpStatus = null;
+  assistantState.fullTextQaJumpLoading = false;
+  assistantState.fullTextQaReturnAvailable = false;
+  assistantState.fullTextQaReturnLoading = false;
+  assistantState.fullTextQaTimestampRequestId += 1;
+  renderAssistantShell();
+
+  try {
+    const result = await sendRuntimeRequest<CurrentVideoFullTextQaResult>(
+      'ASK_CURRENT_VIDEO_FULL_TEXT',
+      params,
+    );
+    if (
+      assistantState.fullTextQaRequestId !== operationId
+      || !fullTextQaActiveRequestStillMatchesCurrent(activeRequest)
+      || result.requestId !== requestId
+      || result.turnId !== turnId
+    ) return;
+    assistantState.fullTextQaResult = result;
+    assistantState.fullTextQaContextKey = contextKey;
+    assistantState.fullTextQaError = null;
+  } catch {
+    if (
+      assistantState.fullTextQaRequestId !== operationId
+      || !fullTextQaActiveRequestStillMatchesCurrent(activeRequest)
+    ) return;
+    assistantState.fullTextQaError = '回答失败，问题已保留。请确认当前视频页和 AI 设置后重试。';
+  } finally {
+    if (assistantState.fullTextQaActiveRequest?.requestId === requestId) {
+      assistantState.fullTextQaActiveRequest = null;
+      assistantState.fullTextQaLoading = false;
+      renderAssistantShell();
+    }
+  }
+}
+
+function cancelCurrentVideoFullTextQaFromPage(): void {
+  const activeRequest = assistantState.fullTextQaActiveRequest;
+  if (!activeRequest) return;
+  assistantState.fullTextQaActiveRequest = null;
+  assistantState.fullTextQaRequestId += 1;
+  assistantState.fullTextQaLoading = false;
+  assistantState.fullTextQaResult = null;
+  assistantState.fullTextQaContextKey = assistantState.contextKey;
+  assistantState.fullTextQaError = '本次回答已取消，问题已保留。';
+  assistantState.fullTextQaPreviewCitationId = null;
+  assistantState.fullTextQaJumpStatus = null;
+  assistantState.fullTextQaReturnAvailable = false;
+  assistantState.fullTextQaTimestampRequestId += 1;
+  renderAssistantShell();
+  void sendRuntimeRequest('CANCEL_CURRENT_VIDEO_FULL_TEXT_QA', activeRequest.params).catch(() => undefined);
+}
+
+async function confirmCurrentVideoFullTextQaJumpFromPage(
+  binding: CurrentVideoFullTextQaCitationBinding,
+): Promise<void> {
+  if (
+    assistantState.fullTextQaJumpLoading
+    || assistantState.fullTextQaReturnLoading
+    || assistantState.context?.kind !== 'video'
+  ) return;
+  const primaryTextBlockReason = primaryTextSubmissionBlockMessage(
+    buildPrimaryTextStateForContext(assistantState.context),
+  );
+  if (primaryTextBlockReason) {
+    assistantState.fullTextQaJumpStatus = primaryTextBlockReason;
+    assistantState.fullTextQaReturnAvailable = false;
+    renderAssistantShell();
+    return;
+  }
+  const result = assistantState.fullTextQaContextKey === assistantState.contextKey
+    ? assistantState.fullTextQaResult
+    : null;
+  const citation = result?.citations.find(item => fullTextQaBindingsEqual(item.binding, binding));
+  if (!citation || assistantState.fullTextQaPreviewCitationId !== citation.id) {
+    assistantState.fullTextQaPreviewCitationId = null;
+    assistantState.fullTextQaJumpStatus = '引用结果已变化，请重新预览后再跳转。';
+    renderAssistantShell();
+    return;
+  }
+
+  const operationId = assistantState.fullTextQaTimestampRequestId + 1;
+  const contextKey = assistantState.contextKey;
+  assistantState.fullTextQaTimestampRequestId = operationId;
+  assistantState.fullTextQaJumpLoading = true;
+  assistantState.fullTextQaReturnLoading = false;
+  assistantState.fullTextQaReturnAvailable = false;
+  assistantState.fullTextQaJumpStatus = '正在确认跳转...';
+  renderAssistantShell();
+
+  try {
+    const response = await sendRuntimeRequest<CurrentVideoTimestampJumpResponse>(
+      'REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP',
+      {
+        ...binding,
+        confirmed: true,
+        ...currentPrimaryTextRequestParams(),
+      },
+    );
+    if (
+      assistantState.fullTextQaTimestampRequestId !== operationId
+      || assistantState.contextKey !== contextKey
+    ) return;
+    assistantState.fullTextQaJumpStatus = response.ok
+      ? '已跳到引用位置，可返回原位置。'
+      : '引用结果或页面状态已变化，请重新提交问题后再试。';
+    assistantState.fullTextQaReturnAvailable = response.ok && response.returnPointSeconds !== null;
+    assistantState.fullTextQaPreviewCitationId = null;
+  } catch {
+    if (assistantState.fullTextQaTimestampRequestId !== operationId) return;
+    assistantState.fullTextQaJumpStatus = '引用跳转失败，请确认当前视频页仍然打开后重试。';
+    assistantState.fullTextQaReturnAvailable = false;
+  } finally {
+    if (assistantState.fullTextQaTimestampRequestId === operationId) {
+      assistantState.fullTextQaJumpLoading = false;
+      renderAssistantShell();
+    }
+  }
+}
+
+async function returnCurrentVideoFullTextQaJumpFromPage(): Promise<void> {
+  if (assistantState.fullTextQaReturnLoading || assistantState.fullTextQaJumpLoading) return;
+  const operationId = assistantState.fullTextQaTimestampRequestId + 1;
+  const contextKey = assistantState.contextKey;
+  assistantState.fullTextQaTimestampRequestId = operationId;
+  assistantState.fullTextQaReturnLoading = true;
+  assistantState.fullTextQaJumpStatus = '正在返回原位置...';
+  renderAssistantShell();
+  try {
+    const response = await sendRuntimeRequest<CurrentVideoTimestampReturnResponse>(
+      'RETURN_CURRENT_VIDEO_SEGMENT_JUMP',
+      currentPrimaryTextRequestParams(),
+    );
+    if (
+      assistantState.fullTextQaTimestampRequestId !== operationId
+      || assistantState.contextKey !== contextKey
+    ) return;
+    assistantState.fullTextQaJumpStatus = timestampReturnStatusText(response);
+    if (response.ok) assistantState.fullTextQaReturnAvailable = false;
+  } catch {
+    if (assistantState.fullTextQaTimestampRequestId !== operationId) return;
+    assistantState.fullTextQaJumpStatus = '返回失败，请确认当前视频页仍然打开后重试。';
+  } finally {
+    if (assistantState.fullTextQaTimestampRequestId === operationId) {
+      assistantState.fullTextQaReturnLoading = false;
+      renderAssistantShell();
+    }
+  }
+}
+
 async function searchCurrentVideoSegmentsFromPage(): Promise<void> {
   if (assistantState.segmentLoading) return;
 
@@ -3989,6 +4410,7 @@ function ensurePrimaryTextSelectionStorageListener(): void {
 
     if (configChanged) {
       invalidateSummaryHighlightsForLiveConfigChange(changes[USER_CONFIG_STORAGE_KEY]?.newValue);
+      invalidateFullTextQaForLiveConfigChange(changes[USER_CONFIG_STORAGE_KEY]?.newValue);
       if (assistantState.context) {
         renderAssistantShell();
         if (assistantState.expanded) void restoreCurrentVideoSummaryHighlightsFromPage();
@@ -4006,6 +4428,10 @@ function replacePrimaryTextSelections(selections: Record<string, string>): void 
 }
 
 function invalidatePrimaryTextDependentAssistantState(): void {
+  const activeQaRequest = assistantState.fullTextQaActiveRequest;
+  if (activeQaRequest) {
+    void sendRuntimeRequest('CANCEL_CURRENT_VIDEO_FULL_TEXT_QA', activeQaRequest.params).catch(() => undefined);
+  }
   assistantState.summaryRequestId += 1;
   if (!assistantState.summaryActiveRequest) {
     assistantState.summaryLoading = false;
@@ -4038,6 +4464,19 @@ function invalidatePrimaryTextDependentAssistantState(): void {
   assistantState.segmentJumpLoading = false;
   assistantState.segmentReturnAvailable = false;
   assistantState.segmentReturnLoading = false;
+
+  assistantState.fullTextQaRequestId += 1;
+  assistantState.fullTextQaActiveRequest = null;
+  assistantState.fullTextQaResult = null;
+  assistantState.fullTextQaContextKey = '';
+  assistantState.fullTextQaLoading = false;
+  assistantState.fullTextQaError = null;
+  assistantState.fullTextQaPreviewCitationId = null;
+  assistantState.fullTextQaJumpStatus = null;
+  assistantState.fullTextQaJumpLoading = false;
+  assistantState.fullTextQaReturnAvailable = false;
+  assistantState.fullTextQaReturnLoading = false;
+  assistantState.fullTextQaTimestampRequestId += 1;
 
   assistantState.subtitleRequestId += 1;
   assistantState.subtitleRefreshing = false;
@@ -4214,6 +4653,55 @@ function summaryActiveRequestStillMatchesCurrent(
     );
 }
 
+function invalidateFullTextQaForLiveConfigChange(userConfig: unknown): void {
+  const activeRequest = assistantState.fullTextQaActiveRequest;
+  if (!activeRequest) return;
+  assistantState.fullTextQaActiveRequest = null;
+  assistantState.fullTextQaRequestId += 1;
+  assistantState.fullTextQaLoading = false;
+  assistantState.fullTextQaResult = null;
+  assistantState.fullTextQaContextKey = assistantState.contextKey;
+  assistantState.fullTextQaPreviewCitationId = null;
+  assistantState.fullTextQaJumpStatus = null;
+  assistantState.fullTextQaReturnAvailable = false;
+  assistantState.fullTextQaTimestampRequestId += 1;
+  const gate = currentVideoSummaryGenerationGate(userConfig);
+  assistantState.fullTextQaError = gate.enabled && gate.configured
+    ? 'AI 设置已变化，本次回答已取消，问题已保留。'
+    : '当前视频 AI 助手已关闭或配置不完整，本次回答已取消，问题已保留。';
+  void sendRuntimeRequest('CANCEL_CURRENT_VIDEO_FULL_TEXT_QA', activeRequest.params).catch(() => undefined);
+}
+
+function fullTextQaActiveRequestStillMatchesCurrent(
+  activeRequest: InPageFullTextQaRequest,
+): boolean {
+  return activeRequest.contextKey === assistantState.contextKey
+    && activeRequest.selectionRevision === primaryTextSelectionsRevision
+    && activeRequest.selectedSourceIdentityKey === selectedSourceIdentityKeyFromParams(
+      currentPrimaryTextRequestParams(),
+    );
+}
+
+function fullTextQaBindingsEqual(
+  left: CurrentVideoFullTextQaCitationBinding,
+  right: CurrentVideoFullTextQaCitationBinding,
+): boolean {
+  return left.requestId === right.requestId
+    && left.turnId === right.turnId
+    && left.citationId === right.citationId;
+}
+
+function fullTextQaSubmissionNotice(context: CurrentVideoContext): string {
+  const lineCount = context.transcriptEvidence?.segmentCount ?? 0;
+  const bytes = context.transcriptEvidence?.serializedBytes ?? 0;
+  const size = bytes > 0 ? `${Math.max(1, Math.ceil(bytes / 1024))} KB` : '大小待读取';
+  return [
+    `本次提交会发送当前分 P 的完整主要文本（约 ${lineCount} 行，${size}）。`,
+    '等待时间和费用由你配置的 AI 服务决定。',
+    '提交即开始；系统不会静默截断或改为片段检索。',
+  ].join(' ');
+}
+
 function selectedSourceIdentityKeyFromParams(params: Record<string, unknown>): string | null {
   const value = params.selectedSourceIdentityKey;
   return typeof value === 'string' && value.trim() ? value.trim() : null;
@@ -4355,6 +4843,9 @@ function timestampReturnStatusText(response: CurrentVideoTimestampReturnResponse
 
 function safeVisibleText(value: string): string {
   return value
+    .replace(/document is not defined/gi, '运行状态不可用')
+    .replace(RAW_FIELD_VALUE_PATTERN, '内部信息已隐藏')
+    .replace(BILIBILI_VIDEO_ID_PATTERN, '视频编号已隐藏')
     .replace(CANDIDATE_ID_PATTERN, '候选片段')
     .replace(TRANSCRIPT_ID_PATTERN, '字幕片段')
     .replace(NODE_ID_PATTERN, '知识节点')

--- a/src/shared/assistant-payload-audit.ts
+++ b/src/shared/assistant-payload-audit.ts
@@ -149,6 +149,41 @@ export const currentVideoSummaryHighlightsPayloadContract: AssistantPayloadAudit
   ],
 };
 
+export const currentVideoFullTextQaPayloadContract: AssistantPayloadAuditContract = {
+  name: 'current-video-full-text-qa-v1',
+  allowedPaths: [
+    '$',
+    '$.intent',
+    '$.request',
+    '$.request.requestId',
+    '$.request.turnId',
+    '$.request.operation',
+    '$.request.submittedAt',
+    '$.request.model',
+    '$.request.lineCount',
+    '$.request.charCount',
+    '$.request.utf8Bytes',
+    '$.question',
+    '$.source',
+    '$.source.label',
+    '$.source.language',
+    '$.textLines',
+    '$.textLines[]',
+    '$.textLines[].lineNo',
+    '$.textLines[].startSeconds',
+    '$.textLines[].endSeconds',
+    '$.textLines[].text',
+    '$.outputRules',
+    '$.outputRules[]',
+  ],
+  contentStringPaths: [
+    '$.request.model',
+    '$.question',
+    '$.source.language',
+    '$.textLines[].text',
+  ],
+};
+
 export const smartFavoriteQaPayloadContract: AssistantPayloadAuditContract = {
   name: 'smart-favorites-qa-synthesis-v1',
   allowedPaths: [

--- a/src/shared/current-video-full-text-qa.ts
+++ b/src/shared/current-video-full-text-qa.ts
@@ -1,0 +1,308 @@
+import type { CurrentVideoFullTextRequestEnvelope } from './current-video-primary-text.ts';
+import type { AiConfig } from './types/config.ts';
+import type { CurrentVideoFullTextQaCitation } from './types/current-video-full-text-qa.ts';
+import {
+  assertAssistantPayloadAudit,
+  currentVideoFullTextQaPayloadContract,
+} from './assistant-payload-audit.ts';
+
+export interface CurrentVideoFullTextQaAiPayload {
+  intent: 'current_video_full_text_qa_v1';
+  outputRules: string[];
+  source: {
+    label: 'B站字幕' | '本地转录';
+    language: string | null;
+  };
+  textLines: Array<{
+    lineNo: number;
+    startSeconds: number;
+    endSeconds: number;
+    text: string;
+  }>;
+  request: {
+    requestId: string;
+    turnId: string;
+    operation: 'qa';
+    submittedAt: number;
+    model: string;
+    lineCount: number;
+    charCount: number;
+    utf8Bytes: number;
+  };
+  question: string;
+}
+
+export interface CurrentVideoFullTextQaAiOutput {
+  supported?: unknown;
+  answerPoints?: unknown;
+  citations?: unknown;
+}
+
+export interface CurrentVideoFullTextQaValidatedAnswerPoint {
+  text: string;
+  evidenceLineNumbers: number[];
+}
+
+export type CurrentVideoFullTextQaChat = (
+  config: AiConfig,
+  messages: Array<{ role: 'system' | 'user'; content: string }>,
+  options?: { signal?: AbortSignal },
+) => Promise<CurrentVideoFullTextQaAiOutput>;
+
+export type CurrentVideoFullTextQaValidationResult =
+  | {
+      ok: true;
+      kind: 'answered';
+      answerPoints: CurrentVideoFullTextQaValidatedAnswerPoint[];
+      answer: string;
+      answerEvidenceLineNumbers: number[];
+      citations: Array<Omit<CurrentVideoFullTextQaCitation, 'sourceLabel' | 'binding'>>;
+    }
+  | {
+      ok: true;
+      kind: 'unsupported';
+      answer: string;
+      answerEvidenceLineNumbers: [];
+      citations: [];
+    }
+  | { ok: false; reason: string };
+
+const MAX_ANSWER_CHARS = 4_000;
+const MAX_ANSWER_POINTS = 4;
+const MAX_ANSWER_POINT_CHARS = 1_500;
+const MAX_ANSWER_EVIDENCE_LINES = 36;
+const MAX_CITATION_LINES = 12;
+const UNSUPPORTED_ANSWER = '当前视频文本没有足够内容回答这个问题。';
+
+export function buildCurrentVideoFullTextQaAiPayload(
+  envelope: CurrentVideoFullTextRequestEnvelope,
+  question: string,
+): CurrentVideoFullTextQaAiPayload {
+  if (envelope.operation !== 'qa' || !envelope.turnId?.trim()) {
+    throw new Error('FULL_TEXT_QA_REQUEST_IDENTITY_INVALID');
+  }
+  const normalizedQuestion = question.replace(/\s+/g, ' ').trim();
+  if (!normalizedQuestion) throw new Error('FULL_TEXT_QA_QUESTION_EMPTY');
+
+  return {
+    intent: 'current_video_full_text_qa_v1',
+    outputRules: [
+      '只返回 JSON 对象，不要 Markdown。',
+      '只能依据 textLines 回答，不得使用标题、简介、通用知识或其他视频内容。',
+      '有充分依据时返回 supported=true、1-4 条 answerPoints，以及 1-3 条 citations。',
+      '每条 answerPoint 只包含 text 和 evidenceLineNumbers；text 是直接中文回答的一部分。',
+      '每条 citation 只包含 evidenceLineNumbers，行号必须连续且来自 textLines。',
+      '每条 answerPoint 的 evidenceLineNumbers 必须全部出现在 citations 引用的行号中。',
+      '正文不足以支持回答时返回 supported=false，citations 为空；不要猜测或补全。',
+      '不要返回视频身份、来源标识、时间戳或引用正文，系统会从本地行号生成引用。',
+    ],
+    source: {
+      label: envelope.sourceLabel,
+      language: envelope.language,
+    },
+    textLines: envelope.text.lines.map(line => ({
+      lineNo: line.lineNo,
+      startSeconds: line.startSeconds,
+      endSeconds: line.endSeconds,
+      text: line.text,
+    })),
+    request: {
+      requestId: envelope.requestId,
+      turnId: envelope.turnId,
+      operation: 'qa',
+      submittedAt: envelope.submittedAt,
+      model: envelope.model,
+      lineCount: envelope.text.lineCount,
+      charCount: envelope.text.charCount,
+      utf8Bytes: envelope.text.utf8Bytes,
+    },
+    question: normalizedQuestion,
+  };
+}
+
+export function buildCurrentVideoFullTextQaMessages(
+  payload: CurrentVideoFullTextQaAiPayload,
+): Array<{ role: 'system' | 'user'; content: string }> {
+  return [
+    {
+      role: 'system',
+      content: [
+        '你是当前视频正文问答助手，只能依据用户提供的带编号时间行回答。',
+        '先形成直接、自然的中文答案，再给出支撑答案的行号；证据不足时必须拒答。',
+        '禁止使用标题、简介、常识或其他视频内容补全，禁止编造引用、正文或时间。',
+        '返回 JSON 对象，字段为 supported、answerPoints、citations。',
+      ].join('\n'),
+    },
+    { role: 'user', content: JSON.stringify(payload) },
+  ];
+}
+
+export async function requestCurrentVideoFullTextQaAi(
+  config: AiConfig,
+  payload: CurrentVideoFullTextQaAiPayload,
+  envelope: CurrentVideoFullTextRequestEnvelope,
+  chat: CurrentVideoFullTextQaChat,
+  options: { signal?: AbortSignal } = {},
+): Promise<CurrentVideoFullTextQaAiOutput> {
+  assertAssistantPayloadAudit(payload, currentVideoFullTextQaPayloadContract);
+  assertCompleteFullTextQaPayload(payload, envelope);
+  return await chat(config, buildCurrentVideoFullTextQaMessages(payload), options);
+}
+
+export function validateCurrentVideoFullTextQaAiOutput(
+  output: unknown,
+  envelope: CurrentVideoFullTextRequestEnvelope,
+): CurrentVideoFullTextQaValidationResult {
+  if (!output || typeof output !== 'object') return invalid('output_not_object');
+  const record = output as CurrentVideoFullTextQaAiOutput;
+  if (typeof record.supported !== 'boolean') return invalid('supported_invalid');
+
+  if (!record.supported) {
+    if (
+      record.answerPoints !== undefined
+      && (!Array.isArray(record.answerPoints) || record.answerPoints.length > 0)
+    ) {
+      return invalid('unsupported_has_answer_points');
+    }
+    if (record.citations !== undefined && (!Array.isArray(record.citations) || record.citations.length > 0)) {
+      return invalid('unsupported_has_citations');
+    }
+    return {
+      ok: true,
+      kind: 'unsupported',
+      answer: UNSUPPORTED_ANSWER,
+      answerEvidenceLineNumbers: [],
+      citations: [],
+    };
+  }
+
+  if (!Array.isArray(record.answerPoints) || record.answerPoints.length < 1 || record.answerPoints.length > MAX_ANSWER_POINTS) {
+    return invalid('answer_point_count');
+  }
+
+  if (!Array.isArray(record.citations) || record.citations.length < 1 || record.citations.length > 3) {
+    return invalid('citation_count');
+  }
+
+  const lineMap = new Map(envelope.text.lines.map(line => [line.lineNo, line]));
+  const answerPoints: CurrentVideoFullTextQaValidatedAnswerPoint[] = [];
+  const answerEvidenceLineNumbers = new Set<number>();
+  for (const item of record.answerPoints) {
+    if (!item || typeof item !== 'object') return invalid('answer_point_invalid');
+    const point = item as { text?: unknown; evidenceLineNumbers?: unknown };
+    const text = typeof point.text === 'string' ? point.text.replace(/\s+/g, ' ').trim() : '';
+    if (!text || text.length > MAX_ANSWER_POINT_CHARS || !/[\u3400-\u9fff]/u.test(text)) {
+      return invalid('answer_point_text_invalid');
+    }
+    const evidence = normalizeLineNumbers(point.evidenceLineNumbers, MAX_ANSWER_EVIDENCE_LINES);
+    if (!evidence.ok) return invalid(`answer_point_${evidence.reason}`);
+    if (!evidence.lineNumbers.every(lineNo => lineMap.has(lineNo))) {
+      return invalid('answer_point_evidence_line_missing');
+    }
+    evidence.lineNumbers.forEach(lineNo => answerEvidenceLineNumbers.add(lineNo));
+    answerPoints.push({ text, evidenceLineNumbers: evidence.lineNumbers });
+  }
+  const answer = answerPoints.map(point => point.text).join('\n\n');
+  if (answer.length > MAX_ANSWER_CHARS) return invalid('answer_too_long');
+
+  const citations: Array<Omit<CurrentVideoFullTextQaCitation, 'sourceLabel' | 'binding'>> = [];
+  const citedLineNumbers = new Set<number>();
+  for (const [index, item] of record.citations.entries()) {
+    if (!item || typeof item !== 'object') return invalid('citation_invalid');
+    const normalized = normalizeLineNumbers(
+      (item as { evidenceLineNumbers?: unknown }).evidenceLineNumbers,
+      MAX_CITATION_LINES,
+    );
+    if (!normalized.ok) return invalid(`citation_${normalized.reason}`);
+    if (!normalized.lineNumbers.every(lineNo => lineMap.has(lineNo))) {
+      return invalid('citation_line_missing');
+    }
+    if (!linesAreContiguous(normalized.lineNumbers)) {
+      return invalid('citation_lines_not_contiguous');
+    }
+    normalized.lineNumbers.forEach(lineNo => citedLineNumbers.add(lineNo));
+    const lines = normalized.lineNumbers.map(lineNo => lineMap.get(lineNo)!);
+    const startSeconds = lines[0]!.startSeconds;
+    const endSeconds = lines[lines.length - 1]!.endSeconds;
+    citations.push({
+      id: `citation-${index + 1}`,
+      evidenceLineNumbers: normalized.lineNumbers,
+      evidenceText: lines.map(line => line.text).join(' '),
+      startSeconds,
+      endSeconds,
+      timeRangeLabel: formatTimeRange(startSeconds, endSeconds),
+    });
+  }
+
+  if (!Array.from(answerEvidenceLineNumbers).every(lineNo => citedLineNumbers.has(lineNo))) {
+    return invalid('answer_point_evidence_not_cited');
+  }
+
+  return {
+    ok: true,
+    kind: 'answered',
+    answerPoints,
+    answer,
+    answerEvidenceLineNumbers: Array.from(answerEvidenceLineNumbers).sort((a, b) => a - b),
+    citations,
+  };
+}
+
+function assertCompleteFullTextQaPayload(
+  payload: CurrentVideoFullTextQaAiPayload,
+  envelope: CurrentVideoFullTextRequestEnvelope,
+): void {
+  const complete = envelope.operation === 'qa'
+    && Boolean(envelope.turnId)
+    && payload.request.requestId === envelope.requestId
+    && payload.request.turnId === envelope.turnId
+    && payload.request.operation === envelope.operation
+    && payload.request.lineCount === envelope.text.lineCount
+    && payload.request.charCount === envelope.text.charCount
+    && payload.request.utf8Bytes === envelope.text.utf8Bytes
+    && payload.textLines.length === envelope.text.lines.length
+    && payload.textLines.every((line, index) => {
+      const captured = envelope.text.lines[index];
+      return Boolean(captured)
+        && line.lineNo === captured!.lineNo
+        && line.startSeconds === captured!.startSeconds
+        && line.endSeconds === captured!.endSeconds
+        && line.text === captured!.text;
+    });
+  if (!complete) {
+    throw new Error('完整文本问答请求未包含本次捕获的全部正文。');
+  }
+}
+
+function normalizeLineNumbers(
+  value: unknown,
+  maxCount: number,
+): { ok: true; lineNumbers: number[] } | { ok: false; reason: string } {
+  if (!Array.isArray(value) || value.length < 1) return { ok: false, reason: 'evidence_missing' };
+  if (value.length > maxCount) return { ok: false, reason: 'evidence_too_many' };
+  if (!value.every(item => Number.isInteger(item) && Number(item) > 0)) {
+    return { ok: false, reason: 'evidence_invalid' };
+  }
+  const lineNumbers = Array.from(new Set(value.map(Number))).sort((a, b) => a - b);
+  if (lineNumbers.length !== value.length) return { ok: false, reason: 'evidence_duplicate' };
+  return { ok: true, lineNumbers };
+}
+
+function linesAreContiguous(lineNumbers: number[]): boolean {
+  return lineNumbers.every((lineNo, index) => index === 0 || lineNo === lineNumbers[index - 1]! + 1);
+}
+
+function formatTimeRange(startSeconds: number, endSeconds: number): string {
+  return `${formatSeconds(startSeconds)}-${formatSeconds(endSeconds)}`;
+}
+
+function formatSeconds(value: number): string {
+  const seconds = Math.max(0, Math.floor(value));
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  return `${minutes}:${String(remainder).padStart(2, '0')}`;
+}
+
+function invalid(reason: string): { ok: false; reason: string } {
+  return { ok: false, reason };
+}

--- a/src/shared/types/current-video-full-text-qa.ts
+++ b/src/shared/types/current-video-full-text-qa.ts
@@ -1,0 +1,70 @@
+export type CurrentVideoFullTextQaStatus =
+  | 'ready'
+  | 'unsupported'
+  | 'no_context'
+  | 'no_text'
+  | 'disabled'
+  | 'not_configured'
+  | 'context_too_long'
+  | 'cancelled'
+  | 'invalid_output'
+  | 'error';
+
+export type CurrentVideoFullTextQaAiStatus =
+  | 'generated'
+  | 'unsupported'
+  | 'disabled'
+  | 'not_configured'
+  | 'context_too_long'
+  | 'cancelled'
+  | 'invalid_output'
+  | 'failed';
+
+export interface CurrentVideoFullTextQaTextSize {
+  lineCount: number;
+  charCount: number | null;
+  utf8Bytes: number;
+}
+
+export interface CurrentVideoFullTextQaCitationBinding {
+  requestId: string;
+  turnId: string;
+  citationId: string;
+}
+
+export interface CurrentVideoFullTextQaCitation {
+  id: string;
+  evidenceLineNumbers: number[];
+  evidenceText: string;
+  startSeconds: number;
+  endSeconds: number;
+  timeRangeLabel: string;
+  sourceLabel: 'B站字幕' | '本地转录';
+  binding: CurrentVideoFullTextQaCitationBinding;
+}
+
+export interface CurrentVideoFullTextQaAiState {
+  status: CurrentVideoFullTextQaAiStatus;
+  model: string | null;
+  note: string;
+  errorCode: string | null;
+}
+
+export interface CurrentVideoFullTextQaResult {
+  status: CurrentVideoFullTextQaStatus;
+  requestId: string;
+  turnId: string;
+  question: string;
+  title: string;
+  partTitle: string | null;
+  sourceLabel: 'B站字幕' | '本地转录' | null;
+  textSize: CurrentVideoFullTextQaTextSize;
+  answer: string;
+  answerEvidenceLineNumbers: number[];
+  citations: CurrentVideoFullTextQaCitation[];
+  message: string;
+  limitations: string[];
+  ai: CurrentVideoFullTextQaAiState;
+  generatedAt: number;
+  canRetry: boolean;
+}

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -43,6 +43,7 @@ import type {
 import type { CurrentVideoSubtitleViewSourcesResult } from '../current-video-subtitle-view.ts';
 import type { CurrentVideoRelatedFavoritesResponse } from './current-video-related-favorites';
 import type { CurrentVideoSummaryHighlightsResult } from './current-video-summary';
+import type { CurrentVideoFullTextQaResult } from './current-video-full-text-qa';
 import type { VideoKnowledgeResult } from './video-knowledge';
 import type { HistoryTailProbeReport } from './history-tail-probe';
 import type { HistorySyncCursorSnapshot, HistorySyncMode } from './history-sync';
@@ -83,12 +84,15 @@ export type RequestAction =
   | 'GET_CURRENT_VIDEO_SUMMARY_HIGHLIGHTS_CACHE'
   | 'GENERATE_CURRENT_VIDEO_SUMMARY_HIGHLIGHTS'
   | 'CANCEL_CURRENT_VIDEO_SUMMARY_HIGHLIGHTS'
+  | 'ASK_CURRENT_VIDEO_FULL_TEXT'
+  | 'CANCEL_CURRENT_VIDEO_FULL_TEXT_QA'
   | 'GET_VIDEO_KNOWLEDGE'
   | 'SEARCH_CURRENT_VIDEO_SEGMENTS'
   | 'GET_CURRENT_VIDEO_SUBTITLE_VIEW_SOURCES'
   | 'GET_CURRENT_VIDEO_RELATED_FAVORITES'
   | 'REQUEST_CURRENT_VIDEO_SEGMENT_JUMP'
   | 'REQUEST_CURRENT_VIDEO_HIGHLIGHT_JUMP'
+  | 'REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP'
   | 'REQUEST_CURRENT_VIDEO_SUBTITLE_JUMP'
   | 'RETURN_CURRENT_VIDEO_SEGMENT_JUMP'
   | 'RETURN_CURRENT_VIDEO_SUBTITLE_JUMP'
@@ -219,6 +223,7 @@ export type CurrentVideoContextResponse = BiliVizResponse<CurrentVideoContextRes
 export type CurrentVideoSubtitleSourceResponse = BiliVizResponse<CurrentVideoSubtitleSourceState>;
 export type CurrentVideoTranscriptEvidenceResponse = BiliVizResponse<CurrentVideoTranscriptEvidenceState>;
 export type CurrentVideoSummaryHighlightsResponse = BiliVizResponse<CurrentVideoSummaryHighlightsResult>;
+export type CurrentVideoFullTextQaResponse = BiliVizResponse<CurrentVideoFullTextQaResult>;
 export type VideoKnowledgeResponse = BiliVizResponse<VideoKnowledgeResult>;
 export type CurrentVideoSegmentRetrievalResponse = BiliVizResponse<CurrentVideoSegmentRetrievalResult>;
 export type CurrentVideoSubtitleViewSourcesResponse = BiliVizResponse<CurrentVideoSubtitleViewSourcesResult>;

--- a/tests/current-video-assistant-shell.mock.html
+++ b/tests/current-video-assistant-shell.mock.html
@@ -86,6 +86,7 @@
       let returnPointSeconds = null;
       let videoDetectionReady = mockParams.get("deferVideoDetection") !== "1";
       let lastSearchResult = null;
+      let lastFullTextQaResult = null;
       let subtitleSourceHash = mockParams.get("sourceVersion") === "v2" ? "mock-source-hash-hidden-v2" : "mock-source-hash-hidden";
       let subtitleBodyHash = mockParams.get("sourceVersion") === "v2" ? "mock-body-hash-hidden-v2" : "mock-body-hash-hidden";
       let subtitleTimelineHash = mockParams.get("sourceVersion") === "v2" ? "mock-timeline-hash-hidden-v2" : "mock-timeline-hash-hidden";
@@ -1587,6 +1588,121 @@
         return withQa(lastSearchResult);
       }
 
+      function currentVideoFullTextQaResult(params) {
+        const requestId = String(params?.requestId || "mock-qa-request");
+        const turnId = String(params?.turnId || "mock-qa-turn");
+        const question = String(params?.question || "").trim();
+        const base = {
+          requestId,
+          turnId,
+          question,
+          title: mockTitle.trim() || "当前视频",
+          partTitle: mockPage === 1 ? "主视频" : "第二分 P",
+          sourceLabel: subtitleCached ? "B站字幕" : null,
+          textSize: { lineCount: subtitleCached ? 4 : 0, charCount: subtitleCached ? 168 : null, utf8Bytes: subtitleCached ? 336 : 0 },
+          answerEvidenceLineNumbers: [],
+          citations: [],
+          limitations: ["本次只使用当前分 P 的完整主要文本。"],
+          generatedAt: Date.now(),
+          canRetry: true,
+        };
+        const state = currentSummaryState();
+        if (state === "disabled" || state === "unconfigured") {
+          lastFullTextQaResult = {
+            ...base,
+            status: state === "disabled" ? "disabled" : "not_configured",
+            answer: "",
+            message: state === "disabled"
+              ? "当前视频 AI 助手已关闭，问题已保留。开启后可重新提交。"
+              : "AI 服务尚未配置完成，问题已保留。完成设置后可重新提交。",
+            ai: { status: state === "disabled" ? "disabled" : "not_configured", model: currentChatModel(), note: "", errorCode: null },
+          };
+          return lastFullTextQaResult;
+        }
+        if (question.includes("正文过长")) {
+          lastFullTextQaResult = {
+            ...base,
+            status: "context_too_long",
+            answer: "",
+            message: "当前正文过长，所选模型没有接受本次完整请求；系统不会截断或分段发送。问题已保留，可更换模型后重试。",
+            ai: { status: "context_too_long", model: currentChatModel(), note: "", errorCode: "context_too_long" },
+          };
+          return lastFullTextQaResult;
+        }
+
+        const search = searchCurrentVideoSegmentsResult(question);
+        if (search.qa?.status !== "answered" || !subtitleCached) {
+          lastFullTextQaResult = {
+            ...base,
+            status: "unsupported",
+            answer: "当前视频文本没有足够内容回答这个问题。",
+            message: "当前视频文本没有足够内容支持回答。",
+            canRetry: false,
+            ai: { status: "unsupported", model: currentChatModel(), note: "", errorCode: null },
+          };
+          return lastFullTextQaResult;
+        }
+
+        const rawVisibleCopy = question.includes("原始身份泄漏");
+        const candidate = search.candidates.find(item => item.startSeconds !== null);
+        const citation = candidate ? {
+          id: "citation-1",
+          evidenceLineNumbers: [1, 2],
+          evidenceText: rawVisibleCopy
+            ? "fallback transcript confidence sourceHash=page-secret segmentId=segment-secret subtitle_url=https://secret.invalid bvid=BV1RawLeak99 CID=2202 独立 BV1RawLeak99"
+            : candidate.evidenceText,
+          startSeconds: candidate.startSeconds,
+          endSeconds: candidate.endSeconds,
+          timeRangeLabel: candidate.timeRangeLabel,
+          sourceLabel: "B站字幕",
+          binding: { requestId, turnId, citationId: "citation-1" },
+        } : null;
+        lastFullTextQaResult = {
+          ...base,
+          status: "ready",
+          answer: rawVisibleCopy
+            ? "document is not defined; fallback transcript confidence sourceHash=page-secret segmentId=segment-secret subtitle_url=https://secret.invalid bvid=BV1RawLeak99 CID=2202 独立 BV1RawLeak99"
+            : "作者说明子代理会承接拆分后的较小任务，并与主流程协作完成工作。",
+          answerEvidenceLineNumbers: [1, 2],
+          citations: citation ? [citation] : [],
+          message: "回答已基于当前分 P 的完整主要文本生成。",
+          ai: { status: "generated", model: currentChatModel(), note: "", errorCode: null },
+        };
+        return lastFullTextQaResult;
+      }
+
+      function requestCurrentVideoQaCitationJump(params) {
+        const citation = lastFullTextQaResult?.citations?.find(item =>
+          item.binding.requestId === params?.requestId
+          && item.binding.turnId === params?.turnId
+          && item.binding.citationId === params?.citationId
+        );
+        if (params?.confirmed !== true || !citation) {
+          return {
+            ok: false,
+            message: params?.confirmed === true ? "当前引用已过期，请重新提交问题后再跳转。" : "需要先确认跳转。",
+            candidateId: String(params?.citationId || ""),
+            targetSeconds: null,
+            targetTimeLabel: null,
+            returnPointSeconds: null,
+            sourceLabel: null,
+            confidence: null,
+          };
+        }
+        returnPointSeconds = playbackPosition;
+        playbackPosition = citation.startSeconds;
+        return {
+          ok: true,
+          message: `已跳到 ${formatMockTime(citation.startSeconds)}。`,
+          candidateId: citation.id,
+          targetSeconds: citation.startSeconds,
+          targetTimeLabel: formatMockTime(citation.startSeconds),
+          returnPointSeconds,
+          sourceLabel: "引用片段",
+          confidence: 1,
+        };
+      }
+
       function requestCurrentVideoSegmentJump(params) {
         const candidate = lastSearchResult?.candidates?.find(item => item.id === params?.candidateId);
         if (params?.confirmed !== true) {
@@ -1820,10 +1936,28 @@
                 data: searchCurrentVideoSegmentsResult(message.params?.query),
               });
             }
+            if (message.action === "ASK_CURRENT_VIDEO_FULL_TEXT") {
+              if (String(message.params?.question || "").includes("后台失败")) {
+                return Promise.resolve({ success: false, error: "MOCK_QA_BACKEND_FAILURE" });
+              }
+              return maybeDeferProtectedResponse(message.action, {
+                success: true,
+                data: currentVideoFullTextQaResult(message.params),
+              });
+            }
+            if (message.action === "CANCEL_CURRENT_VIDEO_FULL_TEXT_QA") {
+              return Promise.resolve({ success: true, data: { cancelled: true } });
+            }
             if (message.action === "REQUEST_CURRENT_VIDEO_SEGMENT_JUMP") {
               return maybeDeferProtectedResponse(message.action, {
                 success: true,
                 data: requestCurrentVideoSegmentJump(message.params),
+              });
+            }
+            if (message.action === "REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP") {
+              return maybeDeferProtectedResponse(message.action, {
+                success: true,
+                data: requestCurrentVideoQaCitationJump(message.params),
               });
             }
             if (message.action === "REQUEST_CURRENT_VIDEO_SUBTITLE_JUMP") {

--- a/tests/current-video-full-text-qa.test.ts
+++ b/tests/current-video-full-text-qa.test.ts
@@ -1,0 +1,558 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  auditAssistantPayload,
+  currentVideoFullTextQaPayloadContract,
+} from '../src/shared/assistant-payload-audit.ts';
+import {
+  buildCurrentVideoFullTextRequestEnvelope,
+} from '../src/shared/current-video-primary-text.ts';
+import {
+  buildCurrentVideoFullTextQaAiPayload,
+  requestCurrentVideoFullTextQaAi,
+  validateCurrentVideoFullTextQaAiOutput,
+} from '../src/shared/current-video-full-text-qa.ts';
+import type { AiConfig } from '../src/shared/types/config.ts';
+import type { UserConfig } from '../src/shared/types/config.ts';
+import type { CurrentVideoContext } from '../src/shared/types/current-video-context.ts';
+import type { CurrentVideoTranscriptSegment } from '../src/shared/types/current-video-transcript.ts';
+import {
+  cancelCurrentVideoFullTextQaForSource,
+  cancelCurrentVideoFullTextQaRequest,
+  generateCurrentVideoFullTextQa,
+  getCurrentVideoFullTextQaCitation,
+  invalidateCurrentVideoFullTextQaConfig,
+  invalidateCurrentVideoFullTextQaPart,
+  registerCurrentVideoFullTextQaPreflightRequest,
+  settleCurrentVideoFullTextQaPreflightRequest,
+} from '../src/background/current-video-full-text-qa.ts';
+
+test('full-text QA payload contains every captured line and excludes unrelated metadata', () => {
+  const envelope = fullTextEnvelope();
+  const payload = buildCurrentVideoFullTextQaAiPayload(envelope, '作者怎样解释这个方法？');
+  const audit = auditAssistantPayload(payload, currentVideoFullTextQaPayloadContract);
+  const raw = JSON.stringify(payload);
+
+  assert.equal(payload.intent, 'current_video_full_text_qa_v1');
+  assert.equal(payload.request.requestId, 'qa-request-1');
+  assert.equal(payload.request.turnId, 'qa-turn-1');
+  assert.equal(payload.textLines.length, envelope.text.lines.length);
+  assert.deepEqual(payload.textLines, envelope.text.lines);
+  assert.ok(raw.indexOf('"textLines"') < raw.indexOf('"request"'));
+  assert.ok(raw.indexOf('"textLines"') < raw.indexOf('"question"'));
+  assert.equal(audit.passed, true, JSON.stringify(audit.violations));
+  assert.doesNotMatch(raw, /title|description|watchHistory|favoriteItems|followingList|feedbackRecords|Cookie|Key\.txt|sourceHash|segmentId|subtitle_url/i);
+});
+
+test('validated answer is returned before one to three citations derived from captured lines', () => {
+  const result = validateCurrentVideoFullTextQaAiOutput({
+    supported: true,
+    answerPoints: [
+      { text: '作者先界定问题，再给出核心方法。', evidenceLineNumbers: [1, 2] },
+      { text: '随后通过例子说明这套方法的适用边界。', evidenceLineNumbers: [3, 4] },
+    ],
+    citations: [
+      { evidenceLineNumbers: [1, 2] },
+      { evidenceLineNumbers: [3, 4] },
+    ],
+  }, fullTextEnvelope());
+
+  assert.equal(result.ok, true);
+  if (!result.ok || result.kind !== 'answered') return;
+  assert.match(result.answer, /^作者先界定问题/);
+  assert.equal(result.answerPoints.length, 2);
+  assert.deepEqual(result.answerPoints[1]?.evidenceLineNumbers, [3, 4]);
+  assert.deepEqual(result.answerEvidenceLineNumbers, [1, 2, 3, 4]);
+  assert.equal(result.citations.length, 2);
+  assert.deepEqual(result.citations[0]?.evidenceLineNumbers, [1, 2]);
+  assert.equal(result.citations[0]?.evidenceText, '第一行说明问题背景。 第二行给出核心方法。');
+  assert.equal(result.citations[0]?.startSeconds, 0);
+  assert.equal(result.citations[0]?.endSeconds, 12);
+  assert.equal(result.citations[0]?.timeRangeLabel, '0:00-0:12');
+});
+
+test('unsupported output becomes a fixed refusal with no citations', () => {
+  const result = validateCurrentVideoFullTextQaAiOutput({
+    supported: false,
+    citations: [],
+  }, fullTextEnvelope());
+
+  assert.deepEqual(result, {
+    ok: true,
+    kind: 'unsupported',
+    answer: '当前视频文本没有足够内容回答这个问题。',
+    answerEvidenceLineNumbers: [],
+    citations: [],
+  });
+});
+
+test('invalid, missing, or non-contiguous evidence rejects the whole answer', () => {
+  const envelope = fullTextEnvelope();
+  const base = {
+    supported: true,
+    answerPoints: [{ text: '这个回答有当前视频文本支持。', evidenceLineNumbers: [1] }],
+    citations: [{ evidenceLineNumbers: [1] }],
+  };
+
+  assert.deepEqual(
+    validateCurrentVideoFullTextQaAiOutput({
+      ...base,
+      answerPoints: [{ text: '这个回答有当前视频文本支持。', evidenceLineNumbers: [99] }],
+    }, envelope),
+    { ok: false, reason: 'answer_point_evidence_line_missing' },
+  );
+  assert.deepEqual(
+    validateCurrentVideoFullTextQaAiOutput({ ...base, citations: [{ evidenceLineNumbers: [1, 3] }] }, envelope),
+    { ok: false, reason: 'citation_lines_not_contiguous' },
+  );
+  assert.deepEqual(
+    validateCurrentVideoFullTextQaAiOutput({ ...base, citations: [] }, envelope),
+    { ok: false, reason: 'citation_count' },
+  );
+  assert.deepEqual(
+    validateCurrentVideoFullTextQaAiOutput({
+      ...base,
+      answerPoints: [{ text: '这个回答有当前视频文本支持。', evidenceLineNumbers: [1, 2] }],
+      citations: [{ evidenceLineNumbers: [1] }],
+    }, envelope),
+    { ok: false, reason: 'answer_point_evidence_not_cited' },
+  );
+});
+
+test('runtime completeness audit blocks a missing full-text line before chat', async () => {
+  const envelope = fullTextEnvelope();
+  const payload = buildCurrentVideoFullTextQaAiPayload(envelope, '这个视频说了什么？');
+  payload.textLines.pop();
+  let chatCalls = 0;
+
+  await assert.rejects(
+    requestCurrentVideoFullTextQaAi(defaultAiConfig(), payload, envelope, async () => {
+      chatCalls += 1;
+      return { supported: false, citations: [] };
+    }),
+    /完整文本问答请求未包含本次捕获的全部正文/,
+  );
+  assert.equal(chatCalls, 0);
+});
+
+test('background generation sends all lines and registers exact citation bindings only after validation', async () => {
+  const context = videoContext();
+  const segments = transcriptSegments();
+  let sentLineCount = 0;
+  const result = await generateCurrentVideoFullTextQa(context, {
+    requestId: 'background-request-1',
+    turnId: 'background-turn-1',
+    question: '作者提出了什么方法？',
+    config: userConfig(),
+    transcriptSegments: segments,
+    chat: async (_config, messages) => {
+      const payload = JSON.parse(messages[1]!.content) as { textLines: unknown[] };
+      sentLineCount = payload.textLines.length;
+      return {
+        supported: true,
+        answerPoints: [{
+          text: '作者先界定问题，再给出方法和适用边界。',
+          evidenceLineNumbers: [1, 2, 3],
+        }],
+        citations: [{ evidenceLineNumbers: [1, 2, 3] }],
+      };
+    },
+  });
+
+  assert.equal(sentLineCount, segments.length);
+  assert.equal(result.status, 'ready');
+  assert.equal(result.answer, '作者先界定问题，再给出方法和适用边界。');
+  assert.equal(result.citations.length, 1);
+  assert.equal(result.citations[0]?.binding.turnId, 'background-turn-1');
+  assert.equal(getCurrentVideoFullTextQaCitation({
+    requestId: 'background-request-1',
+    turnId: 'background-turn-1',
+    citationId: 'citation-1',
+    sourceIdentityKey: context.transcriptEvidence!.sourceIdentityKey!,
+  })?.citation.evidenceText, '第一行说明问题背景。 第二行给出核心方法。 第三行展示第一个例子。');
+});
+
+test('unsupported video question returns a controlled refusal without a binding', async () => {
+  const context = videoContext();
+  const result = await generateCurrentVideoFullTextQa(context, {
+    requestId: 'unsupported-request',
+    turnId: 'unsupported-turn',
+    question: '视频有没有讨论火星天气？',
+    config: userConfig(),
+    transcriptSegments: transcriptSegments(),
+    chat: async () => ({ supported: false, citations: [] }),
+  });
+
+  assert.equal(result.status, 'unsupported');
+  assert.equal(result.answer, '当前视频文本没有足够内容回答这个问题。');
+  assert.equal(result.citations.length, 0);
+  assert.equal(getCurrentVideoFullTextQaCitation({
+    requestId: 'unsupported-request',
+    turnId: 'unsupported-turn',
+    citationId: 'citation-1',
+    sourceIdentityKey: context.transcriptEvidence!.sourceIdentityKey!,
+  }), null);
+});
+
+test('cancel, retry replacement, source clear, and config change abort in-flight network work', async () => {
+  const context = videoContext();
+  const sourceIdentityKey = context.transcriptEvidence!.sourceIdentityKey!;
+
+  const explicit = abortAwareChat();
+  const explicitResult = generateCurrentVideoFullTextQa(context, {
+    requestId: 'cancel-request',
+    turnId: 'cancel-turn',
+    question: '请回答这个问题。',
+    config: userConfig(),
+    transcriptSegments: transcriptSegments(),
+    chat: explicit.chat,
+  });
+  await explicit.started;
+  cancelCurrentVideoFullTextQaRequest('cancel-request');
+  assert.equal((await explicitResult).status, 'cancelled');
+  assert.equal(explicit.aborted(), true);
+
+  const replaced = abortAwareChat();
+  const oldAttempt = generateCurrentVideoFullTextQa(context, {
+    requestId: 'retry-old',
+    turnId: 'retry-turn',
+    question: '同一个逻辑轮次。',
+    config: userConfig(),
+    transcriptSegments: transcriptSegments(),
+    chat: replaced.chat,
+  });
+  await replaced.started;
+  const newAttempt = await generateCurrentVideoFullTextQa(context, {
+    requestId: 'retry-new',
+    turnId: 'retry-turn',
+    question: '同一个逻辑轮次。',
+    config: userConfig(),
+    transcriptSegments: transcriptSegments(),
+    chat: async () => ({
+      supported: true,
+      answerPoints: [{ text: '这是重试后的新回答。', evidenceLineNumbers: [1] }],
+      citations: [{ evidenceLineNumbers: [1] }],
+    }),
+  });
+  assert.equal((await oldAttempt).status, 'cancelled');
+  assert.equal(replaced.aborted(), true);
+  assert.equal(newAttempt.status, 'ready');
+
+  const sourceClear = abortAwareChat();
+  const sourceAttempt = generateCurrentVideoFullTextQa(context, {
+    requestId: 'source-request',
+    turnId: 'source-turn',
+    question: '来源清理测试。',
+    config: userConfig(),
+    transcriptSegments: transcriptSegments(),
+    chat: sourceClear.chat,
+  });
+  await sourceClear.started;
+  cancelCurrentVideoFullTextQaForSource(sourceIdentityKey);
+  assert.equal((await sourceAttempt).status, 'cancelled');
+  assert.equal(sourceClear.aborted(), true);
+
+  const configChange = abortAwareChat();
+  const configAttempt = generateCurrentVideoFullTextQa(context, {
+    requestId: 'config-request',
+    turnId: 'config-turn',
+    question: '配置变化测试。',
+    config: userConfig(),
+    transcriptSegments: transcriptSegments(),
+    chat: configChange.chat,
+  });
+  await configChange.started;
+  invalidateCurrentVideoFullTextQaConfig();
+  assert.equal((await configAttempt).status, 'cancelled');
+  assert.equal(configChange.aborted(), true);
+});
+
+test('part invalidation removes only matching requests and citation bindings', async () => {
+  const first = { context: videoContext(), segments: transcriptSegments() };
+  const second = alternateVideoFixture();
+  const chat = async () => ({
+    supported: true,
+    answerPoints: [{ text: '这是由当前视频正文支持的回答。', evidenceLineNumbers: [1] }],
+    citations: [{ evidenceLineNumbers: [1] }],
+  });
+  const firstResult = await generateCurrentVideoFullTextQa(first.context, {
+    requestId: 'part-first-request',
+    turnId: 'part-first-turn',
+    question: '第一个视频说了什么？',
+    config: userConfig(),
+    transcriptSegments: first.segments,
+    chat,
+  });
+  const secondResult = await generateCurrentVideoFullTextQa(second.context, {
+    requestId: 'part-second-request',
+    turnId: 'part-second-turn',
+    question: '第二个视频说了什么？',
+    config: userConfig(),
+    transcriptSegments: second.segments,
+    chat,
+  });
+
+  invalidateCurrentVideoFullTextQaPart({ bvid: first.context.bvid, cid: first.context.cid!, page: 1 });
+
+  assert.equal(getCurrentVideoFullTextQaCitation({
+    requestId: firstResult.requestId,
+    turnId: firstResult.turnId,
+    citationId: firstResult.citations[0]!.id,
+    sourceIdentityKey: first.context.transcriptEvidence!.sourceIdentityKey!,
+  }), null);
+  assert.notEqual(getCurrentVideoFullTextQaCitation({
+    requestId: secondResult.requestId,
+    turnId: secondResult.turnId,
+    citationId: secondResult.citations[0]!.id,
+    sourceIdentityKey: second.context.transcriptEvidence!.sourceIdentityKey!,
+  }), null);
+
+  registerCurrentVideoFullTextQaPreflightRequest({
+    requestId: 'part-second-retry',
+    turnId: secondResult.turnId,
+    sourceIdentityKey: second.context.transcriptEvidence!.sourceIdentityKey!,
+  });
+  assert.equal(getCurrentVideoFullTextQaCitation({
+    requestId: secondResult.requestId,
+    turnId: secondResult.turnId,
+    citationId: secondResult.citations[0]!.id,
+    sourceIdentityKey: second.context.transcriptEvidence!.sourceIdentityKey!,
+  }), null);
+  settleCurrentVideoFullTextQaPreflightRequest('part-second-retry');
+});
+
+test('HTTP 413 maps to controlled context-too-long copy without raw provider text', async () => {
+  const result = await generateCurrentVideoFullTextQa(videoContext(), {
+    requestId: 'too-long-request',
+    turnId: 'too-long-turn',
+    question: '请总结完整内容。',
+    config: userConfig(),
+    transcriptSegments: transcriptSegments(),
+    chat: async () => {
+      throw new Error('AI_REQUEST_FAILED_413 provider-secret-body');
+    },
+  });
+  const visible = JSON.stringify({ message: result.message, answer: result.answer, limitations: result.limitations });
+
+  assert.equal(result.status, 'context_too_long');
+  assert.match(result.message, /正文过长/);
+  assert.match(result.message, /不会截断/);
+  assert.doesNotMatch(visible, /AI_REQUEST|provider-secret|413/i);
+  assert.equal(result.question, '请总结完整内容。');
+});
+
+function fullTextEnvelope() {
+  return buildCurrentVideoFullTextRequestEnvelope({
+    requestId: 'qa-request-1',
+    operation: 'qa',
+    submittedAt: 10_000,
+    model: 'test-model',
+    video: {
+      bvid: 'BV1FullTextQa',
+      cid: 7301,
+      page: 1,
+      title: '不应进入问答请求的标题',
+      partTitle: '第一分 P',
+      durationSeconds: 120,
+    },
+    source: 'bilibili_subtitle',
+    sourceType: 'bilibili_player_wbi_v2',
+    sourceLabel: 'B站字幕',
+    language: 'zh-CN',
+    lines: [
+      { startSeconds: 0, endSeconds: 6, text: '第一行说明问题背景。' },
+      { startSeconds: 6, endSeconds: 12, text: '第二行给出核心方法。' },
+      { startSeconds: 12, endSeconds: 18, text: '第三行展示第一个例子。' },
+      { startSeconds: 18, endSeconds: 24, text: '第四行说明适用边界。' },
+    ],
+    turnId: 'qa-turn-1',
+  });
+}
+
+function defaultAiConfig(): AiConfig {
+  return {
+    baseURL: 'https://example.invalid',
+    apiKey: 'test-key',
+    chatModel: 'test-model',
+    embeddingModel: '',
+  };
+}
+
+function userConfig(): UserConfig {
+  return {
+    historySync: { mode: 'auto', pageLimit: 3 },
+    assistant: {
+      currentVideoAiAssistantEnabled: true,
+      currentVideoSummaryEnabled: true,
+      currentVideoSegmentRerankEnabled: true,
+      currentVideoQaEnabled: true,
+      smartFavoritesQaEnabled: true,
+      dynamicBillExplanationEnabled: true,
+    },
+    ai: defaultAiConfig(),
+  };
+}
+
+function videoContext(): CurrentVideoContext {
+  const envelope = fullTextEnvelope();
+  return {
+    kind: 'video',
+    url: 'https://www.bilibili.com/video/BV1FullTextQa?p=1',
+    bvid: 'BV1FullTextQa',
+    aid: 73,
+    cid: 7301,
+    title: '用于后台测试的视频标题',
+    authorName: '测试作者',
+    authorMid: 123,
+    durationSeconds: 120,
+    currentPart: { page: 1, cid: 7301, title: '第一分 P', durationSeconds: 120 },
+    parts: [{ page: 1, cid: 7301, title: '第一分 P', durationSeconds: 120 }],
+    description: { availability: 'available', text: '不应进入问答证据。', length: 9 },
+    chapters: [],
+    sources: {
+      metadata: 'available',
+      description: 'available',
+      pages: 'available',
+      chapters: 'missing',
+      transcript: 'available',
+      contentText: 'available',
+    },
+    subtitleProbe: null,
+    transcriptEvidence: {
+      status: 'cached',
+      active: true,
+      checkedAt: 10_000,
+      bvid: 'BV1FullTextQa',
+      cid: 7301,
+      page: 1,
+      language: 'zh-CN',
+      source: 'bilibili_subtitle',
+      sourceType: 'bilibili_player_wbi_v2',
+      sourceIdentityKey: envelope.primaryTextIdentity.sourceIdentityKey,
+      sourceHash: envelope.primaryTextIdentity.sourceHash,
+      bodyHash: envelope.primaryTextIdentity.bodyHash,
+      timelineHash: envelope.primaryTextIdentity.timelineHash,
+      segmentCount: envelope.text.lineCount,
+      staleSegmentCount: 0,
+      serializedBytes: envelope.text.utf8Bytes,
+      coverageStartSeconds: 0,
+      coverageEndSeconds: 24,
+      fetchedAt: 10_000,
+      updatedAt: 10_000,
+      reason: 'cached',
+      message: '已读取正文。',
+      warnings: [],
+    },
+    collectedAt: 10_000,
+    warnings: [],
+  };
+}
+
+function transcriptSegments(): CurrentVideoTranscriptSegment[] {
+  const envelope = fullTextEnvelope();
+  return envelope.text.lines.map(line => ({
+    segmentId: `segment-${line.lineNo}`,
+    sourceIdentityKey: envelope.primaryTextIdentity.sourceIdentityKey,
+    bvid: envelope.video.bvid,
+    cid: envelope.video.cid,
+    page: envelope.video.page,
+    startSeconds: line.startSeconds,
+    endSeconds: line.endSeconds,
+    text: line.text,
+    language: envelope.language,
+    source: 'bilibili_subtitle',
+    sourceType: 'bilibili_player_wbi_v2',
+    sourceHash: envelope.primaryTextIdentity.sourceHash,
+    stale: false,
+    fetchedAt: 10_000,
+  }));
+}
+
+function alternateVideoFixture(): {
+  context: CurrentVideoContext;
+  segments: CurrentVideoTranscriptSegment[];
+} {
+  const envelope = buildCurrentVideoFullTextRequestEnvelope({
+    requestId: 'qa-request-alternate',
+    operation: 'qa',
+    submittedAt: 10_001,
+    model: 'test-model',
+    video: {
+      bvid: 'BV1FullTextQaAlternate',
+      cid: 7302,
+      page: 1,
+      title: '第二个测试视频',
+      partTitle: null,
+      durationSeconds: 60,
+    },
+    source: 'bilibili_subtitle',
+    sourceType: 'bilibili_player_wbi_v2',
+    sourceLabel: 'B站字幕',
+    language: 'zh-CN',
+    lines: [{ startSeconds: 0, endSeconds: 6, text: '第二个视频的第一行正文。' }],
+    turnId: 'qa-turn-alternate',
+  });
+  const context = structuredClone(videoContext());
+  context.url = 'https://www.bilibili.com/video/BV1FullTextQaAlternate?p=1';
+  context.bvid = envelope.video.bvid;
+  context.cid = envelope.video.cid;
+  context.title = envelope.video.title;
+  context.durationSeconds = envelope.video.durationSeconds;
+  context.currentPart = { page: 1, cid: envelope.video.cid, title: null, durationSeconds: 60 };
+  context.parts = [{ page: 1, cid: envelope.video.cid, title: null, durationSeconds: 60 }];
+  context.transcriptEvidence = {
+    ...context.transcriptEvidence!,
+    bvid: envelope.video.bvid,
+    cid: envelope.video.cid,
+    page: envelope.video.page,
+    sourceIdentityKey: envelope.primaryTextIdentity.sourceIdentityKey,
+    sourceHash: envelope.primaryTextIdentity.sourceHash,
+    bodyHash: envelope.primaryTextIdentity.bodyHash,
+    timelineHash: envelope.primaryTextIdentity.timelineHash,
+    segmentCount: envelope.text.lineCount,
+    serializedBytes: envelope.text.utf8Bytes,
+    coverageEndSeconds: 6,
+  };
+  const segments = envelope.text.lines.map(line => ({
+    segmentId: `alternate-${line.lineNo}`,
+    sourceIdentityKey: envelope.primaryTextIdentity.sourceIdentityKey,
+    bvid: envelope.video.bvid,
+    cid: envelope.video.cid,
+    page: envelope.video.page,
+    startSeconds: line.startSeconds,
+    endSeconds: line.endSeconds,
+    text: line.text,
+    language: envelope.language,
+    source: 'bilibili_subtitle' as const,
+    sourceType: 'bilibili_player_wbi_v2' as const,
+    sourceHash: envelope.primaryTextIdentity.sourceHash,
+    stale: false,
+    fetchedAt: 10_001,
+  }));
+  return { context, segments };
+}
+
+function abortAwareChat() {
+  let resolveStarted!: () => void;
+  let aborted = false;
+  const started = new Promise<void>(resolve => {
+    resolveStarted = resolve;
+  });
+  return {
+    started,
+    aborted: () => aborted,
+    chat: async (
+      _config: AiConfig,
+      _messages: Array<{ role: 'system' | 'user'; content: string }>,
+      options?: { signal?: AbortSignal },
+    ) => {
+      resolveStarted();
+      return await new Promise<never>((_resolve, reject) => {
+        options?.signal?.addEventListener('abort', () => {
+          aborted = true;
+          reject(new Error('AI_REQUEST_ABORTED'));
+        }, { once: true });
+      });
+    },
+  };
+}

--- a/tests/current-video-message-handlers.test.ts
+++ b/tests/current-video-message-handlers.test.ts
@@ -14,6 +14,7 @@ import type {
   CurrentVideoTimestampReturnResponse,
 } from '../src/shared/types/current-video-segment-retrieval.ts';
 import type { CurrentVideoSummaryHighlightsResult } from '../src/shared/types/current-video-summary.ts';
+import type { CurrentVideoFullTextQaResult } from '../src/shared/types/current-video-full-text-qa.ts';
 import type { CurrentVideoSubtitleViewSourcesResult } from '../src/shared/current-video-subtitle-view.ts';
 import type { VideoKnowledgeResult } from '../src/shared/types/video-knowledge.ts';
 import {
@@ -513,6 +514,281 @@ test('background full-text handlers fail closed when the readiness marker is mis
   const sourceAfter = await transcriptSource(evidence.sourceRecord.identityKey);
   assert.equal(sourceAfter?.lastAccessedAt, sourceBefore?.lastAccessedAt);
   assert.equal(storageReadCount('userConfig'), 0);
+});
+
+test('handler full-text QA sends every authorized line and explicit cancellation aborts the matching attempt', async () => {
+  resetChromeHarness();
+  await resetTranscriptDb();
+  const tabId = 18_625;
+  const context = handlerVideoContext('BV1HandlerFullQa', 4825);
+  const evidence = normalizeBilibiliTranscriptEvidence(
+    {
+      body: [
+        { from: 2, to: 7, content: '第一行说明当前视频的问题背景。' },
+        { from: 7, to: 12, content: '第二行给出当前视频的方法。' },
+      ],
+    },
+    {
+      bvid: context.bvid,
+      cid: context.cid as number,
+      page: context.currentPart.page,
+      language: 'zh-CN',
+      sourceType: 'bilibili_player_wbi_v2',
+      trackId: 'handler-full-qa',
+      trackUrlHost: 'aisubtitle.hdslb.com',
+      fetchedAt: 12_500,
+    },
+  );
+  const owner = retainTemporaryTranscriptOwnerForContextSnapshot(context, tabId);
+  assert.ok(owner);
+  await upsertCurrentVideoTranscriptEvidence(evidence, { temporaryOwner: owner });
+  const sourceIdentityKey = evidence.sourceRecord.sourceIdentityKey!;
+  storageValues[CURRENT_VIDEO_PRIMARY_TEXT_SELECTIONS_STORAGE_KEY] = {
+    [handlerPartKey(context)]: sourceIdentityKey,
+  };
+  setTabs([{ id: tabId, url: context.url, active: true, lastAccessed: 8_825 }]);
+  await sendContentMessage({ action: 'CURRENT_VIDEO_CONTEXT_UPDATE', payload: context }, tabId, context.url);
+  await confirmHandlerTranscriptCurrent(context, tabId, evidence);
+  await sendRequest<void>({
+    action: 'UPDATE_CONFIG',
+    params: {
+      ai: {
+        baseURL: 'https://example.invalid',
+        apiKey: 'handler-test-key',
+        chatModel: 'handler-test-model',
+      },
+      assistant: { currentVideoAiAssistantEnabled: true },
+    },
+  }, tabId, context.url);
+
+  const originalFetch = globalThis.fetch;
+  try {
+    let outboundPayload: { textLines?: unknown[]; question?: string } | null = null;
+    globalThis.fetch = (async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { messages: Array<{ content: string }> };
+      outboundPayload = JSON.parse(body.messages[1]!.content) as typeof outboundPayload;
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: JSON.stringify({
+          supported: true,
+          answerPoints: [{
+            text: '作者先说明问题背景，再给出处理方法。',
+            evidenceLineNumbers: [1, 2],
+          }],
+          citations: [{ evidenceLineNumbers: [1, 2] }],
+        }) } }],
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as typeof fetch;
+
+    const answered = await sendRequest<CurrentVideoFullTextQaResult>({
+      action: 'ASK_CURRENT_VIDEO_FULL_TEXT' as BiliVizRequest['action'],
+      params: {
+        requestId: 'handler-full-qa-request',
+        turnId: 'handler-full-qa-turn',
+        question: '作者提出了什么方法？',
+        primaryTextSelectionsReady: true,
+        selectedSourceIdentityKey: sourceIdentityKey,
+      },
+    }, tabId, context.url);
+
+    assert.equal(answered.success, true);
+    assert.equal(answered.data?.status, 'ready');
+    assert.equal(answered.data?.requestId, 'handler-full-qa-request');
+    assert.equal(answered.data?.turnId, 'handler-full-qa-turn');
+    assert.equal(outboundPayload?.question, '作者提出了什么方法？');
+    assert.equal(outboundPayload?.textLines?.length, 2);
+    assert.equal(answered.data?.citations[0]?.evidenceText, '第一行说明当前视频的问题背景。 第二行给出当前视频的方法。');
+
+    let markFetchStarted!: () => void;
+    let rejectFetch!: (error: Error) => void;
+    let outboundSignal: AbortSignal | null = null;
+    const fetchStarted = new Promise<void>(resolve => { markFetchStarted = resolve; });
+    globalThis.fetch = ((_input, init) => {
+      outboundSignal = init?.signal as AbortSignal | null;
+      markFetchStarted();
+      return new Promise<Response>((_resolve, reject) => {
+        rejectFetch = reject;
+        outboundSignal?.addEventListener('abort', () => reject(new Error('MOCK_QA_ABORTED')), { once: true });
+      });
+    }) as typeof fetch;
+
+    const pending = sendRequest<CurrentVideoFullTextQaResult>({
+      action: 'ASK_CURRENT_VIDEO_FULL_TEXT' as BiliVizRequest['action'],
+      params: {
+        requestId: 'handler-full-qa-cancel-request',
+        turnId: 'handler-full-qa-cancel-turn',
+        question: '取消这次问题。',
+        primaryTextSelectionsReady: true,
+        selectedSourceIdentityKey: sourceIdentityKey,
+      },
+    }, tabId, context.url);
+    await fetchStarted;
+    await sendRequest<void>({
+      action: 'CANCEL_CURRENT_VIDEO_FULL_TEXT_QA' as BiliVizRequest['action'],
+      params: { requestId: 'handler-full-qa-cancel-request' },
+    }, tabId, context.url);
+    assert.equal(outboundSignal?.aborted, true);
+    rejectFetch(new Error('late duplicate rejection'));
+    const cancelled = await pending;
+    assert.equal(cancelled.success, true);
+    assert.equal(cancelled.data?.status, 'cancelled');
+    assert.equal(cancelled.data?.question, '取消这次问题。');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('handler blocks an old full-text citation when a retry replaces its turn during jump revalidation', async () => {
+  resetChromeHarness();
+  await resetTranscriptDb();
+  const tabId = 18_626;
+  const context = handlerVideoContext('BV1HandlerQaRetryJump', 4826);
+  const evidence = await seedHandlerTranscript(
+    context,
+    tabId,
+    'handler-qa-retry-jump',
+    '这一行正文用于验证重试替换后旧引用不能继续跳转。',
+  );
+  const sourceIdentityKey = evidence.sourceRecord.sourceIdentityKey!;
+  storageValues[CURRENT_VIDEO_PRIMARY_TEXT_SELECTIONS_STORAGE_KEY] = {
+    [handlerPartKey(context)]: sourceIdentityKey,
+  };
+  setTabs([{ id: tabId, url: context.url, active: true, lastAccessed: 8_826 }]);
+  await sendContentMessage({ action: 'CURRENT_VIDEO_CONTEXT_UPDATE', payload: context }, tabId, context.url);
+  await confirmHandlerTranscriptCurrent(context, tabId, evidence);
+  await sendRequest<void>({
+    action: 'UPDATE_CONFIG',
+    params: {
+      ai: {
+        baseURL: 'https://example.invalid',
+        apiKey: 'handler-test-key',
+        chatModel: 'handler-test-model',
+      },
+      assistant: { currentVideoAiAssistantEnabled: true },
+    },
+  }, tabId, context.url);
+
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      choices: [{ message: { content: JSON.stringify({
+        supported: true,
+        answerPoints: [{ text: '当前回答有正文支持。', evidenceLineNumbers: [1] }],
+        citations: [{ evidenceLineNumbers: [1] }],
+      }) } }],
+    }), { status: 200, headers: { 'content-type': 'application/json' } })) as typeof fetch;
+
+    const first = await sendRequest<CurrentVideoFullTextQaResult>({
+      action: 'ASK_CURRENT_VIDEO_FULL_TEXT' as BiliVizRequest['action'],
+      params: {
+        requestId: 'handler-qa-jump-old',
+        turnId: 'handler-qa-jump-turn',
+        question: '这段正文说明了什么？',
+        primaryTextSelectionsReady: true,
+        selectedSourceIdentityKey: sourceIdentityKey,
+      },
+    }, tabId, context.url);
+    const citation = first.data?.citations[0];
+    assert.ok(citation);
+
+    let contentMessageCount = 0;
+    setTabMessageHandler(tabId, () => {
+      contentMessageCount += 1;
+      return blockedTimestampJumpMock(citation.id);
+    });
+    installGuardTestHook('before_timestamp_message', async () => {
+      const retry = await sendRequest<CurrentVideoFullTextQaResult>({
+        action: 'ASK_CURRENT_VIDEO_FULL_TEXT' as BiliVizRequest['action'],
+        params: {
+          requestId: 'handler-qa-jump-retry',
+          turnId: 'handler-qa-jump-turn',
+          question: '这段正文说明了什么？',
+          primaryTextSelectionsReady: true,
+          selectedSourceIdentityKey: sourceIdentityKey,
+        },
+      }, tabId, context.url);
+      assert.equal(retry.data?.status, 'ready');
+    });
+
+    const jump = await sendRequest<CurrentVideoTimestampJumpResponse>({
+      action: 'REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP' as BiliVizRequest['action'],
+      params: {
+        ...citation.binding,
+        confirmed: true,
+        primaryTextSelectionsReady: true,
+        selectedSourceIdentityKey: sourceIdentityKey,
+      },
+    }, tabId, context.url);
+
+    assert.equal(jump.success, true);
+    assert.equal(jump.data?.ok, false);
+    assert.match(jump.data?.message ?? '', /引用已过期/);
+    assert.equal(contentMessageCount, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('popup full-text QA revalidates the persisted source immediately before starting the network request', async () => {
+  resetChromeHarness();
+  await resetTranscriptDb();
+  const tabId = 18_627;
+  const context = handlerVideoContext('BV1PopupQaSourceRace', 4827);
+  const evidence = await seedHandlerTranscript(
+    context,
+    tabId,
+    'popup-qa-source-race',
+    '这一行正文不应在来源选择变化后继续发送。',
+  );
+  const sourceIdentityKey = evidence.sourceRecord.sourceIdentityKey!;
+  storageValues[CURRENT_VIDEO_PRIMARY_TEXT_SELECTIONS_STORAGE_KEY] = {
+    [handlerPartKey(context)]: sourceIdentityKey,
+  };
+  setTabs([{ id: tabId, url: context.url, active: true, lastAccessed: 8_827 }]);
+  await sendContentMessage({ action: 'CURRENT_VIDEO_CONTEXT_UPDATE', payload: context }, tabId, context.url);
+  await confirmHandlerTranscriptCurrent(context, tabId, evidence);
+  await sendRequest<void>({
+    action: 'UPDATE_CONFIG',
+    params: {
+      ai: {
+        baseURL: 'https://example.invalid',
+        apiKey: 'handler-test-key',
+        chatModel: 'handler-test-model',
+      },
+      assistant: { currentVideoAiAssistantEnabled: true },
+    },
+  }, tabId, context.url);
+
+  let fetchCalls = 0;
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = (async () => {
+      fetchCalls += 1;
+      throw new Error('NETWORK_MUST_NOT_START');
+    }) as typeof fetch;
+    installGuardTestHook('before_full_text_qa_network', async () => {
+      storageValues[CURRENT_VIDEO_PRIMARY_TEXT_SELECTIONS_STORAGE_KEY] = {
+        [handlerPartKey(context)]: 'replacement-source-identity',
+      };
+    });
+
+    const response = await sendPopupRequest<CurrentVideoFullTextQaResult>({
+      action: 'ASK_CURRENT_VIDEO_FULL_TEXT' as BiliVizRequest['action'],
+      params: {
+        requestId: 'popup-source-race-request',
+        turnId: 'popup-source-race-turn',
+        question: '这段正文说明了什么？',
+        primaryTextSelectionsReady: true,
+        selectedSourceIdentityKey: sourceIdentityKey,
+      },
+    });
+
+    assert.equal(response.success, true);
+    assert.equal(response.data?.status, 'cancelled');
+    assert.equal(response.data?.question, '这段正文说明了什么？');
+    assert.equal(fetchCalls, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test('UPDATE_CONFIG disables and aborts an in-flight combined generation through handleRequest', async () => {
@@ -2199,6 +2475,7 @@ type GuardTestPhase =
   | 'before_evidence_bind'
   | 'before_segment_body_read'
   | 'after_segment_body_read'
+  | 'before_full_text_qa_network'
   | 'before_timestamp_message';
 
 async function invokeProtectedHandlerAction(
@@ -2436,6 +2713,21 @@ async function sendRequest<T>(
   senderUrl: string,
 ): Promise<BiliVizResponse<T>> {
   return await sendRuntimeMessage<BiliVizResponse<T>>(request, tabId, senderUrl);
+}
+
+async function sendPopupRequest<T>(request: BiliVizRequest): Promise<BiliVizResponse<T>> {
+  const listener = runtimeListeners[0];
+  assert.ok(listener, 'message handler was not registered');
+  return await new Promise<BiliVizResponse<T>>((resolve, reject) => {
+    let settled = false;
+    const keepOpen = listener(request, {}, (response) => {
+      settled = true;
+      resolve(response as BiliVizResponse<T>);
+    });
+    if (keepOpen !== true && !settled) {
+      reject(new Error('Fake popup runtime listener did not respond synchronously or keep the channel open'));
+    }
+  });
 }
 
 async function sendRuntimeMessage<T>(

--- a/tests/current-video-popup.mock-qa.py
+++ b/tests/current-video-popup.mock-qa.py
@@ -15,6 +15,9 @@ POPUP_URL = "http://popup.mock/popup"
 PROTECTED_ACTIONS = {
     "GENERATE_CURRENT_VIDEO_SUMMARY_HIGHLIGHTS",
     "GET_VIDEO_KNOWLEDGE",
+    "ASK_CURRENT_VIDEO_FULL_TEXT",
+    "CANCEL_CURRENT_VIDEO_FULL_TEXT_QA",
+    "REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP",
     "SEARCH_CURRENT_VIDEO_SEGMENTS",
     "REQUEST_CURRENT_VIDEO_SEGMENT_JUMP",
     "REQUEST_CURRENT_VIDEO_HIGHLIGHT_JUMP",
@@ -28,6 +31,7 @@ FORBIDDEN_VISIBLE_TERMS = [
     "BV1PopupMock9",
     "9201",
     "BV1PopupNext7",
+    "BV1RawLeak99",
     "9302",
     "fallback",
     "transcript",
@@ -104,6 +108,26 @@ def assert_clean_page(page):
     assert not overflow, "popup has horizontal overflow"
 
 
+def qa_panel(page):
+    return page.get_by_text("问这个视频", exact=True).locator("..")
+
+
+def submit_qa(page, question):
+    panel = qa_panel(page)
+    panel.locator("textarea").fill(question)
+    panel.get_by_role("button", name="提问", exact=True).click()
+    return panel
+
+
+def prepare_qa_preview(page, question):
+    panel = submit_qa(page, question)
+    expect(panel.get_by_text("回答", exact=True)).to_be_visible()
+    expect(panel.get_by_text("引用片段", exact=True)).to_be_visible()
+    panel.get_by_role("button", name="预览跳转", exact=True).click()
+    expect(panel.get_by_text("确认跳转前预览", exact=True)).to_be_visible()
+    return panel
+
+
 def run_manual_exact_flow(page):
     page.route("**/*", route_popup)
     page.goto(POPUP_URL)
@@ -128,21 +152,23 @@ def run_manual_exact_flow(page):
     expect(page.get_by_text("已返回原位置。").first).to_be_visible()
 
     page.get_by_role("button", name="刷新", exact=True).click()
-    page.locator("input[placeholder='例如：模型架构那段']").fill("授权测试")
-    page.get_by_role("button", name="检索", exact=True).click()
-    expect(page.get_by_role("button", name="预览跳转").first).to_be_visible()
-    page.get_by_role("button", name="预览跳转").last.click()
-    page.get_by_role("button", name="确认跳转").last.click()
-    expect(page.get_by_role("button", name="返回原位置").last).to_be_visible()
-    page.get_by_role("button", name="返回原位置").last.click()
-    expect(page.get_by_text("已返回原位置。").last).to_be_visible()
+    panel = prepare_qa_preview(page, "作者为什么认为这个方法更可靠？")
+    expect(panel.get_by_text("回答：作者为什么认为这个方法更可靠？", exact=False)).to_be_visible()
+    expect(panel.get_by_text("依据《Popup 授权 Mock 视频》 · B站字幕", exact=False)).to_be_visible()
+    answer = panel.get_by_text("回答", exact=True)
+    citations = panel.get_by_text("引用片段", exact=True)
+    assert answer.evaluate("(answer, citations) => Boolean(answer.compareDocumentPosition(citations) & Node.DOCUMENT_POSITION_FOLLOWING)", citations.element_handle())
+    panel.get_by_role("button", name="确认跳转", exact=True).click()
+    expect(panel.get_by_role("button", name="返回原位置", exact=True)).to_be_visible()
+    panel.get_by_role("button", name="返回原位置", exact=True).click()
+    expect(panel.get_by_text("已返回原位置。", exact=True)).to_be_visible()
 
     expected = page.evaluate("window.__popupMockSourceV2")
     for action in {
         "GENERATE_CURRENT_VIDEO_SUMMARY_HIGHLIGHTS",
         "GET_VIDEO_KNOWLEDGE",
-        "SEARCH_CURRENT_VIDEO_SEGMENTS",
-        "REQUEST_CURRENT_VIDEO_SEGMENT_JUMP",
+        "ASK_CURRENT_VIDEO_FULL_TEXT",
+        "REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP",
         "REQUEST_CURRENT_VIDEO_HIGHLIGHT_JUMP",
         "RETURN_CURRENT_VIDEO_SEGMENT_JUMP",
     }:
@@ -163,10 +189,9 @@ def run_stale_saved_source_flow(page):
     page.get_by_role("button", name="生成摘要与亮点").click()
     expect(page.get_by_text("此前保存的主要文本来源已不可用，请到视频页助手重新选择当前来源。").first).to_be_visible()
     page.get_by_role("button", name="刷新", exact=True).click()
-    page.locator("input[placeholder='例如：模型架构那段']").fill("失效来源")
-    page.get_by_role("button", name="检索", exact=True).click()
+    submit_qa(page, "失效来源")
     page.wait_for_timeout(50)
-    expect(page.get_by_role("button", name="预览跳转")).to_have_count(0)
+    expect(qa_panel(page).get_by_role("button", name="预览跳转")).to_have_count(0)
     assert_no_protected_actions(page)
     assert_clean_page(page)
 
@@ -175,18 +200,15 @@ def run_raw_unsuccessful_response_flow(page, query, action):
     page.route("**/*", route_popup)
     page.goto(f"{POPUP_URL}?{query}=1")
     expect(page.get_by_text("Popup 授权 Mock 视频").first).to_be_visible()
-    page.locator("input[placeholder='例如：模型架构那段']").fill("受控失败")
-    page.get_by_role("button", name="检索", exact=True).click()
-    expect(page.get_by_role("button", name="预览跳转")).to_be_visible()
-    page.get_by_role("button", name="预览跳转").click()
-    page.get_by_role("button", name="确认跳转").click()
+    panel = prepare_qa_preview(page, "受控失败")
+    panel.get_by_role("button", name="确认跳转", exact=True).click()
 
     if action == "jump":
-        expect(page.get_by_text("未能完成跳转，请回到当前视频页确认页面和播放器状态后重试。")).to_be_visible()
+        expect(panel.get_by_text("引用结果或页面状态已变化，请重新提交问题后再试。")).to_be_visible()
     else:
-        expect(page.get_by_role("button", name="返回原位置")).to_be_visible()
-        page.get_by_role("button", name="返回原位置").click()
-        expect(page.get_by_text("未能返回原位置，请回到当前视频页确认页面和播放器状态后重试。")).to_be_visible()
+        expect(panel.get_by_role("button", name="返回原位置", exact=True)).to_be_visible()
+        panel.get_by_role("button", name="返回原位置", exact=True).click()
+        expect(panel.get_by_text("未能返回原位置，请回到当前视频页确认页面和播放器状态后重试。")).to_be_visible()
     assert_clean_page(page)
 
 
@@ -199,8 +221,7 @@ def run_blocked_flow(page, query, expected_message):
     page.get_by_role("button", name="生成摘要与亮点").click()
     expect(page.get_by_text(expected_message).first).to_be_visible()
     page.get_by_role("button", name="刷新", exact=True).click()
-    page.locator("input[placeholder='例如：模型架构那段']").fill("不应发送")
-    page.get_by_role("button", name="检索", exact=True).click()
+    submit_qa(page, "不应发送")
     assert_no_protected_actions(page)
     assert_clean_page(page)
 
@@ -211,14 +232,6 @@ def run_missing_title_flow(page):
     expect(page.get_by_text("当前视频", exact=True).first).to_be_visible()
     assert_no_protected_actions(page)
     assert_clean_page(page)
-
-
-def prepare_segment_preview(page, query):
-    page.locator("input[placeholder='例如：模型架构那段']").fill(query)
-    page.get_by_role("button", name="检索", exact=True).click()
-    expect(page.get_by_role("button", name="预览跳转")).to_be_visible()
-    page.get_by_role("button", name="预览跳转").click()
-    expect(page.get_by_role("button", name="确认跳转")).to_be_visible()
 
 
 def run_summary_scope_races(page):
@@ -516,22 +529,21 @@ def run_fail_closed_knowledge_copy(page):
     assert_clean_page(page)
 
 
-def run_search_revision_race(page):
+def run_full_text_qa_revision_race(page):
     page.route("**/*", route_popup)
     page.goto(POPUP_URL)
     expect(page.get_by_text("Popup 授权 Mock 视频").first).to_be_visible()
-    page.evaluate("window.__popupMockDeferNextResponse('SEARCH_CURRENT_VIDEO_SEGMENTS')")
-    page.locator("input[placeholder='例如：模型架构那段']").fill("旧检索")
-    page.get_by_role("button", name="检索", exact=True).click()
-    page.wait_for_function("window.__popupMockPendingResponseCount('SEARCH_CURRENT_VIDEO_SEGMENTS') === 1")
+    page.evaluate("window.__popupMockDeferNextResponse('ASK_CURRENT_VIDEO_FULL_TEXT')")
+    submit_qa(page, "旧问题")
+    page.wait_for_function("window.__popupMockPendingResponseCount('ASK_CURRENT_VIDEO_FULL_TEXT') === 1")
     page.evaluate("window.__popupMockEmitSelectionChange('same')")
-    page.locator("input[placeholder='例如：模型架构那段']").fill("新检索")
-    page.get_by_role("button", name="检索", exact=True).click()
-    expect(page.get_by_text("新检索 的当前候选").first).to_be_visible()
-    page.evaluate("window.__popupMockResolveResponses('SEARCH_CURRENT_VIDEO_SEGMENTS')")
+    submit_qa(page, "新问题")
+    expect(qa_panel(page).get_by_text("回答：新问题。", exact=False)).to_be_visible()
+    page.evaluate("window.__popupMockResolveResponses('ASK_CURRENT_VIDEO_FULL_TEXT')")
     page.wait_for_timeout(50)
-    expect(page.get_by_text("新检索 的当前候选").first).to_be_visible()
-    expect(page.get_by_text("旧检索 的当前候选")).to_have_count(0)
+    expect(qa_panel(page).get_by_text("回答：新问题。", exact=False)).to_be_visible()
+    expect(qa_panel(page).get_by_text("回答：旧问题。", exact=False)).to_have_count(0)
+    assert len(messages_for(page, "CANCEL_CURRENT_VIDEO_FULL_TEXT_QA")) == 1
     assert_clean_page(page)
 
 
@@ -539,18 +551,17 @@ def run_pre_render_selection_scope_race(page):
     page.route("**/*", route_popup)
     page.goto(POPUP_URL)
     expect(page.get_by_text("Popup 授权 Mock 视频").first).to_be_visible()
-    page.evaluate("window.__popupMockDeferNextResponse('SEARCH_CURRENT_VIDEO_SEGMENTS')")
-    page.locator("input[placeholder='例如：模型架构那段']").fill("pre-render-old")
-    page.get_by_role("button", name="检索", exact=True).click()
-    page.wait_for_function("window.__popupMockPendingResponseCount('SEARCH_CURRENT_VIDEO_SEGMENTS') === 1")
+    page.evaluate("window.__popupMockDeferNextResponse('ASK_CURRENT_VIDEO_FULL_TEXT')")
+    submit_qa(page, "渲染前旧问题")
+    page.wait_for_function("window.__popupMockPendingResponseCount('ASK_CURRENT_VIDEO_FULL_TEXT') === 1")
     page.evaluate(
         """() => {
-          window.__popupMockResolveResponses('SEARCH_CURRENT_VIDEO_SEGMENTS');
+          window.__popupMockResolveResponses('ASK_CURRENT_VIDEO_FULL_TEXT');
           window.__popupMockEmitSelectionChange('same');
         }"""
     )
     page.wait_for_timeout(50)
-    expect(page.get_by_text("pre-render-old 的当前候选")).to_have_count(0)
+    expect(qa_panel(page).get_by_text("回答：渲染前旧问题。", exact=False)).to_have_count(0)
     assert_clean_page(page)
 
 
@@ -558,47 +569,115 @@ def run_timestamp_races_and_double_click(page):
     page.route("**/*", route_popup)
     page.goto(POPUP_URL)
     expect(page.get_by_text("Popup 授权 Mock 视频").first).to_be_visible()
-    prepare_segment_preview(page, "第一次跳转")
-    page.evaluate("window.__popupMockDeferNextResponse('REQUEST_CURRENT_VIDEO_SEGMENT_JUMP')")
-    page.get_by_role("button", name="确认跳转").evaluate("button => { button.click(); button.click(); }")
-    page.wait_for_function("window.__popupMockPendingResponseCount('REQUEST_CURRENT_VIDEO_SEGMENT_JUMP') === 1")
-    assert len(messages_for(page, "REQUEST_CURRENT_VIDEO_SEGMENT_JUMP")) == 1
+    panel = prepare_qa_preview(page, "第一次跳转")
+    page.evaluate("window.__popupMockDeferNextResponse('REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP')")
+    panel.get_by_role("button", name="确认跳转", exact=True).evaluate("button => { button.click(); button.click(); }")
+    page.wait_for_function("window.__popupMockPendingResponseCount('REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP') === 1")
+    assert len(messages_for(page, "REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP")) == 1
 
     page.evaluate("window.__popupMockEmitSelectionChange('same')")
-    prepare_segment_preview(page, "较新跳转")
-    page.get_by_role("button", name="确认跳转").click()
-    expect(page.get_by_text("跳转已完成，可返回原位置。")).to_be_visible()
-    page.evaluate("window.__popupMockResolveResponses('REQUEST_CURRENT_VIDEO_SEGMENT_JUMP')")
+    panel = prepare_qa_preview(page, "较新跳转")
+    panel.get_by_role("button", name="确认跳转", exact=True).click()
+    expect(panel.get_by_text("已跳到引用位置，可返回原位置。")).to_be_visible()
+    page.evaluate("window.__popupMockResolveResponses('REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP')")
     page.wait_for_timeout(50)
-    expect(page.get_by_text("跳转已完成，可返回原位置。")).to_be_visible()
+    expect(panel.get_by_text("已跳到引用位置，可返回原位置。")).to_be_visible()
 
     page.evaluate("window.__popupMockDeferNextResponse('RETURN_CURRENT_VIDEO_SEGMENT_JUMP')")
-    page.get_by_role("button", name="返回原位置").evaluate("button => { button.click(); button.click(); }")
+    panel.get_by_role("button", name="返回原位置", exact=True).evaluate("button => { button.click(); button.click(); }")
     page.wait_for_function("window.__popupMockPendingResponseCount('RETURN_CURRENT_VIDEO_SEGMENT_JUMP') === 1")
     assert len(messages_for(page, "RETURN_CURRENT_VIDEO_SEGMENT_JUMP")) == 1
 
     page.evaluate("window.__popupMockEmitSelectionChange('same')")
-    prepare_segment_preview(page, "返回前的新跳转")
-    page.get_by_role("button", name="确认跳转").click()
-    expect(page.get_by_role("button", name="返回原位置")).to_be_visible()
-    page.get_by_role("button", name="返回原位置").click()
-    expect(page.get_by_text("已返回原位置。")).to_be_visible()
+    panel = prepare_qa_preview(page, "返回前的新跳转")
+    panel.get_by_role("button", name="确认跳转", exact=True).click()
+    expect(panel.get_by_role("button", name="返回原位置", exact=True)).to_be_visible()
+    panel.get_by_role("button", name="返回原位置", exact=True).click()
+    expect(panel.get_by_text("已返回原位置。", exact=True)).to_be_visible()
     page.evaluate("window.__popupMockResolveResponses('RETURN_CURRENT_VIDEO_SEGMENT_JUMP')")
     page.wait_for_timeout(50)
-    expect(page.get_by_text("已返回原位置。")).to_be_visible()
+    expect(panel.get_by_text("已返回原位置。", exact=True)).to_be_visible()
     assert len(messages_for(page, "RETURN_CURRENT_VIDEO_SEGMENT_JUMP")) == 2
     assert_clean_page(page)
 
 
 def run_success_raw_response_flow(page):
     page.route("**/*", route_popup)
-    page.goto(f"{POPUP_URL}?rawJumpSuccess=1&rawReturnSuccess=1")
+    page.goto(f"{POPUP_URL}?rawJumpSuccess=1&rawReturnSuccess=1&qaRawVisibleCopy=1")
     expect(page.get_by_text("Popup 授权 Mock 视频").first).to_be_visible()
-    prepare_segment_preview(page, "成功响应文案")
-    page.get_by_role("button", name="确认跳转").click()
-    expect(page.get_by_text("跳转已完成，可返回原位置。")).to_be_visible()
-    page.get_by_role("button", name="返回原位置").click()
-    expect(page.get_by_text("已返回原位置。")).to_be_visible()
+    panel = prepare_qa_preview(page, "成功响应文案")
+    panel.get_by_role("button", name="确认跳转", exact=True).click()
+    expect(panel.get_by_text("已跳到引用位置，可返回原位置。")).to_be_visible()
+    panel.get_by_role("button", name="返回原位置", exact=True).click()
+    expect(panel.get_by_text("已返回原位置。", exact=True)).to_be_visible()
+    assert_clean_page(page)
+
+
+def run_full_text_qa_terminal_states(page):
+    page.route("**/*", route_popup)
+
+    page.goto(f"{POPUP_URL}?qaUnsupported=1")
+    panel = submit_qa(page, "视频没有讲到的问题")
+    expect(panel.get_by_text("当前视频文本没有足够内容回答这个问题。", exact=True)).to_be_visible()
+    expect(panel.get_by_text("引用片段", exact=True)).to_have_count(0)
+    assert_clean_page(page)
+
+    page.goto(f"{POPUP_URL}?qaContextTooLong=1")
+    panel = submit_qa(page, "请概括完整论证")
+    expect(panel.get_by_text("正文超出所选模型限制", exact=True)).to_be_visible()
+    expect(panel.get_by_text("系统不会截断或分段发送", exact=False)).to_be_visible()
+    expect(panel.locator("textarea")).to_have_value("请概括完整论证")
+    expect(panel.get_by_role("button", name="重新提交", exact=True)).to_be_visible()
+    first_ask = last_message_for(page, "ASK_CURRENT_VIDEO_FULL_TEXT")
+    panel.locator("textarea").fill("这是编辑后的新问题")
+    panel.get_by_role("button", name="重新提交", exact=True).click()
+    expect(panel.get_by_text("正文超出所选模型限制", exact=True)).to_be_visible()
+    retry_ask = last_message_for(page, "ASK_CURRENT_VIDEO_FULL_TEXT")
+    assert retry_ask["params"]["requestId"] != first_ask["params"]["requestId"]
+    assert retry_ask["params"]["turnId"] == first_ask["params"]["turnId"]
+    assert retry_ask["params"]["question"] == "请概括完整论证"
+    expect(panel.locator("textarea")).to_have_value("请概括完整论证")
+    assert_clean_page(page)
+
+    page.goto(f"{POPUP_URL}?qaReject=1")
+    panel = submit_qa(page, "保留这个问题")
+    expect(panel.get_by_text("回答失败，问题已保留", exact=False)).to_be_visible()
+    expect(panel.locator("textarea")).to_have_value("保留这个问题")
+    assert_clean_page(page)
+
+
+def run_full_text_qa_cancel_and_context_change(page):
+    page.route("**/*", route_popup)
+    page.goto(POPUP_URL)
+    expect(page.get_by_text("Popup 授权 Mock 视频").first).to_be_visible()
+
+    page.evaluate("window.__popupMockDeferNextResponse('ASK_CURRENT_VIDEO_FULL_TEXT')")
+    panel = submit_qa(page, "取消后仍要保留的问题")
+    page.wait_for_function("window.__popupMockPendingResponseCount('ASK_CURRENT_VIDEO_FULL_TEXT') === 1")
+    ask_message = last_message_for(page, "ASK_CURRENT_VIDEO_FULL_TEXT")
+    panel.get_by_role("button", name="取消", exact=True).click()
+    expect(panel.get_by_text("本次回答已取消，问题已保留。", exact=True)).to_be_visible()
+    expect(panel.locator("textarea")).to_have_value("取消后仍要保留的问题")
+    cancel_message = last_message_for(page, "CANCEL_CURRENT_VIDEO_FULL_TEXT_QA")
+    assert cancel_message["params"]["requestId"] == ask_message["params"]["requestId"]
+    assert cancel_message["params"]["turnId"] == ask_message["params"]["turnId"]
+    page.evaluate("window.__popupMockResolveResponses('ASK_CURRENT_VIDEO_FULL_TEXT')")
+    page.wait_for_timeout(50)
+    expect(panel.get_by_text("回答：取消后仍要保留的问题。", exact=False)).to_have_count(0)
+
+    page.evaluate("window.__popupMockDeferNextResponse('ASK_CURRENT_VIDEO_FULL_TEXT')")
+    submit_qa(page, "切换视频前的问题")
+    page.wait_for_function("window.__popupMockPendingResponseCount('ASK_CURRENT_VIDEO_FULL_TEXT') === 1")
+    page.evaluate("window.__popupMockDeferNextResponse('GET_CURRENT_VIDEO_TRANSCRIPT_EVIDENCE')")
+    page.get_by_role("button", name="重新检测字幕").click()
+    page.wait_for_function("window.__popupMockPendingResponseCount('GET_CURRENT_VIDEO_TRANSCRIPT_EVIDENCE') === 1")
+    page.evaluate("window.__popupMockSwitchContext()")
+    page.evaluate("window.__popupMockResolveResponses('GET_CURRENT_VIDEO_TRANSCRIPT_EVIDENCE')")
+    expect(page.get_by_text("切换后的 Popup 视频").first).to_be_visible()
+    page.evaluate("window.__popupMockResolveResponses('ASK_CURRENT_VIDEO_FULL_TEXT')")
+    page.wait_for_timeout(50)
+    expect(page.get_by_text("回答：切换视频前的问题。", exact=False)).to_have_count(0)
+    assert len(messages_for(page, "CANCEL_CURRENT_VIDEO_FULL_TEXT_QA")) >= 2
     assert_clean_page(page)
 
 
@@ -739,7 +818,7 @@ def main():
             knowledge_blocked.close()
 
             search_race, search_race_errors = new_checked_page(browser)
-            run_search_revision_race(search_race)
+            run_full_text_qa_revision_race(search_race)
             assert not search_race_errors, "\n".join(search_race_errors)
             search_race.close()
 
@@ -758,12 +837,22 @@ def main():
             assert not raw_success_errors, "\n".join(raw_success_errors)
             raw_success.close()
 
+            qa_states, qa_states_errors = new_checked_page(browser)
+            run_full_text_qa_terminal_states(qa_states)
+            assert not qa_states_errors, "\n".join(qa_states_errors)
+            qa_states.close()
+
+            qa_cancel, qa_cancel_errors = new_checked_page(browser)
+            run_full_text_qa_cancel_and_context_change(qa_cancel)
+            assert not qa_cancel_errors, "\n".join(qa_cancel_errors)
+            qa_cancel.close()
+
             desktop, desktop_errors = new_checked_page(browser, {"width": 1024, "height": 820})
             run_layout_smoke(desktop)
             assert not desktop_errors, "\n".join(desktop_errors)
             desktop.close()
 
-            print("current-video popup real UI QA passed: combined summary/key-points/highlights, open/reprobe no generation, no-click disabled/unconfigured entry, cache restore and authorization-off/live-disabled prior result, live model-change cancellation and exact-model cache refresh, failed-refresh old-result preservation, exact source-change cancel with late-response rejection, no-text/generating/error/invalid states, 4-8 highlights, preview/confirm/return and replacement rejection, responsive no-overflow/no-console/raw-copy checks")
+            print("current-video popup real UI QA passed: combined summary/key-points/highlights, explicit full-text Q&A with answer-before-citations, unsupported/context-too-long/cancel and late-response rejection, source/video-scope invalidation, preview/confirm/return, responsive no-overflow/no-console/raw-copy checks")
         finally:
             browser.close()
 

--- a/tests/current-video-popup.mock.js
+++ b/tests/current-video-popup.mock.js
@@ -18,6 +18,7 @@
   const pendingResponses = [];
   const actionSequence = new Map();
   const cancelledSummaryRequestIds = new Set();
+  const cancelledFullTextQaRequestIds = new Set();
   let summaryCacheResult = null;
   let summaryCacheSourceIdentityKey = null;
   let summaryReplacementSequence = 100;
@@ -493,6 +494,110 @@
     };
   }
 
+  function fullTextQaResult(request, authorized) {
+    const requestId = String(request?.requestId || 'popup-qa-request');
+    const turnId = String(request?.turnId || 'popup-qa-turn');
+    const question = String(request?.question || '').trim();
+    const sourceLabel = authorized ? 'B站字幕' : null;
+    const common = {
+      requestId,
+      turnId,
+      question,
+      title: title || '当前视频',
+      partTitle: page > 1 ? `第 ${page} P` : null,
+      sourceLabel,
+      textSize: { lineCount: authorized ? 2 : 0, charCount: authorized ? 34 : null, utf8Bytes: authorized ? 96 : 0 },
+      answerEvidenceLineNumbers: [],
+      citations: [],
+      limitations: [],
+      generatedAt: Date.now(),
+      canRetry: true,
+    };
+    if (cancelledFullTextQaRequestIds.has(requestId)) {
+      return {
+        ...common,
+        status: 'cancelled',
+        answer: '',
+        message: '本次回答已取消，问题已保留，可重新提交。',
+        ai: { status: 'cancelled', model: currentChatModel(), note: '本次请求已取消。', errorCode: null },
+      };
+    }
+    const state = currentSummaryState();
+    if (state === 'disabled') {
+      return {
+        ...common,
+        status: 'disabled',
+        answer: '',
+        message: '当前视频 AI 助手已关闭，问题已保留。开启后可重新提交。',
+        ai: { status: 'disabled', model: currentChatModel(), note: '当前功能未开启。', errorCode: null },
+      };
+    }
+    if (state === 'unconfigured') {
+      return {
+        ...common,
+        status: 'not_configured',
+        answer: '',
+        message: 'AI 服务尚未配置完成，问题已保留。完成设置后可重新提交。',
+        ai: { status: 'not_configured', model: currentChatModel(), note: 'AI 服务未配置。', errorCode: null },
+      };
+    }
+    if (!authorized || params.get('qaNoText') === '1') {
+      return {
+        ...common,
+        status: 'no_text',
+        answer: '',
+        message: '当前分 P 没有可用的主要文本，无法回答。问题已保留。',
+        ai: { status: 'failed', model: currentChatModel(), note: '当前主要文本不可用。', errorCode: 'no_text' },
+      };
+    }
+    if (params.get('qaContextTooLong') === '1') {
+      return {
+        ...common,
+        status: 'context_too_long',
+        answer: '',
+        message: '当前正文过长，所选模型没有接受本次完整请求；系统不会截断或分段发送。问题已保留，可更换模型后重试。',
+        ai: { status: 'context_too_long', model: currentChatModel(), note: '完整正文未被所选模型接受。', errorCode: 'context_too_long' },
+      };
+    }
+    if (params.get('qaUnsupported') === '1') {
+      return {
+        ...common,
+        status: 'unsupported',
+        answer: '当前视频文本没有足够内容回答这个问题。',
+        message: '当前视频文本没有足够内容支持回答。',
+        limitations: ['没有使用标题、简介、通用知识或其他视频内容补答。'],
+        ai: { status: 'unsupported', model: currentChatModel(), note: '当前正文依据不足。', errorCode: null },
+        canRetry: false,
+      };
+    }
+    const citationId = `popup-qa-citation-${requestId}`;
+    const rawVisibleCopy = params.get('qaRawVisibleCopy') === '1';
+    return {
+      ...common,
+      status: 'ready',
+      answer: rawVisibleCopy
+        ? 'document is not defined; fallback transcript confidence sourceHash=popup-secret segmentId=segment-secret subtitle_url=https://secret.invalid bvid=BV1RawLeak99 CID=9201 独立 BV1RawLeak99'
+        : `回答：${question}。作者先说明约束，再用当前视频中的示例给出结论。`,
+      answerEvidenceLineNumbers: [1, 2],
+      citations: [{
+        id: citationId,
+        evidenceLineNumbers: [1, 2],
+        evidenceText: rawVisibleCopy
+          ? 'fallback transcript confidence sourceHash=popup-secret segmentId=segment-secret subtitle_url=https://secret.invalid bvid=BV1RawLeak99 CID=9201 独立 BV1RawLeak99'
+          : '作者先说明约束条件，随后通过当前视频中的示例验证结论。',
+        startSeconds: 4,
+        endSeconds: 8,
+        timeRangeLabel: '0:04-0:08',
+        sourceLabel: 'B站字幕',
+        binding: { requestId, turnId, citationId },
+      }],
+      message: '回答已基于当前分 P 的完整主要文本生成。',
+      limitations: ['回答和引用只基于当前分 P 本次提交的完整主要文本。'],
+      ai: { status: 'generated', model: currentChatModel(), note: '回答已生成。', errorCode: null },
+      canRetry: false,
+    };
+  }
+
   function storageGet(keys) {
     if (params.get('rejectStorage') === '1') {
       return Promise.reject(new Error('MOCK_POPUP_PRIMARY_TEXT_STORAGE_READ_FAILED'));
@@ -702,6 +807,51 @@
                 nextActionSequence(message.action),
               ),
             });
+          case 'ASK_CURRENT_VIDEO_FULL_TEXT':
+            if (params.get('qaReject') === '1') {
+              return Promise.reject(new Error('MOCK_POPUP_QA_NETWORK_FAILURE'));
+            }
+            return maybeDeferResponse(message.action, () => ({
+              success: true,
+              data: fullTextQaResult(message.params, authorized),
+            }));
+          case 'CANCEL_CURRENT_VIDEO_FULL_TEXT_QA': {
+            const requestId = String(message.params?.requestId || '');
+            if (requestId) cancelledFullTextQaRequestIds.add(requestId);
+            return Promise.resolve({ success: true, data: { cancelled: Boolean(requestId) } });
+          }
+          case 'REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP': {
+            const allowed = authorized
+              && message.params?.confirmed === true
+              && String(message.params?.requestId || '').length > 0
+              && String(message.params?.turnId || '').length > 0
+              && String(message.params?.citationId || '').startsWith('popup-qa-citation-');
+            if (params.get('rawJumpFailure') === '1') {
+              return maybeDeferResponse(message.action, { success: true, data: {
+                ok: false,
+                message: 'document is not defined; sourceHash=popup-source-v2',
+                candidateId: String(message.params?.citationId || ''),
+                targetSeconds: null,
+                targetTimeLabel: null,
+                returnPointSeconds: null,
+                sourceLabel: null,
+                confidence: null,
+              } });
+            }
+            returnAvailable = allowed;
+            return maybeDeferResponse(message.action, { success: true, data: {
+              ok: allowed,
+              message: params.get('rawJumpSuccess') === '1'
+                ? 'document is not defined; BVID CID sourceHash segmentId subtitle_url'
+                : (allowed ? '已跳到 0:04，可返回 0:12。' : '引用结果已变化，请重新提交问题。'),
+              candidateId: String(message.params?.citationId || ''),
+              targetSeconds: allowed ? 4 : null,
+              targetTimeLabel: allowed ? '0:04' : null,
+              returnPointSeconds: allowed ? 12 : null,
+              sourceLabel: allowed ? '当前视频文本' : null,
+              confidence: allowed ? 1 : null,
+            } });
+          }
           case 'SEARCH_CURRENT_VIDEO_SEGMENTS':
             return maybeDeferResponse(message.action, {
               success: true,

--- a/tests/current-video-primary-text.mock-qa.py
+++ b/tests/current-video-primary-text.mock-qa.py
@@ -30,6 +30,7 @@ FORBIDDEN_ASSISTANT_IDENTITY_TERMS = [
     "CID",
     "BV1ShellMock9",
     "BV1OtherMock8",
+    "BV1RawLeak99",
     "2202",
     "3303",
     "4404",
@@ -37,7 +38,7 @@ FORBIDDEN_ASSISTANT_IDENTITY_TERMS = [
 FULL_TEXT_OR_SEARCH_ACTIONS = {
     "GENERATE_CURRENT_VIDEO_SUMMARY_HIGHLIGHTS",
     "GET_VIDEO_KNOWLEDGE",
-    "SEARCH_CURRENT_VIDEO_SEGMENTS",
+    "ASK_CURRENT_VIDEO_FULL_TEXT",
 }
 
 
@@ -185,18 +186,21 @@ def run_flow(page):
     page.get_by_role("button", name="提问").click()
     expect(page.get_by_text("回答：有证据")).to_be_visible()
     expect(page.get_by_text("引用片段", exact=True)).to_be_visible()
-    search_message = last_message_for(page, "SEARCH_CURRENT_VIDEO_SEGMENTS")
+    assert page.locator(".bdc-assistant-answer-card").evaluate(
+        "answer => Boolean(answer.compareDocumentPosition(document.querySelector('.bdc-assistant-citation-title')) & Node.DOCUMENT_POSITION_FOLLOWING)"
+    )
+    search_message = last_message_for(page, "ASK_CURRENT_VIDEO_FULL_TEXT")
     assert search_message["params"].get("selectedSourceIdentityKey"), "selected source key was not sent with search"
 
     page.get_by_role("button", name="预览跳转").first.click()
     expect(page.get_by_text("确认跳转前预览")).to_be_visible()
     page.get_by_role("button", name="确认跳转").click()
-    expect(page.get_by_text("返回原位置")).to_be_visible()
-    jump_message = last_message_for(page, "REQUEST_CURRENT_VIDEO_SEGMENT_JUMP")
+    expect(page.get_by_role("button", name="返回原位置")).to_be_visible()
+    jump_message = last_message_for(page, "REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP")
     assert jump_message["params"].get("selectedSourceIdentityKey"), "selected source key was not sent with jump"
 
     page.get_by_role("button", name="返回原位置").click()
-    expect(page.get_by_text("已返回")).to_be_visible()
+    expect(page.get_by_text("已返回 0:12")).to_be_visible()
 
     assert_clean_visible_text(page)
     assert_no_horizontal_overflow(page)
@@ -222,7 +226,7 @@ def open_subtitle_tab(page, query="subtitleCached=1&sourceVersion=v2"):
 def run_subtitle_single_source_flow(page):
     assistant = open_subtitle_tab(page)
     assert "GET_CURRENT_VIDEO_SUBTITLE_VIEW_SOURCES" in message_actions(page)
-    assert message_count_for(page, "SEARCH_CURRENT_VIDEO_SEGMENTS") == 0
+    assert message_count_for(page, "ASK_CURRENT_VIDEO_FULL_TEXT") == 0
     expect(assistant.get_by_text("正在查看：B站字幕").first).to_be_visible()
     expect(assistant.get_by_text("本地转录")).to_have_count(0)
     expect(assistant.get_by_role("radiogroup", name="字幕查看来源")).to_have_count(0)
@@ -266,7 +270,7 @@ def run_subtitle_single_source_flow(page):
     assistant.get_by_role("button", name="查找").click()
     expect(assistant.get_by_text("找到 1 处匹配。")).to_be_visible()
     expect(assistant.locator(".bdc-assistant-subtitle-result").filter(has_text="开场介绍子代理和当前视频助手。").first).to_be_visible()
-    assert message_count_for(page, "SEARCH_CURRENT_VIDEO_SEGMENTS") == 0
+    assert message_count_for(page, "ASK_CURRENT_VIDEO_FULL_TEXT") == 0
 
     search.fill("tool use")
     assistant.get_by_role("button", name="查找").click()
@@ -315,7 +319,7 @@ def run_subtitle_single_source_flow(page):
     actions = message_actions(page)
     assert "GENERATE_CURRENT_VIDEO_SUMMARY_HIGHLIGHTS" not in actions
     assert "GET_VIDEO_KNOWLEDGE" not in actions
-    assert message_count_for(page, "SEARCH_CURRENT_VIDEO_SEGMENTS") == 0
+    assert message_count_for(page, "ASK_CURRENT_VIDEO_FULL_TEXT") == 0
     assert_clean_visible_text(page)
     assert_no_horizontal_overflow(page)
 
@@ -408,7 +412,7 @@ def run_missing_selection_flow(page):
     saved_v1_key = saved_keys[0]
 
     page.evaluate("window.__assistantMockReplaceSubtitleSource()")
-    search_count_before = message_count_for(page, "SEARCH_CURRENT_VIDEO_SEGMENTS")
+    search_count_before = message_count_for(page, "ASK_CURRENT_VIDEO_FULL_TEXT")
     page.get_by_role("button", name="重新检测字幕").first.click()
     page.wait_for_function(
         """(expected) => [...(window.__assistantMockMessages || [])].reverse().some(
@@ -422,7 +426,7 @@ def run_missing_selection_flow(page):
     select_assistant_tab(page, "问答")
     expect(page.locator("textarea")).to_be_disabled()
     expect(page.get_by_role("button", name="提问")).to_be_disabled()
-    assert message_count_for(page, "SEARCH_CURRENT_VIDEO_SEGMENTS") == search_count_before
+    assert message_count_for(page, "ASK_CURRENT_VIDEO_FULL_TEXT") == search_count_before
 
     assert_clean_visible_text(page)
     assert_no_horizontal_overflow(page)
@@ -460,8 +464,8 @@ def run_deferred_storage_flow(page):
     counts_before = {
         action: message_count_for(page, action)
         for action in [
-            "SEARCH_CURRENT_VIDEO_SEGMENTS",
-            "REQUEST_CURRENT_VIDEO_SEGMENT_JUMP",
+            "ASK_CURRENT_VIDEO_FULL_TEXT",
+            "REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP",
         ]
     }
     page.get_by_role("button", name="提问").evaluate("(button) => button.click()")
@@ -490,7 +494,7 @@ def run_deferred_storage_flow(page):
     assert not refresh_message["params"].get("selectedSourceIdentityKey")
 
     page.get_by_role("button", name="提问").evaluate("(button) => button.click()")
-    assert message_count_for(page, "SEARCH_CURRENT_VIDEO_SEGMENTS") == counts_before["SEARCH_CURRENT_VIDEO_SEGMENTS"]
+    assert message_count_for(page, "ASK_CURRENT_VIDEO_FULL_TEXT") == counts_before["ASK_CURRENT_VIDEO_FULL_TEXT"]
     assert_clean_visible_text(page)
     assert_no_horizontal_overflow(page)
 
@@ -510,13 +514,13 @@ def run_single_v2_without_saved_selection_flow(page):
     page.locator("textarea").fill("subagent 在哪里")
     page.get_by_role("button", name="提问").click()
     expect(page.get_by_text("回答：有证据")).to_be_visible()
-    search_message = last_message_for(page, "SEARCH_CURRENT_VIDEO_SEGMENTS")
+    search_message = last_message_for(page, "ASK_CURRENT_VIDEO_FULL_TEXT")
     assert search_message["params"].get("primaryTextSelectionsReady") is True
     assert search_message["params"].get("selectedSourceIdentityKey") == current_v2_key
 
     page.get_by_role("button", name="预览跳转").first.click()
     page.get_by_role("button", name="确认跳转").click()
-    jump_message = last_message_for(page, "REQUEST_CURRENT_VIDEO_SEGMENT_JUMP")
+    jump_message = last_message_for(page, "REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP")
     assert jump_message["params"].get("primaryTextSelectionsReady") is True
     assert jump_message["params"].get("selectedSourceIdentityKey") == current_v2_key
 
@@ -535,8 +539,8 @@ def run_rejected_storage_single_v2_flow(page):
     expect(page.locator("textarea")).to_be_disabled()
 
     blocked_actions = [
-        "SEARCH_CURRENT_VIDEO_SEGMENTS",
-        "REQUEST_CURRENT_VIDEO_SEGMENT_JUMP",
+        "ASK_CURRENT_VIDEO_FULL_TEXT",
+        "REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP",
     ]
     counts_before_reject = {action: message_count_for(page, action) for action in blocked_actions}
     page.get_by_role("button", name="重新检测字幕").first.evaluate("(button) => button.click()")
@@ -595,7 +599,7 @@ def run_rejected_storage_single_v2_flow(page):
     page.locator("textarea").fill("subagent 在哪里")
     page.get_by_role("button", name="提问").click()
     expect(page.get_by_text("回答：有证据")).to_be_visible()
-    search_message = last_message_for(page, "SEARCH_CURRENT_VIDEO_SEGMENTS")
+    search_message = last_message_for(page, "ASK_CURRENT_VIDEO_FULL_TEXT")
     assert search_message["params"].get("primaryTextSelectionsReady") is True
     assert search_message["params"].get("selectedSourceIdentityKey") == current_v2_key
 
@@ -620,8 +624,8 @@ def run_loaded_selection_save_failure_flow(page):
     expect(page.get_by_role("button", name="确认跳转")).to_be_visible()
 
     blocked_actions = [
-        "SEARCH_CURRENT_VIDEO_SEGMENTS",
-        "REQUEST_CURRENT_VIDEO_SEGMENT_JUMP",
+        "ASK_CURRENT_VIDEO_FULL_TEXT",
+        "REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP",
     ]
 
     page.evaluate("window.__assistantMockRejectNextPrimaryTextStorageSet()")
@@ -666,7 +670,7 @@ def run_loaded_storage_change_invalidation_flow(page):
     expect(page.get_by_text("已用于当前视频助手").first).to_be_visible()
     select_assistant_tab(page, "问答")
     page.locator("textarea").fill("清理竞态")
-    page.evaluate("window.__assistantMockDeferNextProtectedAction('SEARCH_CURRENT_VIDEO_SEGMENTS')")
+    page.evaluate("window.__assistantMockDeferNextProtectedAction('ASK_CURRENT_VIDEO_FULL_TEXT')")
     page.get_by_role("button", name="提问").click()
     page.evaluate("window.__assistantMockClearPrimaryTextSelectionsForClearAll()")
     page.evaluate("window.__assistantMockResolveProtectedResponses()")
@@ -675,7 +679,7 @@ def run_loaded_storage_change_invalidation_flow(page):
 
     page.get_by_role("button", name="提问").click()
     expect(page.get_by_text("回答：有证据")).to_be_visible()
-    search_message = last_message_for(page, "SEARCH_CURRENT_VIDEO_SEGMENTS")
+    search_message = last_message_for(page, "ASK_CURRENT_VIDEO_FULL_TEXT")
     assert search_message["params"].get("primaryTextSelectionsReady") is True
     assert search_message["params"].get("selectedSourceIdentityKey") == current_source_key
     assert search_message["params"].get("selectedSourceIdentityKey") != old_source_key
@@ -761,7 +765,7 @@ def start_newer_timestamp_jump(page):
     expect(page.get_by_text("回答：有证据")).to_be_visible()
     page.get_by_role("button", name="预览跳转").first.click()
     page.get_by_role("button", name="确认跳转").click()
-    expect(assistant.get_by_text("可返回 0:30")).to_be_visible()
+    expect(assistant.get_by_text("已跳到引用位置，可返回原位置。")).to_be_visible()
     expect(assistant.get_by_role("button", name="返回原位置")).to_be_visible()
 
 
@@ -775,11 +779,11 @@ def run_late_assistant_timestamp_flow(page, operation, invalidation, newer=False
         page.get_by_role("button", name="返回原位置").click()
         expect(page.get_by_text("正在返回原位置...")).to_be_visible()
     else:
-        page.evaluate("window.__assistantMockDeferNextProtectedAction('REQUEST_CURRENT_VIDEO_SEGMENT_JUMP')")
+        page.evaluate("window.__assistantMockDeferNextProtectedAction('REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP')")
         page.get_by_role("button", name="确认跳转").click()
         expect(page.get_by_text("正在确认跳转...")).to_be_visible()
-        expect(page.get_by_role("button", name="收起预览")).to_be_disabled()
-        expect(page.get_by_role("button", name="取消")).to_be_disabled()
+        expect(page.get_by_role("button", name="已预览")).to_be_disabled()
+        expect(page.get_by_role("button", name="正在跳转...")).to_be_disabled()
 
     if invalidation == "part":
         page.evaluate("window.__assistantMockSwitchToPart(2)")
@@ -802,7 +806,7 @@ def run_late_assistant_timestamp_flow(page, operation, invalidation, newer=False
     expect(page.get_by_text("正在确认跳转...")).to_have_count(0)
     expect(page.get_by_text("正在返回原位置...")).to_have_count(0)
     if newer:
-        expect(assistant.get_by_text("可返回 0:30")).to_be_visible()
+        expect(assistant.get_by_text("已跳到引用位置，可返回原位置。")).to_be_visible()
         expect(assistant.get_by_role("button", name="返回原位置")).to_be_visible()
         expect(assistant.get_by_text("已返回 0:12")).to_have_count(0)
     else:
@@ -1151,8 +1155,8 @@ def run_selection_save_blocks_operations_flow(page):
     counts_before = {
         action: message_count_for(page, action)
         for action in [
-            "SEARCH_CURRENT_VIDEO_SEGMENTS",
-            "REQUEST_CURRENT_VIDEO_SEGMENT_JUMP",
+            "ASK_CURRENT_VIDEO_FULL_TEXT",
+            "REQUEST_CURRENT_VIDEO_QA_CITATION_JUMP",
         ]
     }
     page.locator(".bdc-assistant-source-card").filter(has_text="B站字幕").get_by_role("button", name="用于视频助手").click()
@@ -1230,7 +1234,7 @@ def run_search_no_candidate_flow(page):
     select_assistant_tab(page, "问答")
     page.locator("textarea").fill("没有候选")
     page.get_by_role("button", name="提问").click()
-    expect(page.get_by_text("没有。在当前已缓存的字幕正文或本地节点里，没有找到能回答这个问题的证据。")).to_be_visible()
+    expect(page.get_by_text("当前视频文本没有足够内容回答这个问题。")).to_be_visible()
     expect(page.get_by_role("button", name="预览跳转")).to_have_count(0)
     assert_clean_visible_text(page)
     assert_no_horizontal_overflow(page)
@@ -1245,7 +1249,51 @@ def run_search_backend_failure_flow(page):
     select_assistant_tab(page, "问答")
     page.locator("textarea").fill("后台失败")
     page.get_by_role("button", name="提问").click()
-    expect(page.get_by_text("回答失败：请确认当前 B 站视频页仍然打开，并稍后重试。")).to_be_visible()
+    expect(page.get_by_text("回答失败，问题已保留。请确认当前视频页和 AI 设置后重试。")).to_be_visible()
+    assert_clean_visible_text(page)
+    assert_no_horizontal_overflow(page)
+
+
+def run_full_text_context_too_long_flow(page):
+    page.route("**/*", route_mock)
+    page.goto(f"{MOCK_URL}?subtitleCached=1&sourceVersion=v2")
+    expect(page.locator("#bdc-current-video-assistant")).to_be_visible()
+    page.get_by_text("展开助手").click()
+    page.get_by_role("button", name="重新检测字幕").first.click()
+    select_assistant_tab(page, "问答")
+    question = "正文过长时请完整回答"
+    page.locator("textarea").fill(question)
+    page.get_by_role("button", name="提问").click()
+    expect(page.get_by_text("状态：正文过长")).to_be_visible()
+    expect(page.get_by_text("系统不会截断或分段发送", exact=False)).to_be_visible()
+    expect(page.locator("textarea")).to_have_value(question)
+    expect(page.get_by_role("button", name="重试本题")).to_be_visible()
+    first_ask = last_message_for(page, "ASK_CURRENT_VIDEO_FULL_TEXT")
+    page.locator("textarea").fill("这是编辑后的新问题")
+    page.get_by_role("button", name="重试本题").click()
+    expect(page.get_by_text("状态：正文过长")).to_be_visible()
+    retry_ask = last_message_for(page, "ASK_CURRENT_VIDEO_FULL_TEXT")
+    assert retry_ask["params"]["requestId"] != first_ask["params"]["requestId"]
+    assert retry_ask["params"]["turnId"] == first_ask["params"]["turnId"]
+    assert retry_ask["params"]["question"] == question
+    expect(page.locator("textarea")).to_have_value(question)
+    expect(page.get_by_role("button", name="预览跳转")).to_have_count(0)
+    assert_clean_visible_text(page)
+    assert_no_horizontal_overflow(page)
+
+
+def run_full_text_raw_identity_copy_flow(page):
+    page.route("**/*", route_mock)
+    page.goto(f"{MOCK_URL}?subtitleCached=1&sourceVersion=v2")
+    expect(page.locator("#bdc-current-video-assistant")).to_be_visible()
+    page.get_by_text("展开助手").click()
+    page.get_by_role("button", name="重新检测字幕").first.click()
+    select_assistant_tab(page, "问答")
+    page.locator("textarea").fill("subagent 原始身份泄漏")
+    page.get_by_role("button", name="提问").click()
+    expect(page.get_by_text("回答：有证据")).to_be_visible()
+    expect(page.get_by_text("内部信息已隐藏", exact=False).first).to_be_visible()
+    expect(page.get_by_text("视频编号已隐藏", exact=False).first).to_be_visible()
     assert_clean_visible_text(page)
     assert_no_horizontal_overflow(page)
 
@@ -1871,6 +1919,16 @@ def main():
             run_search_backend_failure_flow(backend_failure)
             assert not backend_failure_errors, "\n".join(backend_failure_errors)
             backend_failure.close()
+
+            too_long, too_long_errors = new_checked_page(browser, viewport={"width": 1280, "height": 820})
+            run_full_text_context_too_long_flow(too_long)
+            assert not too_long_errors, "\n".join(too_long_errors)
+            too_long.close()
+
+            raw_identity, raw_identity_errors = new_checked_page(browser, viewport={"width": 1280, "height": 820})
+            run_full_text_raw_identity_copy_flow(raw_identity)
+            assert not raw_identity_errors, "\n".join(raw_identity_errors)
+            raw_identity.close()
 
             subtitle_desktop, subtitle_desktop_errors = new_checked_page(browser, viewport={"width": 1280, "height": 820})
             run_subtitle_single_source_flow(subtitle_desktop)


### PR DESCRIPTION
## 范围

- 当前分 P 每次显式提问发送完整主要文本，先输出直接中文回答，再列 1-3 条本地绑定引用
- 无依据时拒答；上下文过长、无文本、取消、未配置等状态不裁剪正文并保留问题
- `requestId/turnId`、目标标签页、来源选择、配置、重试与晚到响应均做归属和发网前复核
- 引用跳转保持预览、确认、返回流程，并在发送前再次确认引用未被重试替换
- popup 与页内助手同步接入，来源行显示视频/分 P/文本来源；不包含会话持久化、多视频比较或全局问题模板

## 验证

- `node --test tests/*.test.ts`：389 passed
- focused：41 passed
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- popup production mock QA
- player-monitor production mock QA（桌面/移动端、取消/迟到响应、来源切换、跳转往返）
- 用户可见文案扫描：`未消费|猜你喜欢` 无命中；raw 字段泄漏检查通过

## 边界

- 未读取 Cookie、profile、login-state、key 文件或 `C:\Users\LittleNub\Desktop\Key.txt`
- 未修改 release、tag、package version 或发布资产

Relates #173