### PR TITLE
build: include production dependency licenses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       - run: npm run typecheck
       - run: node scripts/dev-build.mjs --smoke
       - run: npm run build
+      - run: ./scripts/package-release.ps1
+        shell: pwsh
       - run: npm run qa:preference-word-cloud
         env:
           BILI_BILL_REAL_MOCK_QA_SKIP_BUILD: "1"

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -2,7 +2,22 @@ Bili-Bill third-party notices
 ================================
 
 This distribution includes the following third-party software.
-The complete license texts are provided in third_party_licenses/.
+The complete license and NOTICE texts are provided in third_party_licenses/.
+
+Production npm packages
+-----------------------
+
+- @echarts-x/custom-word-cloud 1.0.1 | License: Apache-2.0 | Lock path: node_modules/@echarts-x/custom-word-cloud
+- @preact/signals 2.10.1 | License: MIT | Lock path: node_modules/@preact/signals
+- @preact/signals-core 1.14.4 | License: MIT | Lock path: node_modules/@preact/signals-core
+- dexie 4.4.4 | License: Apache-2.0 | Lock path: node_modules/dexie
+- echarts 6.1.0 | License: Apache-2.0 | Lock path: node_modules/echarts
+- preact 10.29.8 | License: MIT | Lock path: node_modules/preact
+- tslib 2.3.0 | License: 0BSD | Lock path: node_modules/tslib
+- zrender 6.1.0 | License: BSD-3-Clause | Lock path: node_modules/zrender
+
+Exact upstream license and NOTICE files for these packages are copied from the
+installed lockfile versions into third_party_licenses/npm/ during every build.
 
 Apache ECharts 6.1.0
 --------------------
@@ -36,3 +51,4 @@ License files
 - Apache-2.0.txt: Apache License 2.0
 - BSD-3-Clause-d3.txt: d3.js license and copyright notice
 - MIT-wordcloud2.txt: wordcloud2.js license and copyright notice
+- npm/: exact license and NOTICE files for every production npm package

--- a/scripts/copy-release-licenses.mjs
+++ b/scripts/copy-release-licenses.mjs
@@ -1,6 +1,13 @@
-import { cp, copyFile, mkdir } from 'node:fs/promises';
+import { cp, copyFile, mkdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  collectPackageAttributionFiles,
+  collectProductionPackages,
+  getDeclaredLicense,
+  getPackageLicenseDirectory,
+  isLicenseFilePath,
+} from './production-license-contract.mjs';
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const distRoot = path.join(repositoryRoot, 'dist');
@@ -16,3 +23,40 @@ await cp(
   path.join(distRoot, 'third_party_licenses'),
   { recursive: true },
 );
+
+const packageLock = JSON.parse(
+  await readFile(path.join(repositoryRoot, 'package-lock.json'), 'utf8'),
+);
+
+for (const packageRecord of collectProductionPackages(packageLock)) {
+  const packageRoot = path.join(repositoryRoot, ...packageRecord.location.split('/'));
+  const packageMetadata = JSON.parse(
+    await readFile(path.join(packageRoot, 'package.json'), 'utf8'),
+  );
+  if (
+    packageMetadata.name !== packageRecord.name ||
+    packageMetadata.version !== packageRecord.version
+  ) {
+    throw new Error(
+      `Installed package does not match lockfile: ${packageRecord.name}@${packageRecord.version}`,
+    );
+  }
+  const packageLabel = `${packageRecord.name}@${packageRecord.version} (${packageRecord.location})`;
+  const declaredLicense = getDeclaredLicense(packageMetadata, packageLabel);
+  if (packageRecord.license && packageRecord.license !== declaredLicense) {
+    throw new Error(`Installed package license does not match lockfile: ${packageLabel}`);
+  }
+
+  const attributionFiles = await collectPackageAttributionFiles(packageRoot);
+  if (!attributionFiles.some(isLicenseFilePath)) {
+    throw new Error(`Production package has no license file: ${packageLabel}`);
+  }
+
+  const destination = path.join(distRoot, getPackageLicenseDirectory(packageRecord));
+  await mkdir(destination, { recursive: true });
+  await Promise.all(attributionFiles.map(async relativePath => {
+    const target = path.join(destination, ...relativePath.split('/'));
+    await mkdir(path.dirname(target), { recursive: true });
+    await copyFile(path.join(packageRoot, ...relativePath.split('/')), target);
+  }));
+}

--- a/scripts/package-release.ps1
+++ b/scripts/package-release.ps1
@@ -222,7 +222,7 @@ Assert-NotReparsePoint -Path $artifactRoot
 $token = [guid]::NewGuid().ToString('N')
 $temporaryZipPath = Assert-ChildPath -Root $artifactRoot -Path (Join-Path $artifactRoot ".$zipName.$token.tmp")
 $temporaryShaPath = Assert-ChildPath -Root $artifactRoot -Path "$temporaryZipPath.sha256"
-$systemTempRoot = [IO.Path]::GetFullPath($env:TEMP).TrimEnd([IO.Path]::DirectorySeparatorChar)
+$systemTempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath()).TrimEnd([IO.Path]::DirectorySeparatorChar)
 $auditRoot = Assert-ChildPath -Root $systemTempRoot -Path (Join-Path $systemTempRoot ("bili-bill-release-audit-$token"))
 
 try {

--- a/scripts/production-license-contract.mjs
+++ b/scripts/production-license-contract.mjs
@@ -1,0 +1,116 @@
+import { createHash } from 'node:crypto';
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const ATTRIBUTION_DIRECTORY_PATTERN = /^(?:licenses?|licences?|notices?|legal)$/i;
+const ATTRIBUTION_NAME_PATTERN = /(?:^|[-_.])(?:licen[cs]e|notices?|copying|copyright(?:notices?)?|authors?)(?:$|[-_.])/i;
+const LICENSE_NAME_PATTERN = /(?:^|[-_.])(?:licen[cs]e|copying)(?:$|[-_.])/i;
+
+export function collectProductionPackages(packageLock) {
+  if (!packageLock?.packages || typeof packageLock.packages !== 'object') {
+    throw new TypeError('package-lock.json does not contain a packages map');
+  }
+
+  const packages = [];
+  for (const [location, metadata] of Object.entries(packageLock.packages)) {
+    if (!location.startsWith('node_modules/') || metadata?.dev === true) continue;
+    assertSafePackageLocation(location);
+    if (typeof metadata?.version !== 'string' || metadata.version.length === 0) {
+      throw new TypeError(`Production package is missing a version: ${location}`);
+    }
+
+    packages.push({
+      name: packageNameFromLocation(location),
+      version: metadata.version,
+      location,
+      license: typeof metadata.license === 'string' ? metadata.license : null,
+      resolved: typeof metadata.resolved === 'string' ? metadata.resolved : null,
+      integrity: typeof metadata.integrity === 'string' ? metadata.integrity : null,
+    });
+  }
+
+  return packages.sort((left, right) => left.location.localeCompare(right.location));
+}
+
+export function getPackageLicenseDirectory(packageRecord) {
+  const packageSlug = safePathSegment(packageRecord.name);
+  const versionSlug = safePathSegment(packageRecord.version);
+  const locationDigest = createHash('sha256')
+    .update(packageRecord.location)
+    .digest('hex')
+    .slice(0, 16);
+  return path.posix.join(
+    'third_party_licenses',
+    'npm',
+    `package-${packageSlug}`,
+    `version-${versionSlug}`,
+    `location-${locationDigest}`,
+  );
+}
+
+export function getPackageNoticeLine(packageRecord, declaredLicense) {
+  return `- ${packageRecord.name} ${packageRecord.version} | License: ${declaredLicense} | Lock path: ${packageRecord.location}`;
+}
+
+export function getDeclaredLicense(packageMetadata, packageLabel) {
+  if (typeof packageMetadata?.license !== 'string' || packageMetadata.license.trim().length === 0) {
+    throw new TypeError(`Production package has no declared license: ${packageLabel}`);
+  }
+  return packageMetadata.license.trim();
+}
+
+export async function collectPackageAttributionFiles(packageRoot, relativeDirectory = '') {
+  const entries = await readdir(path.join(packageRoot, relativeDirectory), { withFileTypes: true });
+  const files = await Promise.all(entries.map(async entry => {
+    const relativePath = path.posix.join(relativeDirectory.replaceAll('\\', '/'), entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules') return [];
+      return collectPackageAttributionFiles(packageRoot, relativePath);
+    }
+    return entry.isFile() && isAttributionFilePath(relativePath) ? [relativePath] : [];
+  }));
+  return files.flat().sort();
+}
+
+export function isAttributionFilePath(relativePath) {
+  const segments = relativePath.replaceAll('\\', '/').split('/');
+  const fileName = segments.at(-1) ?? '';
+  return (
+    ATTRIBUTION_NAME_PATTERN.test(fileName)
+    || segments.slice(0, -1).some(segment => ATTRIBUTION_DIRECTORY_PATTERN.test(segment))
+  );
+}
+
+export function isLicenseFilePath(relativePath) {
+  const segments = relativePath.replaceAll('\\', '/').split('/');
+  const fileName = segments.at(-1) ?? '';
+  return (
+    LICENSE_NAME_PATTERN.test(fileName)
+    || segments.slice(0, -1).some(segment => /^(?:licenses?|licences?)$/i.test(segment))
+  );
+}
+
+function packageNameFromLocation(location) {
+  const marker = 'node_modules/';
+  const markerIndex = location.lastIndexOf(marker);
+  const name = location.slice(markerIndex + marker.length);
+  if (!name || name === '@' || name.endsWith('/')) {
+    throw new TypeError(`Cannot derive package name from lockfile location: ${location}`);
+  }
+  return name;
+}
+
+function assertSafePackageLocation(location) {
+  const segments = location.split('/');
+  if (
+    location.includes('\\')
+    || segments.some(segment => segment === '' || segment === '.' || segment === '..')
+  ) {
+    throw new TypeError(`Unsafe package-lock location: ${location}`);
+  }
+}
+
+function safePathSegment(value) {
+  const segment = value.replace(/[^0-9A-Za-z._-]+/g, '-').replace(/^-+|-+$/g, '');
+  return segment || 'unnamed';
+}

--- a/scripts/verify-release-dist.mjs
+++ b/scripts/verify-release-dist.mjs
@@ -7,6 +7,14 @@ import {
   collectManifestContentScriptFiles,
   getRequiredReleaseEntryFiles,
 } from './release-entry-contract.mjs';
+import {
+  collectPackageAttributionFiles,
+  collectProductionPackages,
+  getDeclaredLicense,
+  getPackageLicenseDirectory,
+  getPackageNoticeLine,
+  isLicenseFilePath,
+} from './production-license-contract.mjs';
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const distRoot = path.join(repositoryRoot, 'dist');
@@ -21,11 +29,59 @@ const requiredFiles = [
 const MAX_MINIFIED_CHUNK_BYTES = 500_000;
 
 const manifest = JSON.parse(await readFile(path.join(distRoot, 'manifest.json'), 'utf8'));
+const packageLock = JSON.parse(
+  await readFile(path.join(repositoryRoot, 'package-lock.json'), 'utf8'),
+);
+const thirdPartyNotices = await readFile(path.join(distRoot, 'THIRD_PARTY_NOTICES.txt'), 'utf8');
+const thirdPartyNoticeLines = new Set(thirdPartyNotices.split(/\r?\n/).map(line => line.trim()));
 const requiredEntryFiles = getRequiredReleaseEntryFiles(manifest);
+let productionAttributionFileCount = 0;
 
 for (const [relativePath, expected] of requiredFiles) {
   const source = await readFile(path.join(distRoot, relativePath), 'utf8');
   assert.match(source, expected, `Release distribution notice is invalid: ${relativePath}`);
+}
+
+for (const packageRecord of collectProductionPackages(packageLock)) {
+  const packageLabel = `${packageRecord.name} ${packageRecord.version}`;
+  const packageRoot = path.join(repositoryRoot, ...packageRecord.location.split('/'));
+  const packageMetadata = JSON.parse(
+    await readFile(path.join(packageRoot, 'package.json'), 'utf8'),
+  );
+  assert.equal(packageMetadata.name, packageRecord.name, `Installed package name changed: ${packageLabel}`);
+  assert.equal(
+    packageMetadata.version,
+    packageRecord.version,
+    `Installed package version changed: ${packageLabel}`,
+  );
+  const declaredLicense = getDeclaredLicense(packageMetadata, packageLabel);
+  if (packageRecord.license && packageRecord.license !== declaredLicense) {
+    throw new Error(`Installed package license does not match lockfile: ${packageLabel}`);
+  }
+  assert.ok(
+    thirdPartyNoticeLines.has(getPackageNoticeLine(packageRecord, declaredLicense)),
+    `Third-party notices omit or misstate production package license: ${packageLabel}`,
+  );
+
+  const attributionFiles = await collectPackageAttributionFiles(packageRoot);
+  assert.ok(
+    attributionFiles.some(isLicenseFilePath),
+    `Production package has no source license file: ${packageLabel}`,
+  );
+
+  const releaseDirectory = getPackageLicenseDirectory(packageRecord);
+  for (const relativePath of attributionFiles) {
+    const [source, released] = await Promise.all([
+      readFile(path.join(packageRoot, ...relativePath.split('/'))),
+      readFile(path.join(distRoot, releaseDirectory, ...relativePath.split('/'))),
+    ]);
+    assert.deepEqual(
+      released,
+      source,
+      `Release distribution changed ${packageLabel} ${relativePath}`,
+    );
+    productionAttributionFileCount += 1;
+  }
 }
 
 for (const relativePath of requiredEntryFiles) {
@@ -51,17 +107,19 @@ for (const relativePath of chunkFiles) {
 }
 
 console.log(
-  `PASS release distribution: ${requiredFiles.length} licenses, ${requiredEntryFiles.length} entries, ${chunkFiles.length} chunks`,
+  `PASS release distribution: ${requiredFiles.length + productionAttributionFileCount} license/notice files, ${requiredEntryFiles.length} entries, ${chunkFiles.length} chunks`,
 );
 
 async function collectJavaScriptFiles(directory, relativeDirectory = '') {
   const entries = await readdir(directory, { withFileTypes: true });
-  const files = await Promise.all(entries.map(async entry => {
-    const relativePath = path.join(relativeDirectory, entry.name);
-    if (entry.isDirectory()) {
-      return collectJavaScriptFiles(path.join(directory, entry.name), relativePath);
-    }
-    return entry.isFile() && entry.name.endsWith('.js') ? [relativePath] : [];
-  }));
+  const files = await Promise.all(
+    entries.map(async entry => {
+      const relativePath = path.join(relativeDirectory, entry.name);
+      if (entry.isDirectory()) {
+        return collectJavaScriptFiles(path.join(directory, entry.name), relativePath);
+      }
+      return entry.isFile() && entry.name.endsWith('.js') ? [relativePath] : [];
+    }),
+  );
   return files.flat();
 }

--- a/tests/release-readiness.test.ts
+++ b/tests/release-readiness.test.ts
@@ -1,25 +1,32 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   collectManifestContentScriptFiles,
   collectManifestEntryFiles,
   getRequiredReleaseEntryFiles,
   REQUIRED_BUILD_ENTRY_FILES,
 } from "../scripts/release-entry-contract.mjs";
+import {
+  collectPackageAttributionFiles,
+  collectProductionPackages,
+  getPackageLicenseDirectory,
+  getPackageNoticeLine,
+  isAttributionFilePath,
+} from "../scripts/production-license-contract.mjs";
 
 async function readRepositoryFile(path: string): Promise<string> {
   return readFile(new URL(`../${path}`, import.meta.url), "utf8");
 }
 
 test("release metadata, permissions, and license stay coherent", async () => {
-  const [packageSource, manifestSource, licenseSource, prdSource] =
-    await Promise.all([
-      readRepositoryFile("package.json"),
-      readRepositoryFile("public/manifest.json"),
-      readRepositoryFile("LICENSE"),
-      readRepositoryFile("docs/PRD.md"),
-    ]);
+  const [packageSource, manifestSource, licenseSource, prdSource] = await Promise.all([
+    readRepositoryFile("package.json"),
+    readRepositoryFile("public/manifest.json"),
+    readRepositoryFile("LICENSE"),
+    readRepositoryFile("docs/PRD.md"),
+  ]);
   const packageJson = JSON.parse(packageSource) as {
     name: string;
     version: string;
@@ -53,10 +60,7 @@ test("the supported ECharts 6 word-cloud integration is registered", async () =>
   };
 
   assert.match(packageJson.dependencies.echarts, /^\^6\.1\./);
-  assert.equal(
-    packageJson.dependencies["@echarts-x/custom-word-cloud"],
-    "^1.0.1",
-  );
+  assert.equal(packageJson.dependencies["@echarts-x/custom-word-cloud"], "^1.0.1");
   assert.equal(packageJson.dependencies["echarts-wordcloud"], undefined);
   assert.match(registrySource, /@echarts-x\/custom-word-cloud/);
   assert.match(registrySource, /CustomChart/);
@@ -66,12 +70,13 @@ test("the supported ECharts 6 word-cloud integration is registered", async () =>
 });
 
 test("production build keeps chart vendors bounded and background imports consistent", async () => {
-  const [viteConfigSource, blindBoxSource, transcriptCacheSource, verificationSource] = await Promise.all([
-    readRepositoryFile("vite.config.ts"),
-    readRepositoryFile("src/background/api/video-blind-box-candidates.ts"),
-    readRepositoryFile("src/background/current-video-transcript-cache.ts"),
-    readRepositoryFile("scripts/verify-release-dist.mjs"),
-  ]);
+  const [viteConfigSource, blindBoxSource, transcriptCacheSource, verificationSource] =
+    await Promise.all([
+      readRepositoryFile("vite.config.ts"),
+      readRepositoryFile("src/background/api/video-blind-box-candidates.ts"),
+      readRepositoryFile("src/background/current-video-transcript-cache.ts"),
+      readRepositoryFile("scripts/verify-release-dist.mjs"),
+    ]);
 
   assert.match(viteConfigSource, /rolldownOptions:/);
   assert.match(viteConfigSource, /codeSplitting:/);
@@ -100,7 +105,14 @@ test("production build keeps chart vendors bounded and background imports consis
 });
 
 test("Vite 8 build configuration uses Rolldown and Oxc without deprecated compatibility options", async () => {
-  const [packageSource, ciSource, devBuildSource, viteConfigSource, sidebarConfigSource, playerMonitorConfigSource] = await Promise.all([
+  const [
+    packageSource,
+    ciSource,
+    devBuildSource,
+    viteConfigSource,
+    sidebarConfigSource,
+    playerMonitorConfigSource,
+  ] = await Promise.all([
     readRepositoryFile("package.json"),
     readRepositoryFile(".github/workflows/ci.yml"),
     readRepositoryFile("scripts/dev-build.mjs"),
@@ -167,7 +179,9 @@ test("release entry contract covers every manifest-declared runtime entry", asyn
     ...(manifest.web_accessible_resources ?? [])
       .flatMap(entry => entry.resources ?? [])
       .filter(resource => !resource.includes("*")),
-  ].filter((entry): entry is string => Boolean(entry)).sort();
+  ]
+    .filter((entry): entry is string => Boolean(entry))
+    .sort();
 
   assert.deepEqual(collectManifestEntryFiles(manifest), expectedManifestEntries);
   assert.deepEqual(
@@ -182,9 +196,11 @@ test("release entry contract covers every manifest-declared runtime entry", asyn
 
 test("release entry contract ignores wildcard web resources but keeps concrete pages", () => {
   const manifest = {
-    web_accessible_resources: [{
-      resources: ["assets/*", "dashboard/index.html"],
-    }],
+    web_accessible_resources: [
+      {
+        resources: ["assets/*", "dashboard/index.html"],
+      },
+    ],
   };
 
   assert.deepEqual(collectManifestEntryFiles(manifest), ["dashboard/index.html"]);
@@ -194,9 +210,10 @@ test("release entry contract ignores wildcard web resources but keeps concrete p
 });
 
 test("release builds carry project and third-party licenses", async () => {
-  const [packageSource, noticesSource, apacheSource, d3Source, wordCloudSource] =
+  const [packageSource, lockSource, noticesSource, apacheSource, d3Source, wordCloudSource] =
     await Promise.all([
       readRepositoryFile("package.json"),
+      readRepositoryFile("package-lock.json"),
       readRepositoryFile("THIRD_PARTY_NOTICES.txt"),
       readRepositoryFile("third_party/licenses/Apache-2.0.txt"),
       readRepositoryFile("third_party/licenses/BSD-3-Clause-d3.txt"),
@@ -205,6 +222,8 @@ test("release builds carry project and third-party licenses", async () => {
   const packageJson = JSON.parse(packageSource) as {
     scripts: Record<string, string>;
   };
+  const productionPackages = collectProductionPackages(JSON.parse(lockSource));
+  const noticeLines = new Set(noticesSource.split(/\r?\n/).map(line => line.trim()));
 
   assert.match(packageJson.scripts.build, /copy-release-licenses\.mjs/);
   assert.match(packageJson.scripts.build, /verify-release-dist\.mjs/);
@@ -214,6 +233,91 @@ test("release builds carry project and third-party licenses", async () => {
   assert.match(apacheSource, /Apache License\s+Version 2\.0/);
   assert.match(d3Source, /Copyright 2010-2016 Mike Bostock/);
   assert.match(wordCloudSource, /Copyright \(c\) 2011- Timothy Guan-tin Chien/);
+  assert.deepEqual(
+    productionPackages.map(packageRecord => packageRecord.name),
+    [
+      "@echarts-x/custom-word-cloud",
+      "@preact/signals",
+      "@preact/signals-core",
+      "dexie",
+      "echarts",
+      "preact",
+      "tslib",
+      "zrender",
+    ],
+  );
+  for (const packageRecord of productionPackages) {
+    assert.ok(packageRecord.license);
+    assert.ok(noticeLines.has(getPackageNoticeLine(packageRecord, packageRecord.license)));
+    assert.match(
+      getPackageLicenseDirectory(packageRecord),
+      /^third_party_licenses\/npm\/package-[^/]+\/version-[^/]+\/location-[0-9a-f]{16}$/,
+    );
+    assert.ok(!getPackageLicenseDirectory(packageRecord).split("/").includes("node_modules"));
+  }
+
+  const echartsAttributions = await collectPackageAttributionFiles(
+    fileURLToPath(new URL("../node_modules/echarts", import.meta.url)),
+  );
+  const tslibAttributions = await collectPackageAttributionFiles(
+    fileURLToPath(new URL("../node_modules/tslib", import.meta.url)),
+  );
+  assert.ok(echartsAttributions.includes("licenses/LICENSE-d3"));
+  assert.ok(tslibAttributions.includes("CopyrightNotice.txt"));
+});
+
+test("production license contract includes scoped and transitive packages but excludes dev-only packages", () => {
+  const packages = collectProductionPackages({
+    packages: {
+      "": { dependencies: { runtime: "1.0.0" } },
+      "node_modules/runtime": { version: "1.0.0" },
+      "node_modules/runtime/node_modules/transitive": { version: "2.0.0" },
+      "node_modules/@scope/runtime": { version: "3.0.0" },
+      "node_modules/other/node_modules/runtime": {
+        version: "1.0.0",
+        resolved: "git+https://example.test/runtime.git#different-source",
+      },
+      "node_modules/dev-only": { version: "4.0.0", dev: true },
+    },
+  });
+
+  assert.deepEqual(packages.map(packageRecord => packageRecord.location), [
+    "node_modules/@scope/runtime",
+    "node_modules/other/node_modules/runtime",
+    "node_modules/runtime",
+    "node_modules/runtime/node_modules/transitive",
+  ]);
+  assert.equal(packages.filter(packageRecord => packageRecord.name === "runtime").length, 2);
+  assert.equal(
+    packages.find(packageRecord => packageRecord.location.includes("other"))?.resolved,
+    "git+https://example.test/runtime.git#different-source",
+  );
+  const runtimeDirectories = packages
+    .filter(packageRecord => packageRecord.name === "runtime")
+    .map(getPackageLicenseDirectory);
+  assert.equal(new Set(runtimeDirectories).size, 2);
+  assert.throws(
+    () => collectProductionPackages({
+      packages: {
+        "node_modules/../../escape": { version: "1.0.0" },
+      },
+    }),
+    /Unsafe package-lock location/,
+  );
+});
+
+test("production license contract recognizes non-standard and nested attribution paths", () => {
+  for (const relativePath of [
+    "LICENSE-MIT",
+    "NOTICE-third-party",
+    "THIRD_PARTY_NOTICES",
+    "CopyrightNotice.txt",
+    "licenses/LICENSE-d3",
+    "legal/upstream.txt",
+  ]) {
+    assert.equal(isAttributionFilePath(relativePath), true, relativePath);
+  }
+  assert.equal(isAttributionFilePath("README.md"), false);
 });
 
 test("release packaging builds fresh and promotes only a validated artifact", async () => {
@@ -230,9 +334,12 @@ test("release packaging builds fresh and promotes only a validated artifact", as
   assert.match(packagerSource, /Assert-ChildPath/);
   assert.match(packagerSource, /Assert-NotReparsePoint/);
   assert.match(packagerSource, /Assert-SafeReleaseTree/);
+  assert.match(packagerSource, /Forbidden release path/);
   assert.match(packagerSource, /browser\[-_\]\?profile/);
   assert.match(packagerSource, /key\\\.txt/);
   assert.match(packagerSource, /temporaryZipPath/);
+  assert.match(packagerSource, /\[IO\.Path\]::GetTempPath\(\)/);
+  assert.ok(!packagerSource.includes("$env:TEMP"));
   assert.match(packagerSource, /Refusing to replace a different existing release ZIP/);
   assert.match(packagerSource, /Assert-RequiredReleaseFiles/);
   assert.ok(!packagerSource.includes("Remove-Item -LiteralPath $zipPath"));


### PR DESCRIPTION
## Summary

- enumerate every production package by its exact `package-lock.json` location without collapsing same-name/version artifacts
- recursively copy standard and non-standard attribution files, including nested license directories and copyright notices
- encode each lock location into a release-safe unique directory and compare copied files byte-for-byte
- require exact structured `name + version + declared license + lock path` lines in `THIRD_PARTY_NOTICES.txt`
- use the runtime temp directory API so packaging works consistently on Windows and Linux PowerShell
- run the real PowerShell packager in CI so release-tree safety and ZIP round-trip are enforced
- cover scoped/transitive/dev-only packages, duplicate artifacts, unsafe paths, and non-standard attribution names

## Validation

- `npm test` (494/494)
- `npm run typecheck`
- `npm run build` (`18 license/notice files`, 8 entries, 14 chunks)
- `npm run package:release` (41-file ZIP, checksum and extracted hash-map verification)
- `npm audit --audit-level=high` (0 vulnerabilities)
- `git diff --check`
- GitHub Actions `validate`, including the real `pwsh` packaging smoke

The package smoke created only ignored local verification artifacts. No release/tag/package version or published asset changed. No Cookie, browser profile, login-state, key file, or `C:\Users\LittleNub\Desktop\Key.txt` was read.

Closes #230