### PR TITLE
chore(deps): update Chrome type definitions to 0.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "preact": "^10.25.0"
       },
       "devDependencies": {
-        "@types/chrome": "^0.0.270",
+        "@types/chrome": "^0.2.5",
         "fake-indexeddb": "^6.2.5",
         "prettier": "^3.3.0",
         "typescript": "^7.0.2",
@@ -890,9 +890,9 @@
       ]
     },
     "node_modules/@types/chrome": {
-      "version": "0.0.270",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.270.tgz",
-      "integrity": "sha512-ADvkowV7YnJfycZZxL2brluZ6STGW+9oKG37B422UePf2PCXuFA/XdERI0T18wtuWPx0tmFeZqq6MOXVk1IC+Q==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.5.tgz",
+      "integrity": "sha512-DwLFgwj3D0zjxRBhQ3610RBso2g+yI1cakq/JdIGopZ9Bc5UhQluyfcLGZwivFE4t2h4b2QZYZhPV7KylExSbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "typescript": "^7.0.2",
     "vite": "^6.4.3",
-    "@types/chrome": "^0.0.270",
+    "@types/chrome": "^0.2.5",
     "fake-indexeddb": "^6.2.5",
     "prettier": "^3.3.0"
   }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -136,7 +136,7 @@ chrome.action.onClicked.addListener(async () => {
       focused: true,
     });
 
-    if (win.id !== undefined) {
+    if (win?.id !== undefined) {
       await chrome.storage.local.set({ [FLOATING_POPUP_WINDOW_KEY]: win.id });
     }
   });

--- a/src/background/storage/config-store.ts
+++ b/src/background/storage/config-store.ts
@@ -185,7 +185,7 @@ function finiteNumber(value: unknown, fallback: number): number {
 }
 
 export async function getLastSyncTime(): Promise<number> {
-  const result = await chrome.storage.local.get('lastSyncTime');
+  const result = await chrome.storage.local.get<{ lastSyncTime?: number }>('lastSyncTime');
   return result.lastSyncTime ?? 0;
 }
 
@@ -265,7 +265,7 @@ export async function clearOrphanedHistorySyncLock(): Promise<void> {
 }
 
 export async function getBackfillComplete(): Promise<boolean> {
-  const result = await chrome.storage.local.get('backfillComplete');
+  const result = await chrome.storage.local.get<{ backfillComplete?: boolean }>('backfillComplete');
   return result.backfillComplete ?? false;
 }
 
@@ -274,7 +274,7 @@ export async function setBackfillComplete(complete = true): Promise<void> {
 }
 
 export async function getDeviceTypeMigrationComplete(): Promise<boolean> {
-  const result = await chrome.storage.local.get('deviceTypeMigrationComplete');
+  const result = await chrome.storage.local.get<{ deviceTypeMigrationComplete?: boolean }>('deviceTypeMigrationComplete');
   return result.deviceTypeMigrationComplete ?? false;
 }
 


### PR DESCRIPTION
## Summary
- upgrade `@types/chrome` from 0.0.270 to 0.2.5 without changing TypeScript, Vite, Signals, or release metadata
- handle the tightened optional `chrome.windows.create()` result without writing a missing window id
- add narrow `chrome.storage.local.get<T>` result shapes while preserving the existing nullish-default runtime semantics

## Validation on `origin/main@25b9c8c`
- `npm ci` with TypeScript 7.0.2, Signals 2.10.1, Preact 10.29.8, and `@types/chrome` 0.2.5
- focused Chrome/storage plus inherited release checks: 17/17 before the type-only scope rework
- `npm test`: 485/485 after the scope rework
- `npm run typecheck`
- warning-free `npm run build`: 8 required entries, 13 JavaScript outputs
- `npm audit`: 0 vulnerabilities
- ECharts canvas QA, MV3/public-page smoke, popup/current-video QA, and settings privacy QA
- `git diff --check`

## Review notes
- Independent Standards and Spec review both identified the same P2: corrupt stored-scalar normalization changed runtime behavior outside this dependency-only issue.
- That P2 is resolved: the normalization policy and its regression were removed; only narrow result typing remains.
- The `windows.create()` guard remains in the service-worker bootstrap. Extracting bootstrap registration solely for an isolated undefined-result test would expand this dependency-only PR; typecheck, build, CI, popup QA, and MV3 smoke cover the integrated path.
- Manifest-driven extension entry verification is inherited from merged PR #223 and is exercised by both `npm test` and `npm run build`; it is not duplicated here.

Closes #213
