### PR TITLE
chore(deps): migrate Preact Signals to 2.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@echarts-x/custom-word-cloud": "^1.0.1",
-        "@preact/signals": "^1.3.0",
+        "@preact/signals": "^2.10.1",
         "dexie": "^4.0.0",
         "echarts": "^6.1.0",
-        "preact": "^10.24.0"
+        "preact": "^10.25.0"
       },
       "devDependencies": {
         "@types/chrome": "^0.0.270",
@@ -475,25 +475,25 @@
       }
     },
     "node_modules/@preact/signals": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.4.tgz",
-      "integrity": "sha512-TPMkStdT0QpSc8FpB63aOwXoSiZyIrPsP9Uj347KopdS6olZdAYeeird/5FZv/M1Yc1ge5qstub2o8VDbvkT4g==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.10.1.tgz",
+      "integrity": "sha512-fJfOJ2F6vYiZ7G8ANy/fUDQgPxurE0YS+C+g1cGHxT7b/xLBmvqChu4O2DwuwdS9ywyQ6B3ytBQba/8BJ3V+WQ==",
       "license": "MIT",
       "dependencies": {
-        "@preact/signals-core": "^1.7.0"
+        "@preact/signals-core": "^1.14.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
       },
       "peerDependencies": {
-        "preact": "10.x"
+        "preact": ">= 10.25.0 || >=11.0.0-0"
       }
     },
     "node_modules/@preact/signals-core": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.2.tgz",
-      "integrity": "sha512-RZHdBj9ZF4n40Rp4jS052EHHjBWf96P9oNdXPfhQTovCuWY9iQn3Gq+gOTJSgBO9A/JBuPfMOWsSX/lIU9Pc/A==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "test:video-knowledge": "node --test tests/video-knowledge.test.ts"
   },
   "dependencies": {
-    "preact": "^10.24.0",
-    "@preact/signals": "^1.3.0",
+    "preact": "^10.25.0",
+    "@preact/signals": "^2.10.1",
     "@echarts-x/custom-word-cloud": "^1.0.1",
     "echarts": "^6.1.0",
     "dexie": "^4.0.0"

--- a/tests/current-video-popup.mock-qa.py
+++ b/tests/current-video-popup.mock-qa.py
@@ -108,6 +108,12 @@ def assert_clean_page(page):
     assert not overflow, "popup has horizontal overflow"
 
 
+def assert_quick_stats_signal_render(page):
+    completion_label = page.get_by_text("平均完播率", exact=True)
+    expect(completion_label).to_be_visible()
+    expect(completion_label.locator("..").get_by_text("50%", exact=True)).to_be_visible()
+
+
 def qa_panel(page):
     return page.get_by_text("问这个视频", exact=True).locator("..")
 
@@ -131,6 +137,7 @@ def prepare_qa_preview(page, question):
 def run_manual_exact_flow(page):
     page.route("**/*", route_popup)
     page.goto(POPUP_URL)
+    assert_quick_stats_signal_render(page)
     expect(page.get_by_text("Popup 授权 Mock 视频").first).to_be_visible()
     assert_no_protected_actions(page)
 

--- a/tests/signals-state.test.ts
+++ b/tests/signals-state.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { activeTab } from '../dashboard/signals.ts';
+import {
+  completionPercent,
+  quickStats,
+  todayPercent,
+} from '../popup/signals.ts';
+
+test('dashboard signals retain direct value updates', () => {
+  const previous = activeTab.value;
+
+  try {
+    activeTab.value = 4;
+    assert.equal(activeTab.value, 4);
+  } finally {
+    activeTab.value = previous;
+  }
+});
+
+test('popup computed signals react to QuickStats updates', () => {
+  const previous = quickStats.value;
+
+  try {
+    quickStats.value = {
+      todayWatchTime: 45,
+      dailyGoal: 60,
+      streakDays: 2,
+      avgCompletion: 0.734,
+      efficiencyScore: 80,
+      weeklyWatchTime: 120,
+      weeklyLocalPcWatchTime: 90,
+      weeklyLocalPcDays: 3,
+    };
+
+    assert.equal(completionPercent.value, 73);
+    assert.equal(todayPercent.value, 75);
+  } finally {
+    quickStats.value = previous;
+  }
+});


### PR DESCRIPTION
## What changed

- migrate `@preact/signals` from 1.3.4 / `^1.3.0` to 2.10.1 / `^2.10.1`
- update `@preact/signals-core` transitively from 1.14.2 to 1.14.4
- raise the declared Preact minimum to `^10.25.0`, matching Signals 2's peer contract; the lockfile remains on tested Preact 10.29.8
- add focused signal/computed state coverage and a production popup assertion that `quickStats` updates render `50%` average completion

## Official compatibility review

- [Signals 2.0.0 release notes](https://github.com/preactjs/signals/releases/tag/%40preact%2Fsignals%402.0.0): 2.x defers direct DOM updates and batches them after Preact's render cycle. This makes real rendered-UI coverage important for the migration.
- [Preact Signals guide](https://preactjs.com/guide/v10/signals/): the repository's use of `signal`, `.value`, and `computed` remains within the documented stable API.
- [Signals 2.10.1 release](https://github.com/preactjs/signals/releases/tag/%40preact%2Fsignals%402.10.1) and package peer metadata: Preact must be `>=10.25.0`; this PR aligns the declared range and tested lockfile.

The repository uses only `signal` and `computed`. No hook, transform, or React adapter migration is involved.

## Validation

- focused Signals contract: 2/2
- `npm test`: 481/481
- `npm run typecheck`
- `npm run build`
- current-video popup production mock QA, including rendered QuickStats reactivity and answer/source safety flows
- preference production mock QA: hash-route signal update renders the preference page and nonblank word cloud on desktop/mobile
- Settings local-data/privacy production mock QA
- `npm audit`: 0 vulnerabilities
- `git diff --check`

The existing Vite warnings remain tracked separately by #206.

Closes #210