### PR TITLE
chore: update nanoid audit baseline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1652,9 +1652,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- update transitive `nanoid` from `3.3.16` to `3.3.17` within PostCSS's existing compatible range
- clear `GHSA-2v37-7h3g-55p8` without adding a direct dependency
- keep the maintenance change isolated from docs-only PR #258

## Validation

- `npm ci`
- `npm test` (494 passed)
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- local `npm audit` request was blocked by an intermittent TLS connection failure; GitHub CI is the final audit check

Closes #259