### PR TITLE
chore(deps): update Preact 10.x lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1101,13 +1101,21 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.29.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
-      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
       }
     },
     "node_modules/prettier": {


### PR DESCRIPTION
## What changed

- update the locked Preact version from 10.29.1 to 10.29.8
- keep the existing `^10.24.0` manifest range unchanged
- do not update any other dependency

## Why

This completes the isolated compatible Preact patch evaluation from #207 without combining lockfile changes.

## Validation

- `npm test`: 479/479
- `npm run typecheck`
- `npm run build`
- `npm audit`: 0 vulnerabilities
- `git diff --check`
- current-video popup production mock QA
- Settings local-data/privacy production mock QA

The existing build warnings remain tracked separately by #206.

Closes #207