### PR TITLE
build: resolve production bundle warnings

### DIFF
--- a/scripts/release-entry-contract.mjs
+++ b/scripts/release-entry-contract.mjs
@@ -1,0 +1,55 @@
+export const REQUIRED_BUILD_ENTRY_FILES = Object.freeze([
+  'dashboard.js',
+  'popup.js',
+  'popup/index.html',
+]);
+
+export function collectManifestEntryFiles(manifest) {
+  const entries = new Set();
+
+  addEntry(entries, manifest.background?.service_worker);
+  for (const contentScript of manifest.content_scripts ?? []) {
+    for (const script of contentScript.js ?? []) {
+      addEntry(entries, script);
+    }
+  }
+
+  addEntry(entries, manifest.action?.default_popup);
+  addEntry(entries, manifest.options_page);
+  addEntry(entries, manifest.options_ui?.page);
+  addEntry(entries, manifest.side_panel?.default_path);
+  addEntry(entries, manifest.devtools_page);
+
+  for (const page of Object.values(manifest.chrome_url_overrides ?? {})) {
+    addEntry(entries, page);
+  }
+  for (const page of manifest.sandbox?.pages ?? []) {
+    addEntry(entries, page);
+  }
+  for (const resourceGroup of manifest.web_accessible_resources ?? []) {
+    for (const resource of resourceGroup.resources ?? []) {
+      if (isConcreteWebAccessibleResource(resource)) {
+        addEntry(entries, resource);
+      }
+    }
+  }
+
+  return [...entries].sort();
+}
+
+export function getRequiredReleaseEntryFiles(manifest) {
+  return [...new Set([
+    ...collectManifestEntryFiles(manifest),
+    ...REQUIRED_BUILD_ENTRY_FILES,
+  ])].sort();
+}
+
+function addEntry(entries, value) {
+  if (typeof value === 'string' && value.length > 0) {
+    entries.add(value.replaceAll('\\', '/'));
+  }
+}
+
+function isConcreteWebAccessibleResource(value) {
+  return typeof value === 'string' && !value.includes('*');
+}

--- a/scripts/verify-release-dist.mjs
+++ b/scripts/verify-release-dist.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { readFile, readdir, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { getRequiredReleaseEntryFiles } from './release-entry-contract.mjs';
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const distRoot = path.join(repositoryRoot, 'dist');
@@ -13,14 +14,10 @@ const requiredFiles = [
   ['third_party_licenses/BSD-3-Clause-d3.txt', /Copyright 2010-2016 Mike Bostock/],
   ['third_party_licenses/MIT-wordcloud2.txt', /Copyright \(c\) 2011- Timothy Guan-tin Chien/],
 ];
-const requiredEntryFiles = [
-  'background.js',
-  'content/player-monitor.js',
-  'content/sidebar-card.js',
-  'dashboard.js',
-  'popup.js',
-];
 const MAX_MINIFIED_CHUNK_BYTES = 500_000;
+
+const manifest = JSON.parse(await readFile(path.join(distRoot, 'manifest.json'), 'utf8'));
+const requiredEntryFiles = getRequiredReleaseEntryFiles(manifest);
 
 for (const [relativePath, expected] of requiredFiles) {
   const source = await readFile(path.join(distRoot, relativePath), 'utf8');

--- a/scripts/verify-release-dist.mjs
+++ b/scripts/verify-release-dist.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { readFile, readdir, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -13,10 +13,46 @@ const requiredFiles = [
   ['third_party_licenses/BSD-3-Clause-d3.txt', /Copyright 2010-2016 Mike Bostock/],
   ['third_party_licenses/MIT-wordcloud2.txt', /Copyright \(c\) 2011- Timothy Guan-tin Chien/],
 ];
+const requiredEntryFiles = [
+  'background.js',
+  'content/player-monitor.js',
+  'content/sidebar-card.js',
+  'dashboard.js',
+  'popup.js',
+];
+const MAX_MINIFIED_CHUNK_BYTES = 500_000;
 
 for (const [relativePath, expected] of requiredFiles) {
   const source = await readFile(path.join(distRoot, relativePath), 'utf8');
   assert.match(source, expected, `Release distribution notice is invalid: ${relativePath}`);
 }
 
-console.log(`PASS release distribution licenses: ${requiredFiles.length} files`);
+for (const relativePath of requiredEntryFiles) {
+  const entry = await stat(path.join(distRoot, relativePath));
+  assert.ok(entry.isFile(), `Release distribution entry point is missing: ${relativePath}`);
+}
+
+const chunkFiles = await collectJavaScriptFiles(distRoot);
+for (const relativePath of chunkFiles) {
+  const chunk = await stat(path.join(distRoot, relativePath));
+  assert.ok(
+    chunk.size <= MAX_MINIFIED_CHUNK_BYTES,
+    `Minified chunk exceeds ${MAX_MINIFIED_CHUNK_BYTES} bytes: ${relativePath} (${chunk.size})`,
+  );
+}
+
+console.log(
+  `PASS release distribution: ${requiredFiles.length} licenses, ${requiredEntryFiles.length} entries, ${chunkFiles.length} chunks`,
+);
+
+async function collectJavaScriptFiles(directory, relativeDirectory = '') {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = await Promise.all(entries.map(async entry => {
+    const relativePath = path.join(relativeDirectory, entry.name);
+    if (entry.isDirectory()) {
+      return collectJavaScriptFiles(path.join(directory, entry.name), relativePath);
+    }
+    return entry.isFile() && entry.name.endsWith('.js') ? [relativePath] : [];
+  }));
+  return files.flat();
+}

--- a/src/background/api/client.ts
+++ b/src/background/api/client.ts
@@ -1,8 +1,8 @@
-import { API_BASE } from '../../shared/constants';
+import { API_BASE } from '../../shared/constants.ts';
 import type { BiliApiResponse } from '../../shared/types/video-info';
-import { apiRateLimiter } from './rate-limiter';
-import { signWbi } from './wbi-sign';
-import { abortableDelay } from '../utils/abortable-delay';
+import { apiRateLimiter } from './rate-limiter.ts';
+import { signWbi } from './wbi-sign.ts';
+import { abortableDelay } from '../utils/abortable-delay.ts';
 
 const WBI_REQUIRED_CODES = [-403, -400];
 const REQUEST_TIMEOUT_MS = 30_000;

--- a/src/background/api/rate-limiter.ts
+++ b/src/background/api/rate-limiter.ts
@@ -1,5 +1,5 @@
-import { RATE_LIMIT_TOKENS_PER_SEC, RATE_LIMIT_MAX_BURST } from '../../shared/constants';
-import { abortableDelay } from '../utils/abortable-delay';
+import { RATE_LIMIT_TOKENS_PER_SEC, RATE_LIMIT_MAX_BURST } from '../../shared/constants.ts';
+import { abortableDelay } from '../utils/abortable-delay.ts';
 
 export class RateLimiter {
   private tokens: number;

--- a/src/background/api/video-blind-box-candidates.ts
+++ b/src/background/api/video-blind-box-candidates.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../shared/types/analytics';
 import type { FollowedCreator } from '../../shared/types/dynamic-bill';
 import type { WatchHistoryRecord } from '../../shared/types/watch-event';
+import { biliGet } from './client.ts';
 
 const DAY_MS = 86_400_000;
 const RELATED_VIDEO_ENDPOINT = '/x/web-interface/archive/related';
@@ -222,8 +223,6 @@ export async function fetchRelatedVideoCandidates(
   const candidates: ExperimentRealVideoCandidate[] = [];
   const failures: ExperimentRealCandidateFailure[] = [];
   const seenBvids = new Set(selectedSeeds.map(seed => seed.bvid));
-  const { biliGet } = await import('./client.ts');
-
   for (const seed of selectedSeeds) {
     if (options.signal?.aborted) throw new Error('SYNC_CANCELLED');
     const seedController = new AbortController();
@@ -501,8 +500,6 @@ export async function fetchCreatorArchiveCandidatePool(
   let requestFailureCount = 0;
   let excludedRecentSubmissionCount = 0;
   let excludedInvalidCandidateCount = 0;
-  const { biliGet } = await import('./client.ts');
-
   for (const seed of selectedSeeds) {
     try {
       const data = await biliGet<SpaceArchiveResponse>(
@@ -767,7 +764,6 @@ async function requestCrossRegionCandidates(
   params: Record<string, string>,
   signal?: AbortSignal,
 ): Promise<BiliRegionResponse> {
-  const { biliGet } = await import('./client.ts');
   return biliGet<BiliRegionResponse>(endpoint, params, 2, false, signal);
 }
 

--- a/src/background/api/wbi-sign.ts
+++ b/src/background/api/wbi-sign.ts
@@ -1,5 +1,5 @@
-import { NAV_ENDPOINT } from '../../shared/constants';
-import { biliGet } from './client';
+import { NAV_ENDPOINT } from '../../shared/constants.ts';
+import { biliGet } from './client.ts';
 
 const MIXIN_KEY_ENC_TAB = [
   46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35,

--- a/src/background/current-video-transcript-cache.ts
+++ b/src/background/current-video-transcript-cache.ts
@@ -20,6 +20,8 @@ import {
   canUseCurrentVideoTranscriptClearGeneration,
   getCurrentVideoTranscriptClearState,
 } from './current-video-transcript-clear-epoch.ts';
+import { biliGet } from './api/client.ts';
+import { upsertCurrentVideoTranscriptEvidence } from './storage/current-video-transcript-repo.ts';
 
 const SUBTITLE_FETCH_TIMEOUT_MS = 30_000;
 const PLAYER_INFO_ATTEMPTS: Array<PlayerInfoFetchOptions> = [
@@ -276,8 +278,7 @@ async function defaultUpsertEvidence(
     expectedClearGeneration?: number;
   } = {},
 ): Promise<CurrentVideoTranscriptEvidenceState> {
-  const repo = await import('./storage/current-video-transcript-repo.ts');
-  return await repo.upsertCurrentVideoTranscriptEvidence(evidence, options);
+  return await upsertCurrentVideoTranscriptEvidence(evidence, options);
 }
 
 function transcriptClearedDuringRequestState(
@@ -300,7 +301,6 @@ const fetchBilibiliPlayerInfo: CurrentVideoSubtitlePlayerInfoFetcher = async (
   target,
   options,
 ) => {
-  const { biliGet } = await import('./api/client.ts');
   return await biliGet<unknown>(
     options.sourcePath,
     {

--- a/src/shared/echarts/register.ts
+++ b/src/shared/echarts/register.ts
@@ -1,15 +1,11 @@
 import * as echarts from 'echarts/core';
 import wordCloudCustomSeriesInstaller from '@echarts-x/custom-word-cloud';
-import { BarChart, CustomChart, LineChart, PieChart, TreemapChart, HeatmapChart, GaugeChart } from 'echarts/charts';
+import { BarChart, CustomChart, LineChart, PieChart, HeatmapChart, GaugeChart } from 'echarts/charts';
 import {
-  TitleComponent,
   TooltipComponent,
   GridComponent,
   LegendComponent,
   VisualMapComponent,
-  DataZoomComponent,
-  CalendarComponent,
-  GraphicComponent,
 } from 'echarts/components';
 import { CanvasRenderer } from 'echarts/renderers';
 
@@ -19,17 +15,12 @@ echarts.use([
   CustomChart,
   LineChart,
   PieChart,
-  TreemapChart,
   HeatmapChart,
   GaugeChart,
-  TitleComponent,
   TooltipComponent,
   GridComponent,
   LegendComponent,
   VisualMapComponent,
-  DataZoomComponent,
-  CalendarComponent,
-  GraphicComponent,
   CanvasRenderer,
 ]);
 

--- a/tests/background-api-client-wbi.test.ts
+++ b/tests/background-api-client-wbi.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { biliGet } from '../src/background/api/client.ts';
+import { NAV_ENDPOINT } from '../src/shared/constants.ts';
+
+test('WBI-required responses fetch signing material and retry through the static client cycle', async (t) => {
+  const originalFetch = globalThis.fetch;
+  const requests: URL[] = [];
+  const responses = [
+    { code: -403, message: 'WBI signature required', data: null },
+    {
+      code: 0,
+      message: '0',
+      data: {
+        wbi_img: {
+          img_url: 'https://i0.hdslb.com/bfs/wbi/7cd084941338484aae1ad9425b84077c.png',
+          sub_url: 'https://i0.hdslb.com/bfs/wbi/4932caff0ff746eab6f01bf08b70ac45.png',
+        },
+      },
+    },
+    { code: 0, message: '0', data: { accepted: true } },
+  ];
+
+  globalThis.fetch = (async (input, init) => {
+    const request = new URL(String(input));
+    const response = responses[requests.length];
+    assert.ok(response, `Unexpected fetch: ${request}`);
+    assert.equal(init?.credentials, 'include');
+    requests.push(request);
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const result = await biliGet<{ accepted: boolean }>('/x/test/wbi-required', {
+    keyword: 'build hygiene',
+  });
+
+  assert.deepEqual(result, { accepted: true });
+  assert.deepEqual(
+    requests.map(request => request.pathname),
+    ['/x/test/wbi-required', NAV_ENDPOINT, '/x/test/wbi-required'],
+  );
+  assert.equal(requests[0].searchParams.get('w_rid'), null);
+  assert.equal(requests[1].search, '');
+  assert.equal(requests[2].searchParams.get('keyword'), 'build hygiene');
+  assert.match(requests[2].searchParams.get('wts') ?? '', /^\d+$/);
+  assert.match(requests[2].searchParams.get('w_rid') ?? '', /^[a-f0-9]{32}$/);
+});

--- a/tests/release-readiness.test.ts
+++ b/tests/release-readiness.test.ts
@@ -59,6 +59,39 @@ test("the supported ECharts 6 word-cloud integration is registered", async () =>
   assert.ok(!preferenceSource.includes("type: 'wordCloud'"));
 });
 
+test("production build keeps chart vendors bounded and background imports consistent", async () => {
+  const [viteConfigSource, blindBoxSource, transcriptCacheSource, verificationSource] = await Promise.all([
+    readRepositoryFile("vite.config.ts"),
+    readRepositoryFile("src/background/api/video-blind-box-candidates.ts"),
+    readRepositoryFile("src/background/current-video-transcript-cache.ts"),
+    readRepositoryFile("scripts/verify-release-dist.mjs"),
+  ]);
+
+  assert.match(viteConfigSource, /manualChunks: buildVendorChunk/);
+  assert.match(viteConfigSource, /echarts-word-cloud/);
+  assert.match(viteConfigSource, /echarts-renderer/);
+  assert.match(viteConfigSource, /return 'echarts';/);
+  assert.doesNotMatch(viteConfigSource, /chunkSizeWarningLimit/);
+  assert.match(blindBoxSource, /import \{ biliGet \} from '\.\/client\.ts';/);
+  assert.doesNotMatch(blindBoxSource, /await import\('\.\/client\.ts'\)/);
+  assert.match(transcriptCacheSource, /import \{ biliGet \} from '\.\/api\/client\.ts';/);
+  assert.match(
+    transcriptCacheSource,
+    /import \{ upsertCurrentVideoTranscriptEvidence \} from '\.\/storage\/current-video-transcript-repo\.ts';/,
+  );
+  assert.doesNotMatch(transcriptCacheSource, /await import\('\.\/api\/client\.ts'\)/);
+  assert.doesNotMatch(
+    transcriptCacheSource,
+    /await import\('\.\/storage\/current-video-transcript-repo\.ts'\)/,
+  );
+  assert.match(verificationSource, /MAX_MINIFIED_CHUNK_BYTES = 500_000/);
+  assert.match(verificationSource, /'background\.js'/);
+  assert.match(verificationSource, /'content\/player-monitor\.js'/);
+  assert.match(verificationSource, /'content\/sidebar-card\.js'/);
+  assert.match(verificationSource, /'dashboard\.js'/);
+  assert.match(verificationSource, /'popup\.js'/);
+});
+
 test("release builds carry project and third-party licenses", async () => {
   const [packageSource, noticesSource, apacheSource, d3Source, wordCloudSource] =
     await Promise.all([

--- a/tests/release-readiness.test.ts
+++ b/tests/release-readiness.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
+import {
+  collectManifestEntryFiles,
+  getRequiredReleaseEntryFiles,
+  REQUIRED_BUILD_ENTRY_FILES,
+} from "../scripts/release-entry-contract.mjs";
 
 async function readRepositoryFile(path: string): Promise<string> {
   return readFile(new URL(`../${path}`, import.meta.url), "utf8");
@@ -85,11 +90,56 @@ test("production build keeps chart vendors bounded and background imports consis
     /await import\('\.\/storage\/current-video-transcript-repo\.ts'\)/,
   );
   assert.match(verificationSource, /MAX_MINIFIED_CHUNK_BYTES = 500_000/);
-  assert.match(verificationSource, /'background\.js'/);
-  assert.match(verificationSource, /'content\/player-monitor\.js'/);
-  assert.match(verificationSource, /'content\/sidebar-card\.js'/);
-  assert.match(verificationSource, /'dashboard\.js'/);
-  assert.match(verificationSource, /'popup\.js'/);
+  assert.match(verificationSource, /getRequiredReleaseEntryFiles\(manifest\)/);
+});
+
+test("release entry contract covers every manifest-declared runtime entry", async () => {
+  const manifestSource = await readRepositoryFile("public/manifest.json");
+  const manifest = JSON.parse(manifestSource) as {
+    background?: { service_worker?: string };
+    content_scripts?: Array<{ js?: string[] }>;
+    action?: { default_popup?: string };
+    options_page?: string;
+    options_ui?: { page?: string };
+    side_panel?: { default_path?: string };
+    devtools_page?: string;
+    chrome_url_overrides?: Record<string, string>;
+    sandbox?: { pages?: string[] };
+    web_accessible_resources?: Array<{ resources?: string[] }>;
+  };
+  const expectedManifestEntries = [
+    manifest.background?.service_worker,
+    ...(manifest.content_scripts ?? []).flatMap(entry => entry.js ?? []),
+    manifest.action?.default_popup,
+    manifest.options_page,
+    manifest.options_ui?.page,
+    manifest.side_panel?.default_path,
+    manifest.devtools_page,
+    ...Object.values(manifest.chrome_url_overrides ?? {}),
+    ...(manifest.sandbox?.pages ?? []),
+    ...(manifest.web_accessible_resources ?? [])
+      .flatMap(entry => entry.resources ?? [])
+      .filter(resource => !resource.includes("*")),
+  ].filter((entry): entry is string => Boolean(entry)).sort();
+
+  assert.deepEqual(collectManifestEntryFiles(manifest), expectedManifestEntries);
+  assert.deepEqual(
+    getRequiredReleaseEntryFiles(manifest),
+    [...new Set([...expectedManifestEntries, ...REQUIRED_BUILD_ENTRY_FILES])].sort(),
+  );
+});
+
+test("release entry contract ignores wildcard web resources but keeps concrete pages", () => {
+  const manifest = {
+    web_accessible_resources: [{
+      resources: ["assets/*", "dashboard/index.html"],
+    }],
+  };
+
+  assert.deepEqual(collectManifestEntryFiles(manifest), ["dashboard/index.html"]);
+  const requiredEntries = getRequiredReleaseEntryFiles(manifest);
+  assert.ok(requiredEntries.includes("dashboard/index.html"));
+  assert.ok(!requiredEntries.includes("assets/*"));
 });
 
 test("release builds carry project and third-party licenses", async () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,22 @@ const __dirname = path.dirname(__filename);
 
 const resolveRoot = (...segments: string[]) => path.resolve(__dirname, ...segments);
 
+function buildVendorChunk(id: string): string | undefined {
+  const normalizedId = id.replaceAll('\\', '/');
+
+  if (normalizedId.includes('/node_modules/@echarts-x/custom-word-cloud/')) {
+    return 'echarts-word-cloud';
+  }
+  if (normalizedId.includes('/node_modules/zrender/')) {
+    return 'echarts-renderer';
+  }
+  if (normalizedId.includes('/node_modules/echarts/')) {
+    return 'echarts';
+  }
+
+  return undefined;
+}
+
 export default defineConfig({
   root: __dirname,
   esbuild: {
@@ -36,6 +52,8 @@ export default defineConfig({
         entryFileNames: '[name].js',
         chunkFileNames: 'chunks/[name]-[hash].js',
         assetFileNames: 'assets/[name]-[hash].[ext]',
+        // Keep shared chart dependencies cached independently while keeping every output below Vite's warning threshold.
+        manualChunks: buildVendorChunk,
       },
     },
   },


### PR DESCRIPTION
## Summary
- replace the two mixed dynamic/static production imports with consistent static TypeScript imports
- split ECharts renderer and word-cloud dependencies into named chunks and remove unused chart registrations
- derive release entry checks from the built MV3 manifest, including every concrete content/page entry such as `content/page-runtime-bridge.js`, plus the Vite-only popup/dashboard entry contract
- treat wildcard `web_accessible_resources` values such as `assets/*` as resource patterns rather than literal files to `stat()`, while retaining concrete resources such as `dashboard/index.html`
- exercise the WBI-required request path through unsigned request, NAV signing-material fetch, and signed retry

## Baseline note
`src/background/api/client.ts` and `src/background/api/wbi-sign.ts` already statically imported each other on the pre-#206 base. This PR only makes the other mixed imports static; the focused execution test proves the existing cycle initializes and completes the MV3/WBI request path.

## Validation
- rebased onto `origin/main` at TypeScript 7 merge `d6397c5f7662f649d4dea605a062fe19b76c271e`
- `npm ci` (0 vulnerabilities)
- `npx tsc --version` (`7.0.2`)
- `node --test tests/background-api-client-wbi.test.ts tests/release-readiness.test.ts` (8/8)
- `npm test` (485/485)
- `npm run typecheck`
- warning-free `npm run build` (8 concrete required entries, 13 JavaScript outputs; largest output 474,004 bytes)
- `npm audit` (0 vulnerabilities)
- `npm run qa:preference-word-cloud`
- `python tests/qa-0.13-public-page-smoke.py` (MV3 service worker and single/multi-part extension flow)
- `git diff --check`

Closes #206