### PR TITLE
fix: restore Bilibili homepage summary card

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,7 @@ jobs:
       - run: npm run qa:preference-word-cloud
         env:
           BILI_BILL_REAL_MOCK_QA_SKIP_BUILD: "1"
+      - run: npm run qa:sidebar-card
+        env:
+          BILI_BILL_REAL_MOCK_QA_SKIP_BUILD: "1"
       - run: npm audit

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "node --test tests/*.test.ts",
     "audit:high": "npm audit --audit-level=high",
     "qa:preference-word-cloud": "python tests/preference-word-cloud.real-mock-qa.py",
+    "qa:sidebar-card": "python tests/sidebar-card.real-mock-qa.py",
     "verify:release-dist": "node scripts/verify-release-dist.mjs",
     "package:release": "npm run build && powershell -NoProfile -ExecutionPolicy Bypass -File scripts/package-release.ps1",
     "test:experiments": "node --test tests/experiment-blind-boxes.test.ts",

--- a/src/content/sidebar-card/index.ts
+++ b/src/content/sidebar-card/index.ts
@@ -1,27 +1,39 @@
 import { buildSidebarCard } from './renderer';
+import { findSidebarAnchor, placeSidebarCard, SIDEBAR_CARD_ID } from './placement';
+
+const INITIAL_DELAY_MS = 2_000;
+const REINJECTION_DELAY_MS = 500;
+const ANCHOR_TIMEOUT_MS = 10_000;
+const ANCHOR_POLL_INTERVAL_MS = 250;
+
+let initializationTimer: ReturnType<typeof setTimeout> | null = null;
+let initializationInFlight: Promise<void> | null = null;
+let injectedCard: HTMLElement | null = null;
+let cachedQuickStats: Parameters<typeof buildSidebarCard>[0] | null = null;
+let retryAfterInitialization = false;
+let navigationGeneration = 0;
 
 function isHomePage(): boolean {
   return location.pathname === '/' || location.pathname === '/index.html';
 }
 
-function waitForElement<T extends Element = Element>(
-  selector: string,
-  timeout = 30_000,
-  interval = 500,
-): Promise<T> {
-  const existing = document.querySelector<T>(selector);
+function waitForSidebarAnchor(
+  timeout = ANCHOR_TIMEOUT_MS,
+  interval = ANCHOR_POLL_INTERVAL_MS,
+): Promise<ReturnType<typeof findSidebarAnchor>> {
+  const existing = findSidebarAnchor();
   if (existing) return Promise.resolve(existing);
 
-  return new Promise((resolve, reject) => {
+  return new Promise(resolve => {
     const start = Date.now();
     const timer = setInterval(() => {
-      const el = document.querySelector<T>(selector);
-      if (el) {
+      const anchor = findSidebarAnchor();
+      if (anchor) {
         clearInterval(timer);
-        resolve(el);
+        resolve(anchor);
       } else if (Date.now() - start > timeout) {
         clearInterval(timer);
-        reject(new Error(`Timeout waiting for element: ${selector}`));
+        resolve(null);
       }
     }, interval);
   });
@@ -29,39 +41,94 @@ function waitForElement<T extends Element = Element>(
 
 async function initializeSidebar(): Promise<void> {
   if (!isHomePage()) return;
+  const generation = navigationGeneration;
 
   try {
-    // Fetch quick stats from background
-    const response = await chrome.runtime.sendMessage({ action: 'GET_QUICK_STATS' });
-    if (!response || !response.success || !response.data) {
-      console.warn('[BiliViz] Failed to get quick stats for sidebar');
+    const existingCard = document.getElementById(SIDEBAR_CARD_ID);
+    if (existingCard instanceof HTMLElement) {
+      injectedCard = existingCard;
       return;
     }
 
-    // Wait for B站 sidebar to be ready
-    const container = await waitForElement('.right-container, .recommend-container, .home-content', 10_000);
+    const anchor = await waitForSidebarAnchor();
+    if (generation !== navigationGeneration || !anchor || !isHomePage()) return;
+    if (!document.contains(anchor.container)) {
+      retryAfterInitialization = true;
+      return;
+    }
 
-    // Check if card already exists
-    if (document.getElementById('bdc-sidebar-card')) return;
+    if (!cachedQuickStats) {
+      const response = await chrome.runtime.sendMessage({ action: 'GET_QUICK_STATS' });
+      if (!response || !response.success || !response.data) {
+        console.warn('[BiliViz] Failed to get quick stats for sidebar');
+        return;
+      }
+      if (generation !== navigationGeneration || !isHomePage()) return;
+      cachedQuickStats = response.data;
+    }
 
-    const card = buildSidebarCard(response.data);
-    container.insertBefore(card, container.firstChild);
-    console.log('[BiliViz] Sidebar card injected');
-  } catch (e) {
-    console.error('[BiliViz] Failed to inject sidebar card:', e);
+    if (generation !== navigationGeneration || !isHomePage()) return;
+    if (!document.contains(anchor.container)) {
+      retryAfterInitialization = true;
+      return;
+    }
+
+    const quickStats = cachedQuickStats;
+    if (!quickStats) return;
+    const card = buildSidebarCard(quickStats);
+    if (placeSidebarCard(document, anchor, card)) {
+      injectedCard = card;
+      console.log('[BiliViz] Sidebar card injected');
+    }
+  } catch {
+    console.warn('[BiliViz] Sidebar card unavailable');
   }
 }
 
-// Run after page settles
-setTimeout(initializeSidebar, 2000);
+function scheduleInitialization(delay: number): void {
+  if (!isHomePage() || initializationTimer || initializationInFlight) return;
+  initializationTimer = setTimeout(() => {
+    initializationTimer = null;
+    initializationInFlight = initializeSidebar().finally(() => {
+      initializationInFlight = null;
+      if (retryAfterInitialization) {
+        retryAfterInitialization = false;
+        scheduleInitialization(REINJECTION_DELAY_MS);
+      }
+    });
+  }, delay);
+}
+
+scheduleInitialization(INITIAL_DELAY_MS);
 
 // Also listen for B站 SPA navigation back to homepage
 let lastPath = location.pathname;
 const navObserver = new MutationObserver(() => {
   if (location.pathname !== lastPath) {
     lastPath = location.pathname;
+    navigationGeneration += 1;
+    cachedQuickStats = null;
+    retryAfterInitialization = false;
+    if (injectedCard && document.contains(injectedCard)) {
+      injectedCard.remove();
+    }
+    injectedCard = null;
     if (isHomePage()) {
-      setTimeout(initializeSidebar, 2000);
+      if (initializationInFlight) {
+        retryAfterInitialization = true;
+      } else {
+        scheduleInitialization(INITIAL_DELAY_MS);
+      }
+    }
+    return;
+  }
+
+  if (isHomePage() && injectedCard && !document.contains(injectedCard)) {
+    injectedCard = null;
+    if (initializationInFlight) {
+      retryAfterInitialization = true;
+    } else {
+      scheduleInitialization(REINJECTION_DELAY_MS);
     }
   }
 });

--- a/src/content/sidebar-card/placement.ts
+++ b/src/content/sidebar-card/placement.ts
@@ -1,0 +1,72 @@
+export const SIDEBAR_CARD_ID = 'bdc-sidebar-card';
+
+export interface SidebarAnchor {
+  container: Element;
+  layout: 'current_feed' | 'legacy';
+}
+
+const CURRENT_FEED_SELECTOR = '.recommended-container_floor-aside > .container';
+const LEGACY_SELECTORS = ['.right-container', '.recommend-container', '.home-content'];
+const FEED_ITEM_SELECTOR = '.feed-card, .bili-video-card, .floor-single-card';
+
+export function findSidebarAnchor(
+  root: Pick<Document, 'querySelector'> = document,
+): SidebarAnchor | null {
+  const currentFeed = root.querySelector(CURRENT_FEED_SELECTOR);
+  if (currentFeed && isValidatedCurrentFeed(currentFeed)) {
+    return { container: currentFeed, layout: 'current_feed' };
+  }
+
+  for (const selector of LEGACY_SELECTORS) {
+    const container = root.querySelector(selector);
+    if (container) {
+      return { container, layout: 'legacy' };
+    }
+  }
+
+  return null;
+}
+
+export function placeSidebarCard(
+  root: Pick<Document, 'getElementById'>,
+  anchor: SidebarAnchor,
+  card: HTMLElement,
+): boolean {
+  if (root.getElementById(SIDEBAR_CARD_ID)) return false;
+
+  if (anchor.layout === 'current_feed') {
+    card.classList.add('bdc-card--feed');
+    const insertionPoint = findFirstFullFeedRow(anchor.container);
+    anchor.container.insertBefore(card, insertionPoint);
+  } else {
+    anchor.container.insertBefore(card, anchor.container.firstChild);
+  }
+
+  return true;
+}
+
+function isValidatedCurrentFeed(container: Element): boolean {
+  const children = Array.from(container.children);
+  const hasCarousel = children.some(child => child.matches('.recommended-swipe'));
+  const feedItemCount = children.filter(isFeedItem).length;
+  return hasCarousel && feedItemCount >= 2;
+}
+
+function findFirstFullFeedRow(container: Element): Element | null {
+  const children = Array.from(container.children);
+  const carousel = children.find(child => child.matches('.recommended-swipe'));
+  if (!carousel) {
+    return children.find(isFeedItem) ?? null;
+  }
+
+  const carouselBottom = carousel.getBoundingClientRect().bottom;
+  return children.find(child => {
+    if (!isFeedItem(child)) return false;
+    const rect = child.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0 && rect.top >= carouselBottom - 1;
+  }) ?? null;
+}
+
+function isFeedItem(element: Element): boolean {
+  return element.matches(FEED_ITEM_SELECTOR);
+}

--- a/src/content/sidebar-card/renderer.ts
+++ b/src/content/sidebar-card/renderer.ts
@@ -1,4 +1,5 @@
 import type { QuickStats } from '../../shared/types/analytics';
+import { SIDEBAR_CARD_ID } from './placement';
 
 const STYLE_ID = 'bdc-sidebar-styles';
 
@@ -11,6 +12,12 @@ const CSS = `
   color: #e0e0e0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans SC", sans-serif;
   box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+}
+.bdc-card--feed {
+  align-self: stretch;
+  box-sizing: border-box;
+  min-width: 0;
+  margin-bottom: 0;
 }
 .bdc-card-header {
   font-size: 15px;
@@ -87,7 +94,7 @@ export function buildSidebarCard(data: QuickStats): HTMLElement {
 
   const card = document.createElement('div');
   card.className = 'bdc-card';
-  card.id = 'bdc-sidebar-card';
+  card.id = SIDEBAR_CARD_ID;
 
   card.innerHTML = `
     <div class="bdc-card-header">本周消费小结</div>

--- a/tests/sidebar-card-placement.test.ts
+++ b/tests/sidebar-card-placement.test.ts
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  findSidebarAnchor,
+  placeSidebarCard,
+  SIDEBAR_CARD_ID,
+} from '../src/content/sidebar-card/placement.ts';
+
+interface RectInit {
+  top?: number;
+  width?: number;
+  height?: number;
+}
+
+class FakeClassList {
+  readonly values = new Set<string>();
+
+  add(value: string): void {
+    this.values.add(value);
+  }
+}
+
+class FakeElement {
+  readonly classList = new FakeClassList();
+  readonly children: FakeElement[] = [];
+  readonly classes: string[];
+  private readonly rect: RectInit;
+  id = '';
+
+  constructor(classes: string[] = [], rect: RectInit = {}) {
+    this.classes = classes;
+    this.rect = rect;
+  }
+
+  get firstChild(): FakeElement | null {
+    return this.children[0] ?? null;
+  }
+
+  matches(selector: string): boolean {
+    return selector.split(',').some(candidate => {
+      const className = candidate.trim().replace(/^\./, '');
+      return this.classes.includes(className);
+    });
+  }
+
+  getBoundingClientRect(): DOMRect {
+    const top = this.rect.top ?? 0;
+    const width = this.rect.width ?? 240;
+    const height = this.rect.height ?? 200;
+    return {
+      x: 0,
+      y: top,
+      top,
+      right: width,
+      bottom: top + height,
+      left: 0,
+      width,
+      height,
+      toJSON: () => ({}),
+    } as DOMRect;
+  }
+
+  insertBefore(newChild: FakeElement, referenceChild: FakeElement | null): FakeElement {
+    if (referenceChild === null) {
+      this.children.push(newChild);
+      return newChild;
+    }
+    const index = this.children.indexOf(referenceChild);
+    assert.notEqual(index, -1);
+    this.children.splice(index, 0, newChild);
+    return newChild;
+  }
+}
+
+class FakeDocument {
+  private readonly selectors: Record<string, FakeElement | undefined>;
+  private readonly existingCard: FakeElement | null;
+
+  constructor(
+    selectors: Record<string, FakeElement | undefined>,
+    existingCard: FakeElement | null = null,
+  ) {
+    this.selectors = selectors;
+    this.existingCard = existingCard;
+  }
+
+  querySelector(selector: string): Element | null {
+    return (this.selectors[selector] ?? null) as unknown as Element | null;
+  }
+
+  getElementById(id: string): HTMLElement | null {
+    return id === SIDEBAR_CARD_ID
+      ? this.existingCard as unknown as HTMLElement | null
+      : null;
+  }
+}
+
+test('selects the validated current Bilibili feed before legacy fallbacks', () => {
+  const current = new FakeElement();
+  current.children.push(
+    new FakeElement(['recommended-swipe']),
+    new FakeElement(['feed-card']),
+    new FakeElement(['bili-video-card']),
+  );
+  const legacy = new FakeElement();
+  const document = new FakeDocument({
+    '.recommended-container_floor-aside > .container': current,
+    '.right-container': legacy,
+  });
+
+  const anchor = findSidebarAnchor(document);
+
+  assert.equal(anchor?.layout, 'current_feed');
+  assert.equal(anchor?.container, current as unknown as Element);
+});
+
+test('rejects an unvalidated current container and keeps the legacy fallback', () => {
+  const unvalidated = new FakeElement();
+  unvalidated.children.push(new FakeElement(['feed-card']));
+  const legacy = new FakeElement();
+  const document = new FakeDocument({
+    '.recommended-container_floor-aside > .container': unvalidated,
+    '.recommend-container': legacy,
+  });
+
+  const anchor = findSidebarAnchor(document);
+
+  assert.equal(anchor?.layout, 'legacy');
+  assert.equal(anchor?.container, legacy as unknown as Element);
+});
+
+test('returns no anchor when neither a validated current feed nor a legacy container exists', () => {
+  const document = new FakeDocument({});
+  assert.equal(findSidebarAnchor(document), null);
+});
+
+test('places the card at the first complete feed row after the current carousel', () => {
+  const container = new FakeElement();
+  const carousel = new FakeElement(['recommended-swipe'], { top: 100, height: 400 });
+  const topRow = new FakeElement(['feed-card'], { top: 100 });
+  const secondRow = new FakeElement(['feed-card'], { top: 320 });
+  const firstFullRow = new FakeElement(['feed-card'], { top: 540 });
+  container.children.push(carousel, topRow, secondRow, firstFullRow);
+  const card = new FakeElement();
+  const document = new FakeDocument({});
+
+  const inserted = placeSidebarCard(
+    document,
+    { container: container as unknown as Element, layout: 'current_feed' },
+    card as unknown as HTMLElement,
+  );
+
+  assert.equal(inserted, true);
+  assert.equal(container.children.indexOf(card), 3);
+  assert.equal(container.children[4], firstFullRow);
+  assert.equal(card.classList.values.has('bdc-card--feed'), true);
+});
+
+test('places the card first in a legacy sidebar container', () => {
+  const container = new FakeElement();
+  const existingChild = new FakeElement();
+  const card = new FakeElement();
+  container.children.push(existingChild);
+  const document = new FakeDocument({});
+
+  const inserted = placeSidebarCard(
+    document,
+    { container: container as unknown as Element, layout: 'legacy' },
+    card as unknown as HTMLElement,
+  );
+
+  assert.equal(inserted, true);
+  assert.deepEqual(container.children, [card, existingChild]);
+  assert.equal(card.classList.values.has('bdc-card--feed'), false);
+});
+
+test('does not insert a duplicate card', () => {
+  const container = new FakeElement();
+  const existing = new FakeElement();
+  const card = new FakeElement();
+  const document = new FakeDocument({}, existing);
+
+  const inserted = placeSidebarCard(
+    document,
+    { container: container as unknown as Element, layout: 'legacy' },
+    card as unknown as HTMLElement,
+  );
+
+  assert.equal(inserted, false);
+  assert.equal(container.children.length, 0);
+});

--- a/tests/sidebar-card.real-mock-qa.py
+++ b/tests/sidebar-card.real-mock-qa.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import mimetypes
+import os
+from pathlib import Path
+import subprocess
+from urllib.parse import urlparse
+
+from playwright.sync_api import expect, sync_playwright
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DIST = ROOT / "dist"
+SIDEBAR_BUNDLE = DIST / "content" / "sidebar-card.js"
+QA_URL = "http://bilibili-home.mock/"
+FORBIDDEN_VISIBLE_TERMS = [
+    "未消费",
+    "猜你喜欢",
+    "fallback",
+    "transcript",
+    "confidence",
+    "sourceHash",
+    "segmentId",
+    "subtitle_url",
+    "document is not defined",
+    "ReferenceError",
+]
+
+
+def main() -> None:
+    ensure_sidebar_bundle()
+    run_browser_qa()
+    print("PASS sidebar-card.real-mock-qa: current feed placement, reinjection, and dashboard action")
+
+
+def ensure_sidebar_bundle() -> None:
+    if os.environ.get("BILI_BILL_REAL_MOCK_QA_SKIP_BUILD") == "1":
+        if not SIDEBAR_BUNDLE.exists():
+            raise AssertionError("dist/content/sidebar-card.js is missing. Run npm run build first.")
+        return
+
+    npm = "npm.cmd" if os.name == "nt" else "npm"
+    result = subprocess.run(
+        [npm, "run", "build"],
+        cwd=ROOT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=180,
+    )
+    if result.returncode != 0:
+        raise AssertionError("npm run build failed before sidebar QA:\n" + result.stdout[-8000:])
+
+
+def run_browser_qa() -> None:
+    console_errors: list[str] = []
+    page_errors: list[str] = []
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        page = browser.new_page(viewport={"width": 1280, "height": 900}, locale="zh-CN")
+        page.on(
+            "console",
+            lambda message: console_errors.append(message.text) if message.type == "error" else None,
+        )
+        page.on("pageerror", lambda error: page_errors.append(str(error)))
+        page.add_init_script(chrome_mock_script())
+        page.route("**/*", route_mock_home)
+
+        page.goto(QA_URL, wait_until="networkidle")
+        card = page.locator("#bdc-sidebar-card")
+        expect(card).to_have_count(1, timeout=15_000)
+        expect(card).to_be_visible()
+        expect(card).to_have_class("bdc-card bdc-card--feed")
+        assert_card_starts_after_carousel(page)
+        assert_no_horizontal_overflow(page)
+        assert_clean_visible_copy(page)
+
+        page.get_by_text("查看完整面板 →", exact=True).click()
+        opened_url = page.evaluate("globalThis.__sidebarQaOpenedUrl")
+        if opened_url != "chrome-extension://sidebar-qa/dashboard/index.html":
+            raise AssertionError(f"Unexpected dashboard URL: {opened_url}")
+
+        page.evaluate("document.querySelector('#bdc-sidebar-card').remove()")
+        expect(page.locator("#bdc-sidebar-card")).to_have_count(1, timeout=5_000)
+        send_count = page.evaluate("globalThis.__sidebarQaSendCount")
+        if send_count != 1:
+            raise AssertionError(f"Same-page reinjection reread quick stats: {send_count}")
+
+        page.evaluate("document.body.appendChild(document.createElement('span'))")
+        page.wait_for_timeout(800)
+        expect(page.locator("#bdc-sidebar-card")).to_have_count(1)
+
+        race_page = browser.new_page(viewport={"width": 1280, "height": 900})
+        race_console_errors: list[str] = []
+        race_page.on(
+            "console",
+            lambda message: race_console_errors.append(message.text)
+            if message.type == "error"
+            else None,
+        )
+        race_page.add_init_script(chrome_mock_script())
+        race_page.route("**/*", route_mock_home)
+        race_page.goto(f"{QA_URL}?mode=initialization-race", wait_until="networkidle")
+        race_page.wait_for_function("typeof globalThis.__sidebarQaReleaseStats === 'function'", timeout=10_000)
+        race_page.evaluate(
+            """() => {
+              const current = document.querySelector('.recommended-container_floor-aside > .container');
+              current.replaceWith(current.cloneNode(true));
+              globalThis.__sidebarQaReleaseStats();
+            }"""
+        )
+        expect(race_page.locator("#bdc-sidebar-card")).to_have_count(1, timeout=5_000)
+        if race_console_errors:
+            raise AssertionError(f"Sidebar initialization-race console errors: {race_console_errors}")
+        race_page.close()
+
+        navigation_page = browser.new_page(viewport={"width": 1280, "height": 900})
+        navigation_console_errors: list[str] = []
+        navigation_page.on(
+            "console",
+            lambda message: navigation_console_errors.append(message.text)
+            if message.type == "error"
+            else None,
+        )
+        navigation_page.add_init_script(chrome_mock_script())
+        navigation_page.route("**/*", route_mock_home)
+        navigation_page.goto(f"{QA_URL}?mode=navigation-race", wait_until="networkidle")
+        navigation_page.wait_for_function(
+            "typeof globalThis.__sidebarQaReleaseStats === 'function'",
+            timeout=10_000,
+        )
+        navigation_page.evaluate(
+            """() => {
+              history.pushState({}, '', '/away?mode=navigation-race');
+              document.body.appendChild(document.createElement('span'));
+            }"""
+        )
+        navigation_page.wait_for_timeout(100)
+        navigation_page.evaluate(
+            """() => {
+              history.pushState({}, '', '/?mode=navigation-race');
+              document.body.appendChild(document.createElement('span'));
+            }"""
+        )
+        navigation_page.wait_for_timeout(100)
+        navigation_page.evaluate("globalThis.__sidebarQaReleaseStats()")
+        expect(navigation_page.locator("#bdc-sidebar-card")).to_have_count(1, timeout=7_000)
+        expect(navigation_page.locator(".bdc-stat-value").first).to_have_text("2小时")
+        navigation_send_count = navigation_page.evaluate("globalThis.__sidebarQaSendCount")
+        if navigation_send_count != 2:
+            raise AssertionError(
+                f"Navigation did not discard and refresh the stale stats request: {navigation_send_count}"
+            )
+        if navigation_console_errors:
+            raise AssertionError(
+                f"Sidebar navigation-race console errors: {navigation_console_errors}"
+            )
+        navigation_page.close()
+
+        if console_errors:
+            raise AssertionError(f"Sidebar QA console errors: {console_errors}")
+        if page_errors:
+            raise AssertionError(f"Sidebar QA page errors: {page_errors}")
+
+        browser.close()
+
+
+def route_mock_home(route) -> None:
+    parsed = urlparse(route.request.url)
+    if parsed.path == "/":
+        route.fulfill(status=200, content_type="text/html; charset=utf-8", body=mock_home_html())
+        return
+
+    local_path = DIST / parsed.path.lstrip("/")
+    if local_path.exists() and local_path.is_file():
+        content_type = mimetypes.guess_type(local_path.name)[0] or "application/octet-stream"
+        route.fulfill(status=200, content_type=content_type, body=local_path.read_bytes())
+        return
+
+    route.fulfill(status=404, body="not found")
+
+
+def assert_card_starts_after_carousel(page) -> None:
+    positions = page.evaluate(
+        """() => {
+          const carousel = document.querySelector('.recommended-swipe').getBoundingClientRect();
+          const card = document.querySelector('#bdc-sidebar-card').getBoundingClientRect();
+          return { carouselBottom: carousel.bottom, cardTop: card.top };
+        }"""
+    )
+    if positions["cardTop"] < positions["carouselBottom"] - 1:
+        raise AssertionError(f"Sidebar card interrupted the featured carousel rows: {positions}")
+
+
+def assert_no_horizontal_overflow(page) -> None:
+    dimensions = page.evaluate(
+        """() => ({
+          clientWidth: document.documentElement.clientWidth,
+          scrollWidth: document.documentElement.scrollWidth,
+        })"""
+    )
+    if dimensions["scrollWidth"] > dimensions["clientWidth"] + 1:
+        raise AssertionError(f"Sidebar card caused horizontal overflow: {dimensions}")
+
+
+def assert_clean_visible_copy(page) -> None:
+    visible = page.locator("body").inner_text()
+    for term in FORBIDDEN_VISIBLE_TERMS:
+        if term.lower() in visible.lower():
+            raise AssertionError(f"Visible sidebar copy leaked forbidden term: {term}")
+
+
+def chrome_mock_script() -> str:
+    return """
+      globalThis.__sidebarQaSendCount = 0;
+      globalThis.__sidebarQaOpenedUrl = null;
+      globalThis.chrome = {
+        runtime: {
+          sendMessage: async message => {
+            if (message?.action !== 'GET_QUICK_STATS') {
+              return { success: false };
+            }
+            globalThis.__sidebarQaSendCount += 1;
+            const requestNumber = globalThis.__sidebarQaSendCount;
+            if (
+              location.search.includes('mode=initialization-race')
+              || (location.search.includes('mode=navigation-race') && requestNumber === 1)
+            ) {
+              await new Promise(resolve => {
+                globalThis.__sidebarQaReleaseStats = resolve;
+              });
+            }
+            return {
+              success: true,
+              data: {
+                todayWatchTime: location.search.includes('mode=navigation-race')
+                  ? (requestNumber === 1 ? 60 : 7200)
+                  : 3720,
+                streakDays: 6,
+                efficiencyScore: 82,
+              },
+            };
+          },
+          getURL: path => `chrome-extension://sidebar-qa/${path}`,
+        },
+      };
+      window.open = url => {
+        globalThis.__sidebarQaOpenedUrl = url;
+        return null;
+      };
+    """
+
+
+def mock_home_html() -> str:
+    cards = "".join(f'<div class="feed-card">视频 {index}</div>' for index in range(1, 9))
+    return f"""<!doctype html>
+      <html lang="zh-CN">
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <style>
+            * {{ box-sizing: border-box; }}
+            body {{ margin: 0; background: #f4f6f8; }}
+            .recommended-container_floor-aside {{ padding: 32px; }}
+            .container {{
+              display: grid;
+              grid-template-columns: repeat(4, minmax(0, 1fr));
+              gap: 20px;
+              max-width: 1120px;
+              margin: 0 auto;
+            }}
+            .recommended-swipe {{
+              grid-column: 1 / 3;
+              grid-row: 1 / 3;
+              min-height: 420px;
+              background: #dbeafe;
+            }}
+            .feed-card {{ min-height: 200px; background: white; }}
+          </style>
+        </head>
+        <body>
+          <main class="bili-feed4-layout">
+            <div class="feed2">
+              <div class="recommended-container_floor-aside">
+                <div class="container">
+                  <div class="recommended-swipe">首页轮播</div>
+                  {cards}
+                </div>
+              </div>
+            </div>
+          </main>
+          <script src="/content/sidebar-card.js"></script>
+        </body>
+      </html>"""
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- recognize the current Bilibili homepage feed only after validating its featured carousel and direct feed items
- place the Bili-Bill consumption summary at the first complete grid row after the carousel without breaking responsive layout
- retain bounded legacy sidebar fallbacks and fail quietly when no trusted anchor exists
- prevent duplicate injection and restore the card after same-page host rerenders, including a feed replacement while the initial stats request is in flight
- reuse already-loaded quick stats for same-page reinjection; bind requests to a navigation generation so late pre-navigation responses are discarded and return-to-home refreshes
- add focused placement tests and a production-bundle Playwright QA enforced by CI

## Validation
- focused sidebar placement tests: 6/6
- `npm test`: 492/492
- `npm run typecheck`
- warning-free `npm run build`: 8 required entries, 14 JavaScript outputs
- `npm run qa:sidebar-card`: current grid placement, unique injection, ordinary reinjection, in-flight container replacement, cross-navigation stale-response rejection, dashboard action, overflow and visible-copy checks
- `npm audit --audit-level=high`: 0 vulnerabilities
- `git diff --check`
- clean temporary Edge profile on the live anonymous Bilibili homepage: one visible card; direct child of the current feed grid; card top below the featured carousel; zero horizontal overflow; dashboard opened; no page error

## Scope
- no release metadata, tag, package version, permission, API, AI, current-video, Dynamic Bill, or data-schema changes
- no Cookie, browser profile, login-state, credential, or key file was read

Closes #228


