### PR TITLE
chore(deps): update Prettier 3.x lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1119,9 +1119,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {


### PR DESCRIPTION
## What changed

- update the locked Prettier version from 3.8.3 to 3.9.6
- keep the existing `^3.3.0` manifest range unchanged
- do not format or modify any source file

## Validation

- `npm test`: 479/479
- `npm run typecheck`
- `npm run build`
- `npm audit`: 0 vulnerabilities
- `git diff --check`

The existing Vite warnings remain tracked separately by #206.

Closes #209