### PR TITLE
chore(deps): update Dexie 4.x lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -932,9 +932,9 @@
       "license": "MIT"
     },
     "node_modules/dexie": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.4.2.tgz",
-      "integrity": "sha512-zMtV8q79EFE5U8FKZvt0Y/77PCU/Hr/RDxv1EDeo228L+m/HTbeN2AjoQm674rhQCX8n3ljK87lajt7UQuZfvw==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.4.4.tgz",
+      "integrity": "sha512-jIwsYI8Os2hgnqc6O49YwFDKGc5v5QjGx0wPVp543ip1F53VFAKMLthV2pQosQcVTv3eAskTWYspOx195PM0FQ==",
       "license": "Apache-2.0"
     },
     "node_modules/echarts": {


### PR DESCRIPTION
## What changed

- update the locked Dexie version from 4.4.2 to 4.4.4
- keep the existing `^4.0.0` manifest range unchanged
- do not update any other dependency or database schema

## Validation

- focused IndexedDB/storage tests: 90/90
- `npm test`: 479/479
- `npm run typecheck`
- `npm run build`
- `npm audit`: 0 vulnerabilities
- `git diff --check`

The existing Vite warnings remain tracked separately by #206.

Closes #208