### PR TITLE
feat(0.14): LG-1 笔记与书签保存、重开与最小列表

### DIFF
--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -48,6 +48,10 @@ The word-cloud layout includes portions of wordcloud2.js under the MIT License.
 
 License files
 -------------
+Lucide icons (revision 94e4cb9d9db5907053ebf3636a97c45529cf776b)
+Source: https://github.com/lucide-icons/lucide
+License: ISC; Feather-derived geometry additionally MIT. Notices: Lucide.txt.
+
 - Apache-2.0.txt: Apache License 2.0
 - BSD-3-Clause-d3.txt: d3.js license and copyright notice
 - MIT-wordcloud2.txt: wordcloud2.js license and copyright notice

--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -11,6 +11,7 @@ import { BehaviorPage } from './modules/behavior/BehaviorPage';
 import { ExperimentsPage } from './modules/experiments/ExperimentsPage';
 import { SmartFavoritesPage } from './modules/favorites/SmartFavoritesPage';
 import { SettingsPage } from './modules/settings/SettingsPage';
+import { LearningPage } from './modules/learning/LearningPage';
 import type { WatchHistoryRecord } from '../src/shared/types/watch-event';
 import type { HistorySyncStatus } from '../src/shared/types/history-sync';
 
@@ -23,6 +24,7 @@ const NAV_ITEMS = [
   { id: 'experiments', label: '盲盒', caption: '视频盲盒', shortLabel: '盒' },
   { id: 'smart-favorites', label: '智能收藏', caption: '收藏夹整理', shortLabel: '藏' },
   { id: 'settings', label: '设置', caption: 'AI 与隐私', shortLabel: '设' },
+  { id: 'learning-notes', label: '学习笔记', caption: '笔记与书签', shortLabel: '记' },
 ];
 
 const PAGES = [
@@ -34,6 +36,7 @@ const PAGES = [
   ExperimentsPage,
   SmartFavoritesPage,
   SettingsPage,
+  LearningPage,
 ];
 
 const EXPORT_PAGE_SIZE = 500;

--- a/dashboard/components/AppShell.tsx
+++ b/dashboard/components/AppShell.tsx
@@ -31,7 +31,7 @@ export function AppShell({
             <span>面板 / {activeItem.label}</span>
             <h1>Bili-Bill</h1>
           </div>
-          <div className="bb-topbar-tools">
+          {activeItem.id !== 'learning-notes' && <div className="bb-topbar-tools">
             {synced && <div className="bb-sync-status">{synced}</div>}
             <div className="bb-export-actions" aria-label="导出本地历史">
               <button type="button" onClick={() => onExport('json')} disabled={exporting}>
@@ -41,7 +41,7 @@ export function AppShell({
                 导出 CSV
               </button>
             </div>
-          </div>
+          </div>}
         </header>
         <section className={`bb-page-frame${activeItem.id === 'learning-notes' ? ' bb-page-frame-learning' : ''}`}>
           {children}

--- a/dashboard/components/AppShell.tsx
+++ b/dashboard/components/AppShell.tsx
@@ -43,7 +43,7 @@ export function AppShell({
             </div>
           </div>
         </header>
-        <section className="bb-page-frame">
+        <section className={`bb-page-frame${activeItem.id === 'learning-notes' ? ' bb-page-frame-learning' : ''}`}>
           {children}
         </section>
       </main>

--- a/dashboard/components/SideNav.tsx
+++ b/dashboard/components/SideNav.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'preact/hooks';
+
 export interface SideNavItem {
   id: string;
   label: string;
@@ -12,6 +14,10 @@ interface Props {
 }
 
 export function SideNav({ items, activeIndex, onChange }: Props) {
+  const navigation = useRef<HTMLElement>(null);
+  useEffect(() => {
+    navigation.current?.querySelector('[aria-current="page"]')?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }, [activeIndex]);
   return (
     <aside className="bb-sidebar" aria-label="Bili-Bill 面板导航">
       <div className="bb-brand">
@@ -22,7 +28,7 @@ export function SideNav({ items, activeIndex, onChange }: Props) {
         </div>
       </div>
 
-      <nav className="bb-nav-list">
+      <nav className="bb-nav-list" ref={navigation}>
         {items.map((item, index) => (
           <button
             key={item.id}

--- a/dashboard/modules/learning/LearningPage.tsx
+++ b/dashboard/modules/learning/LearningPage.tsx
@@ -1,0 +1,279 @@
+import { useEffect, useRef, useState } from "preact/hooks";
+import { requestSW } from "../../utils/messaging";
+import {
+  learningTime,
+  type LearningAsset,
+  type LearningList,
+} from "../../../src/shared/learning.ts";
+import { learningIconPaths } from "../../../src/shared/learning-icons.ts";
+import "./learning.css";
+
+function Icon({ name }: { name: keyof typeof learningIconPaths }) {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {learningIconPaths[name].map((d) => (
+        <path d={d} />
+      ))}
+    </svg>
+  );
+}
+export function LearningPage() {
+  const [list, setList] = useState<LearningList | null>(null);
+  const [selected, setSelected] = useState<LearningAsset | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const sequence = useRef(0);
+  const detailSequence = useRef(0);
+  const pageOffset = useRef(0);
+  const selectedId = useRef<string | null>(null);
+
+  async function refresh(offset = pageOffset.current) {
+    const generation = ++sequence.current;
+    setLoading(true);
+    setError("");
+    try {
+      let result = await requestSW<LearningList>("LEARNING_LIST", { offset });
+      if (offset >= result.total && offset > 0)
+        result = await requestSW("LEARNING_LIST", {
+          offset: Math.max(0, Math.floor((result.total - 1) / 30) * 30),
+        });
+      if (sequence.current !== generation) return;
+      pageOffset.current = result.offset;
+      setList(result);
+      if (selectedId.current) {
+        const id = selectedId.current;
+        const row = await requestSW<LearningAsset | null>("LEARNING_GET", {
+          id,
+        });
+        if (sequence.current === generation && selectedId.current === id) {
+          setSelected(row);
+          if (!row) selectedId.current = null;
+        }
+      }
+    } catch {
+      if (sequence.current === generation)
+        setError("暂时无法读取学习笔记，请重试。");
+    } finally {
+      if (sequence.current === generation) setLoading(false);
+    }
+  }
+  useEffect(() => {
+    void refresh();
+    const focus = () => {
+      void refresh();
+    };
+    window.addEventListener("focus", focus);
+    return () => {
+      sequence.current++;
+      detailSequence.current++;
+      window.removeEventListener("focus", focus);
+    };
+  }, []);
+  async function open(id: string) {
+    selectedId.current = id;
+    setConfirmDelete(false);
+    setError("");
+    setNotice("");
+    const generation = ++detailSequence.current;
+    try {
+      const row = await requestSW<LearningAsset | null>("LEARNING_GET", { id });
+      if (detailSequence.current !== generation || selectedId.current !== id)
+        return;
+      setSelected(row);
+      if (!row) {
+        selectedId.current = null;
+        setNotice("这条笔记已被删除。");
+        void refresh();
+      }
+    } catch {
+      if (detailSequence.current === generation)
+        setError("暂时无法打开这条笔记，请重试。");
+    }
+  }
+  async function remove() {
+    if (!selected || !list || busy) return;
+    setBusy(true);
+    setError("");
+    try {
+      await requestSW("LEARNING_DELETE", {
+        id: selected.id,
+        epoch: list.epoch,
+      });
+      selectedId.current = null;
+      detailSequence.current++;
+      setSelected(null);
+      setConfirmDelete(false);
+      setNotice("已删除");
+      await refresh();
+    } catch {
+      setError("删除未完成，请刷新后确认。");
+    } finally {
+      setBusy(false);
+    }
+  }
+  return (
+    <section class="bb-learning" aria-label="学习笔记">
+      <header class="learning-heading">
+        <div>
+          <h1>学习笔记</h1>
+          <span>{list ? `${list.total} 条记录` : "本地保存"}</span>
+        </div>
+        <button
+          class="learning-icon"
+          title="刷新列表"
+          aria-label="刷新列表"
+          disabled={loading || busy}
+          onClick={() => void refresh()}
+        >
+          <Icon name="refresh" />
+        </button>
+      </header>
+      <div class="learning-notice" role={error ? "alert" : "status"}>
+        {error || notice}
+      </div>
+      {loading && !list ? (
+        <div class="learning-empty">读取中</div>
+      ) : !list?.total ? (
+        <div class="learning-empty">
+          <Icon name="note" />
+          <h2>暂无学习笔记</h2>
+        </div>
+      ) : (
+        <div class={`learning-workspace${selected ? " has-selection" : ""}`}>
+          <div class="learning-master">
+            <div class="learning-list" aria-label="已保存的笔记">
+              {list.items.map((item) => (
+                <button
+                  key={item.id}
+                  class={`learning-row${selected?.id === item.id ? " selected" : ""}`}
+                  onClick={() => void open(item.id)}
+                  disabled={busy}
+                >
+                  <span class={`learning-kind ${item.kind}`}>
+                    <Icon name={item.kind} />
+                  </span>
+                  <span class="learning-row-text">
+                    <strong>
+                      {item.title ||
+                        (item.kind === "note" ? "未命名笔记" : "时间书签")}
+                    </strong>
+                    {item.preview && (
+                      <span class="learning-preview">{item.preview}</span>
+                    )}
+                    <span class="learning-source">
+                      {item.videoTitle || "视频"}
+                      {item.page !== null ? ` · P${item.page}` : ""}
+                      {item.bookmarkMs !== null
+                        ? ` · ${learningTime(item.bookmarkMs)}`
+                        : ""}
+                    </span>
+                  </span>
+                </button>
+              ))}
+            </div>
+            {list.total > 30 && (
+              <nav class="learning-pagination" aria-label="笔记分页">
+                <button
+                  disabled={loading || list.offset === 0}
+                  onClick={() => void refresh(list.offset - 30)}
+                >
+                  上一页
+                </button>
+                <span>
+                  {Math.floor(list.offset / 30) + 1} /{" "}
+                  {Math.ceil(list.total / 30)}
+                </span>
+                <button
+                  disabled={loading || list.offset + 30 >= list.total}
+                  onClick={() => void refresh(list.offset + 30)}
+                >
+                  下一页
+                </button>
+              </nav>
+            )}
+          </div>
+          {selected ? (
+            <article class="learning-detail" aria-label="笔记详情">
+              <div class="learning-detail-tools">
+                <span>
+                  {selected.kind === "note" ? "个人笔记" : "时间书签"}
+                </span>
+                <div>
+                  <button
+                    class="learning-delete"
+                    disabled={busy}
+                    onClick={() => setConfirmDelete(true)}
+                  >
+                    删除
+                  </button>
+                  <button
+                    class="learning-icon"
+                    title="关闭详情"
+                    aria-label="关闭详情"
+                    disabled={busy}
+                    onClick={() => {
+                      selectedId.current = null;
+                      detailSequence.current++;
+                      setSelected(null);
+                    }}
+                  >
+                    <Icon name="close" />
+                  </button>
+                </div>
+              </div>
+              {confirmDelete && (
+                <div class="learning-confirm" role="alert">
+                  <span>删除这条笔记？</span>
+                  <button disabled={busy} onClick={() => void remove()}>
+                    {busy ? "删除中" : "确认删除"}
+                  </button>
+                  <button
+                    disabled={busy}
+                    onClick={() => setConfirmDelete(false)}
+                  >
+                    取消
+                  </button>
+                </div>
+              )}
+              <h2>
+                {selected.personal.title ||
+                  (selected.kind === "note" ? "未命名笔记" : "时间书签")}
+              </h2>
+              <div class="learning-detail-source">
+                {selected.video.title || "视频"}
+                {selected.part ? ` · P${selected.part.page}` : ""}
+                {selected.bookmarkMs !== null
+                  ? ` · ${learningTime(selected.bookmarkMs)}`
+                  : ""}
+              </div>
+              <div class="learning-body">
+                {selected.personal.note || "未添加备注"}
+              </div>
+              <time dateTime={new Date(selected.createdAt).toISOString()}>
+                {new Date(selected.createdAt).toLocaleString("zh-CN")}
+              </time>
+            </article>
+          ) : (
+            <div class="learning-detail-empty">
+              <Icon name="note" />
+              <span>已保存的内容</span>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/dashboard/modules/learning/learning.css
+++ b/dashboard/modules/learning/learning.css
@@ -1,0 +1,254 @@
+.bb-page-frame.bb-page-frame-learning {
+  background: var(--bb-panel, #fff);
+  color: var(--bb-ink, #18191c);
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  padding: 20px;
+}
+.bb-learning {
+  color: var(--bb-ink, #18191c);
+  letter-spacing: 0;
+  min-width: 0;
+}
+.learning-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 0 16px;
+  border-bottom: 1px solid var(--bb-border, #e3e5e7);
+}
+.learning-heading h1 {
+  font-size: 24px;
+  line-height: 1.4;
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+.learning-heading span {
+  color: var(--bb-muted, #61666d);
+  font-size: 13px;
+}
+.bb-learning button {
+  font: inherit;
+  cursor: pointer;
+  color: inherit;
+  background: transparent;
+  border: 1px solid var(--bb-border, #e3e5e7);
+  border-radius: 6px;
+  padding: 6px 12px;
+  min-height: 34px;
+}
+.bb-learning button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.bb-learning button:focus-visible {
+  outline: 2px solid #00aeec;
+  outline-offset: 2px;
+}
+.bb-learning button.learning-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  padding: 7px;
+  flex-shrink: 0;
+}
+.learning-notice {
+  font-size: 13px;
+  min-height: 30px;
+  padding: 5px 0;
+  overflow-wrap: anywhere;
+}
+.learning-notice[role="alert"] {
+  color: #b63552;
+}
+.learning-workspace {
+  display: grid;
+  grid-template-columns: minmax(250px, 42%) minmax(0, 1fr);
+  min-height: 480px;
+  background: var(--bb-panel, #fff);
+  border-top: 1px solid var(--bb-border, #e3e5e7);
+}
+.learning-master {
+  min-width: 0;
+  border-right: 1px solid var(--bb-border, #e3e5e7);
+}
+.learning-list {
+  max-height: 65vh;
+  overflow: auto;
+}
+.bb-learning button.learning-row {
+  display: flex;
+  gap: 12px;
+  text-align: left;
+  width: 100%;
+  padding: 18px 16px;
+  border: 0;
+  border-bottom: 1px solid var(--bb-border, #e3e5e7);
+  border-radius: 0;
+  min-height: 98px;
+}
+.learning-row:hover {
+  background: #f6f8f9;
+}
+.bb-learning .learning-row.selected {
+  background: #edf8fc;
+  box-shadow: inset 3px 0 #00aeec;
+}
+.learning-kind {
+  display: flex;
+  align-items: flex-start;
+  flex: 0 0 20px;
+  padding-top: 2px;
+  color: #00a0c8;
+}
+.learning-kind.bookmark {
+  color: #d9668a;
+}
+.learning-row-text {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+  gap: 6px;
+  overflow-wrap: anywhere;
+}
+.learning-row-text strong {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.5;
+}
+.learning-preview {
+  font-size: 13px;
+  line-height: 1.6;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  color: #61666d;
+}
+.learning-source {
+  font-size: 12px;
+  color: #9499a0;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.learning-detail {
+  padding: 20px 28px;
+  min-width: 0;
+}
+.learning-detail-tools {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 22px;
+  color: #9499a0;
+  font-size: 12px;
+}
+.learning-detail-tools > div {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.bb-learning .learning-delete {
+  border: 0;
+  color: #a94860;
+}
+.learning-detail h2 {
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 1.5;
+  margin: 0 0 12px;
+  overflow-wrap: anywhere;
+}
+.learning-detail-source {
+  font-size: 12px;
+  color: #9499a0;
+  overflow-wrap: anywhere;
+  padding-bottom: 18px;
+  border-bottom: 1px solid #edf0f2;
+}
+.learning-body {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-size: 14px;
+  line-height: 1.9;
+  padding: 20px 0;
+  max-height: 55vh;
+  overflow: auto;
+}
+.learning-detail time {
+  font-size: 12px;
+  color: #9499a0;
+}
+.learning-confirm {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  padding: 10px 0 18px;
+  font-size: 13px;
+  color: #a94860;
+}
+.learning-empty,
+.learning-detail-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  min-height: 340px;
+  color: #9499a0;
+}
+.learning-empty svg,
+.learning-detail-empty svg {
+  width: 32px;
+  height: 32px;
+}
+.learning-empty h2 {
+  font-size: 16px;
+  font-weight: 400;
+}
+.learning-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 14px;
+  font-size: 12px;
+}
+@media (max-width: 800px) {
+  .bb-page-frame.bb-page-frame-learning {
+    padding: 16px 12px;
+  }
+  .learning-workspace {
+    grid-template-columns: minmax(0, 1fr);
+    min-height: 350px;
+  }
+  .learning-detail-empty {
+    display: none;
+  }
+  .learning-master {
+    border-right: 0;
+  }
+  .learning-workspace.has-selection .learning-master {
+    display: none;
+  }
+  .learning-detail {
+    padding: 16px;
+  }
+  .learning-heading h1 {
+    font-size: 22px;
+  }
+  .learning-list {
+    max-height: none;
+  }
+  .learning-body {
+    max-height: none;
+  }
+}

--- a/dashboard/modules/settings/SettingsPage.tsx
+++ b/dashboard/modules/settings/SettingsPage.tsx
@@ -726,7 +726,7 @@ export function SettingsPage() {
           <div className="settings-danger-box">
             <div>
               <strong>确认清理本地数据</strong>
-              <p>这会删除 Bili-Bill 保存在浏览器扩展里的本地内容数据和本地设置，不会修改 B 站账号、关注关系、收藏夹或视频数据。</p>
+              <p>这会删除下列本地内容数据和本地设置，保留学习笔记；不会修改 B 站账号、关注关系、收藏夹或视频数据。</p>
             </div>
             <ul>
               {dangerousLocalDataClearScope().map(item => <li key={item}>{item}</li>)}

--- a/dashboard/styles.d.ts
+++ b/dashboard/styles.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/scripts/learning-demo.py
+++ b/scripts/learning-demo.py
@@ -1,0 +1,92 @@
+"""Offline interview demo using the real extension and an isolated synthetic host."""
+import argparse
+import json
+import shutil
+import uuid
+from pathlib import Path
+from playwright.sync_api import sync_playwright, expect, Error as PlaywrightError
+
+ROOT = Path(__file__).resolve().parents[1]
+URL = 'https://www.bilibili.com/video/BV1xx411c7mD/'
+parser = argparse.ArgumentParser(description='Bili-Bill offline learning demo')
+parser.add_argument('--dist', type=Path, default=ROOT / 'dist')
+parser.add_argument('--smoke', action='store_true')
+args = parser.parse_args()
+extension = args.dist.resolve()
+assert extension.is_relative_to(ROOT) and (extension / 'manifest.json').is_file()
+profile = ROOT / 'release-artifacts' / 'lg1' / ('p-' + uuid.uuid4().hex[:8])
+profile.parent.mkdir(parents=True, exist_ok=True)
+html = (ROOT / 'tests' / 'learning-save.mock.html').read_text(encoding='utf-8')
+
+
+def launch(playwright):
+    context = playwright.chromium.launch_persistent_context(str(profile), channel='chromium', headless=args.smoke,
+        viewport={'width': 1440, 'height': 900}, args=[
+            '--disable-extensions-except=' + str(extension), '--load-extension=' + str(extension),
+            '--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE localhost', '--no-first-run'])
+    context.set_offline(True)
+    context.route('**/*', lambda route: route.fulfill(status=200, content_type='text/html', body=html)
+        if route.request.url.startswith(URL) else route.continue_() if route.request.url.startswith('chrome-extension:') else route.abort())
+    return context
+
+
+def video_page(context):
+    page = context.new_page()
+    page.goto(URL, wait_until='domcontentloaded')
+    page.wait_for_selector('html[data-video-ready=true]', timeout=25000)
+    page.get_by_role('button', name='展开助手', exact=True).click()
+    return page
+
+
+with sync_playwright() as playwright:
+    context = None
+    try:
+        print('正在启动独立离线演示，准备合成样例。不会使用个人账号或浏览记录。', flush=True)
+        context = launch(playwright)
+        worker = context.service_workers[0] if context.service_workers else context.wait_for_event('serviceworker')
+        extension_id = worker.url.split('/')[2]
+        page = video_page(context)
+        page.get_by_role('button', name='记笔记', exact=True).click()
+        expect(page.locator('#bb-learning-editor .source')).to_contain_text('从想法到可用产品', timeout=15000)
+        page.get_by_label('标题', exact=True).fill('先验证最小闭环')
+        page.get_by_label('笔记', exact=True).fill('看完之后，留下自己的理解。\n先验证保存、重开和再次使用，再扩展更多能力。')
+        page.locator('#bb-learning-editor').get_by_role('button', name='保存', exact=True).click()
+        expect(page.locator('#bb-learning-editor .status')).to_have_text('已保存', timeout=15000)
+        page.get_by_role('button', name='关闭并保留草稿', exact=True).click()
+        page.get_by_role('button', name='存书签', exact=True).click()
+        expect(page.locator('#bb-learning-editor .source')).to_contain_text('0:02')
+        page.get_by_label('标题', exact=True).fill('关于验证闭环的提醒')
+        page.locator('#bb-learning-editor').get_by_role('button', name='保存', exact=True).click()
+        expect(page.locator('#bb-learning-editor .status')).to_have_text('已保存', timeout=15000)
+        context.close()
+
+        # Reopen the entire browser, not just a page, before presenting saved data.
+        context = launch(playwright)
+        page = video_page(context)
+        dashboard = context.new_page()
+        dashboard.goto('chrome-extension://' + extension_id + '/dashboard/index.html#learning-notes')
+        expect(dashboard.locator('.learning-heading')).to_contain_text('2 条记录', timeout=15000)
+        dashboard.get_by_role('button', name='先验证最小闭环', exact=False).click()
+        expect(dashboard.locator('.learning-body')).to_contain_text('留下自己的理解')
+        for blank in list(context.pages):
+            if blank.url == 'about:blank': blank.close()
+        if args.smoke:
+            print(json.dumps({'status': 'pass', 'checks': ['real_extension_save', 'full_restart_readback'], 'data': 'synthetic'}, ensure_ascii=False))
+        else:
+            dashboard.bring_to_front()
+            print('演示已就绪：两个标签页分别是视频和学习笔记。关闭此独立浏览器后自动清理演示数据。', flush=True)
+            while context.browser.is_connected():
+                pages = context.pages
+                if not pages: break
+                try: pages[-1].wait_for_timeout(500)
+                except PlaywrightError:
+                    if not context.browser.is_connected(): break
+    finally:
+        if context:
+            try: context.close()
+            except PlaywrightError: pass
+        target = profile.resolve()
+        assert target.parent == (ROOT / 'release-artifacts' / 'lg1').resolve()
+        assert target.name.startswith('p-') and len(target.name) == 10
+        if target.exists(): shutil.rmtree(target)
+        print('本次合成演示数据已清理。', flush=True)

--- a/scripts/package-learning-demo.mjs
+++ b/scripts/package-learning-demo.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const qa = path.resolve(root, process.argv[2] ?? '');
+assert.equal(path.dirname(qa), path.join(root, 'release-artifacts', 'lg1'));
+const report = JSON.parse(readFileSync(path.join(qa, 'report.json'), 'utf8'));
+const commit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
+assert.equal(report.status, 'pass');
+assert.equal(report.profileRemoved, true);
+assert.equal(report.workingTreeDirty, false);
+assert.equal(report.sourceCommit, commit);
+assert.equal(execFileSync('git', ['status', '--porcelain'], { cwd: root, encoding: 'utf8' }).trim(), '');
+for (const [file, hash] of Object.entries(report.distSha256)) {
+  const actual = createHash('sha256').update(readFileSync(path.join(root, 'dist', file))).digest('hex');
+  assert.equal(actual, hash, file);
+}
+const output = path.join(root, 'release-artifacts', 'interview', `Bili-Bill-${commit.slice(0, 7)}-${Date.now()}`);
+mkdirSync(output, { recursive: true });
+cpSync(path.join(root, 'dist'), path.join(output, 'extension'), { recursive: true });
+mkdirSync(path.join(output, 'screenshots'));
+for (const file of readdirSync(qa).filter(name => name.endsWith('.png'))) {
+  cpSync(path.join(qa, file), path.join(output, 'screenshots', file));
+}
+cpSync(path.join(qa, 'report.json'), path.join(output, 'verification.json'));
+writeFileSync(path.join(output, 'Start-Demo.cmd'), `@echo off\r\npython -X utf8 -u "${path.join(root, 'scripts', 'learning-demo.py')}" --dist "%~dp0extension"\r\nif errorlevel 1 pause\r\n`);
+const guide = `# Bili-Bill 面试演示
+
+这是有限学习闭环的开发演示，不是 V0.14.0 正式发布。代码提交：${commit}。
+
+## 启动
+
+双击本目录的 Start-Demo.cmd，约 20 秒后打开两个标签页：视频与学习笔记。
+使用当前机器已安装的 Python、Playwright Chromium。启动器依赖原项目目录，不要移动或删除项目。
+每次创建独立的离线浏览器，自动保存两条合成样例，再完整重启浏览器验证读回。
+这是真实扩展和真实 IndexedDB；视频宿主页与视频素材是合成演示，不代表真实 B 站适配验收。
+演示不需要网络、账号或 AI 密钥；不会读取个人浏览器数据。关闭独立浏览器后清理本次演示数据。
+
+## 三分钟顺序
+
+1. 20 秒讲问题：B 站有大量有价值的内容，但看过、收藏和真正留下自己的理解是不同的动作。我做的是个人内容账单，并逐步补齐学习沉淀能力。
+2. 60 秒展示保存：打开视频标签页，点击页内助手的笔记图标，输入自己的理解并保存。再存一个时间书签，说明位置来自实际播放器，不让模型猜时间。
+3. 40 秒展示重开：切到学习笔记，刷新列表，打开刚才保存的内容。启动器已先完成整个浏览器重启后的读回；需要时可关闭视频标签页再重新打开学习笔记。删除一条样例并刷新确认。
+4. 40 秒讲开发方法：我负责问题定义、范围裁决和验收，把任务拆为可检查的切片；AI 辅助实现，我用关键评审、边界测试和真实扩展交互验证结果。保存成功不仅要有提示，还要重开后能读到。
+5. 20 秒讲边界：这次展示的是笔记、真实位置书签与保存重开。原文/答案保存、搜索与来源回看、备份恢复以及整版验收仍是后续工作，V0.14.0 尚未全部完成。
+
+## 现场兜底
+
+- 如果启动失败，打开 Guide.html，按真实操作截图讲解，不宣称它是正在运行的演示。
+- 不进入真实账号同步或 AI 设置，不在现场依赖在线模型生成。
+- 这份包没有合入仍独立审查中的 UX-014 PR #274，不把设计稿当成已发布界面。
+- 扩展文件在 extension 目录，仅作为开发演示包；版本字段沿用现有 0.13，未创建 tag 或 release。
+- verification.json 记录同一构建的文件摘要及合成浏览器检查，不能当作真实用户规模或业务效果。
+`;
+writeFileSync(path.join(output, 'README.md'), guide);
+writeFileSync(path.join(output, 'Guide.html'), `<!doctype html><html lang="zh-CN"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Bili-Bill 面试演示</title><style>body{margin:0;background:#f6f7f8;color:#18191c;font:16px/1.8 system-ui,"Microsoft YaHei",sans-serif;letter-spacing:0}main{max-width:1100px;margin:auto;padding:36px 24px}h1{font-size:32px;margin:0}h2{font-size:22px;margin-top:36px}p{max-width:850px;color:#61666d}img{display:block;width:100%;height:auto;border:1px solid #e3e5e7}section{padding:18px 0;border-top:1px solid #e3e5e7}a{color:#0086b3}</style><main><h1>Bili-Bill</h1><p>面试演示准备包 · 保存理解，重开仍在</p><p>开发切片，不是 V0.14.0 正式发布。以下均为真实扩展在合成宿主页的操作截图。双击同目录 Start-Demo.cmd 可操作；无需联网或登录。</p><p><a href="README.md">完整讲解顺序与能力边界</a></p><section><h2>01 记下自己的理解</h2><img src="screenshots/note-editor-desktop.png" alt="真实笔记编辑弹窗"></section><section><h2>02 保存后重开仍可读到</h2><img src="screenshots/learning-desktop.png" alt="学习笔记列表与详情"></section><section><h2>03 窄屏详情</h2><img style="max-width:390px" src="screenshots/learning-mobile-detail.png" alt="窄屏学习笔记详情"></section><p>代码 ${commit.slice(0, 7)}。来源绑定、取消、容量与无损升级通过相关测试；真实 B 站宿主和整版发布验收不由这些截图替代。</p></main></html>`);
+console.log(JSON.stringify({ output, commit, status: 'packaged-local-development-demo' }));

--- a/src/background/messages/handlers.ts
+++ b/src/background/messages/handlers.ts
@@ -50,6 +50,7 @@ import {
   setDeviceTypeMigrationComplete,
 } from '../storage/config-store';
 import { db } from '../storage/db';
+import { handleLearningRequest } from './learning-handlers.ts';
 import type { UserConfig } from '../../shared/types/config';
 import {
   approximateSizeFromContext,
@@ -477,10 +478,12 @@ function contextMatchesVideoUrlIdentity(
     && context.currentPart.page === identity.page;
 }
 
+
 export async function handleRequest<T>(
   request: BiliVizRequest,
   requestTabId: number | null = null,
 ): Promise<BiliVizResponse<T>> {
+  if (request.action.startsWith('LEARNING_')) return await handleLearningRequest(request.action, request.params, requestTabId) as BiliVizResponse<T>;
   if (DYNAMIC_BILL_DATA_OPERATION_ACTIONS.has(request.action)) {
     return runDynamicBillDataOperation(async () => {
       await ensureDynamicBill013Migration();

--- a/src/background/messages/learning-handlers.ts
+++ b/src/background/messages/learning-handlers.ts
@@ -1,0 +1,168 @@
+import type { RequestAction } from "../../shared/types/messages.ts";
+import {
+  canonicalLearning,
+  learningAssert,
+  learningError,
+  learningId,
+  learningInteger,
+  validateLearningAsset,
+  type LearningCapture,
+  type LearningAsset,
+} from "../../shared/learning.ts";
+import { db } from "../storage/db.ts";
+import { LearningRepository } from "../storage/learning-repo.ts";
+
+const repo = new LearningRepository(db);
+const operations = new Map<
+  string,
+  {
+    controller: AbortController;
+    phase: string;
+    promise: Promise<LearningAsset>;
+    signature: string;
+  }
+>();
+async function fromPage(
+  tabId: number,
+  action: string,
+  params: Record<string, unknown>,
+): Promise<LearningCapture> {
+  const tab = await chrome.tabs.get(tabId);
+  const url = new URL(tab.url ?? "about:blank");
+  learningAssert(
+    url.protocol === "https:" &&
+      ["www.bilibili.com", "bilibili.com"].includes(url.hostname) &&
+      url.pathname.startsWith("/video/"),
+    "stale_capture",
+  );
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const response = await Promise.race([
+      chrome.tabs.sendMessage(tabId, { action, ...params }, { frameId: 0 }),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(Error("stale_capture")), 3000);
+      }),
+    ]);
+    learningAssert(
+      response?.capture && typeof response.capture === "object",
+      "stale_capture",
+    );
+    const capture = response.capture as LearningCapture;
+    learningId(capture.token);
+    learningAssert(
+      capture.video.bvid === url.pathname.split("/")[2] &&
+        (capture.part === null ||
+          capture.part.page === Number(url.searchParams.get("p") ?? 1)),
+      "stale_capture",
+    );
+    return capture;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function handleLearningRequest(
+  action: RequestAction,
+  params: Record<string, unknown> = {},
+  tabId: number | null = null,
+) {
+  try {
+    switch (action) {
+      case "LEARNING_LIST":
+        return {
+          success: true,
+          data: await repo.list(params.offset as number | undefined),
+        };
+      case "LEARNING_GET":
+        return {
+          success: true,
+          data: (await repo.get(params.id as string)) ?? null,
+        };
+      case "LEARNING_DELETE":
+        await repo.remove(params.epoch as number, params.id as string);
+        return { success: true, data: true };
+      case "LEARNING_PREPARE": {
+        learningAssert(tabId !== null, "stale_capture");
+        learningAssert(
+          params.kind === "note" || params.kind === "bookmark",
+          "kind",
+        );
+        const capture = await fromPage(tabId, "CAPTURE_LEARNING_CONTEXT", {
+          kind: params.kind,
+        });
+        return {
+          success: true,
+          data: { epoch: (await repo.state()).meta.epoch, capture },
+        };
+      }
+      case "LEARNING_CANCEL": {
+        learningAssert(tabId !== null, "stale_capture");
+        learningId(params.id);
+        const operation = operations.get(`${tabId}:${params.id}`);
+        if (operation?.phase === "preparing") operation.controller.abort();
+        return {
+          success: true,
+          data: { phase: operation?.phase ?? "settled" },
+        };
+      }
+      case "LEARNING_SAVE": {
+        learningAssert(tabId !== null, "stale_capture");
+        validateLearningAsset(params.asset);
+        learningId(params.token);
+        learningInteger(params.epoch);
+        const asset = params.asset;
+        const token = params.token;
+        const key = `${tabId}:${asset.id}`;
+        const signature = canonicalLearning({ epoch: params.epoch, asset });
+        const existing = operations.get(key);
+        if (existing) {
+          learningAssert(
+            existing.signature === signature,
+            "save_identity_conflict",
+          );
+          return { success: true, data: await existing.promise };
+        }
+        learningAssert(operations.size < 16, "busy_retry");
+        const controller = new AbortController();
+        const operation = {
+          controller,
+          phase: "preparing",
+          signature,
+          promise: null as unknown as Promise<LearningAsset>,
+        };
+        const assertCurrent = async () => {
+          const capture = await fromPage(tabId, "CHECK_LEARNING_CONTEXT", {
+            token,
+          });
+          learningAssert(
+            capture.token === token &&
+              capture.kind === asset.kind &&
+              canonicalLearning(capture.video) ===
+                canonicalLearning(asset.video) &&
+              canonicalLearning(capture.part) ===
+                canonicalLearning(asset.part) &&
+              capture.bookmarkMs === asset.bookmarkMs,
+            "stale_capture",
+          );
+        };
+        operation.promise = repo.save(params.epoch, asset, {
+          signal: controller.signal,
+          assertCurrent,
+          onPhase: (phase) => {
+            operation.phase = phase;
+          },
+        });
+        operations.set(key, operation);
+        try {
+          return { success: true, data: await operation.promise };
+        } finally {
+          operations.delete(key);
+        }
+      }
+      default:
+        throw Error("unknown_action");
+    }
+  } catch (error) {
+    return { success: false, error: learningError(error) };
+  }
+}

--- a/src/background/storage/db.ts
+++ b/src/background/storage/db.ts
@@ -21,8 +21,11 @@ import type {
 import type { CurrentVideoSummaryHighlightsCacheRecord } from '../../shared/types/current-video-summary.ts';
 import type { CurrentVideoQaSessionRecord } from '../../shared/types/current-video-qa-session.ts';
 import { clearLegacyCurrentVideoTranscriptCache } from './current-video-transcript-migration.ts';
+import type { LearningAsset, LearningMeta } from '../../shared/learning.ts';
 
 export class BiliAnalyticsDB extends Dexie {
+  lgAssets!: Table<LearningAsset, string>;
+  lgMeta!: Table<LearningMeta, string>;
   watchHistory!: Table<WatchHistoryRecord, number>;
   playerEvents!: Table<PlayerEvent, number>;
   dailyAggregates!: Table<DailyAggregate, number>;
@@ -411,6 +414,7 @@ export class BiliAnalyticsDB extends Dexie {
       currentVideoQaSessions:
         '++id, &sessionId, lastAccessedAt, updatedAt',
     });
+    this.version(14).stores({ lgAssets: 'id', lgMeta: 'key' });
   }
 }
 

--- a/src/background/storage/learning-repo.ts
+++ b/src/background/storage/learning-repo.ts
@@ -1,0 +1,143 @@
+import Dexie from "dexie";
+import type { BiliAnalyticsDB } from "./db.ts";
+import {
+  LEARNING_MAX_ASSETS,
+  LEARNING_MAX_BYTES,
+  canonicalLearning,
+  learningAssert,
+  learningBytes,
+  learningId,
+  learningInteger,
+  validateLearningAsset,
+  type LearningAsset,
+  type LearningMeta,
+  type LearningList,
+} from "../../shared/learning.ts";
+
+interface SaveOptions {
+  signal?: AbortSignal;
+  assertCurrent?: () => Promise<void>;
+  onPhase?: (phase: "preparing" | "committing" | "committed") => void;
+}
+const initial = (): LearningMeta => ({ key: "state", epoch: 0, revision: 0 });
+const notCancelled = (signal?: AbortSignal) =>
+  learningAssert(!signal?.aborted, "cancelled");
+
+export class LearningRepository {
+  private database: BiliAnalyticsDB;
+  constructor(database: BiliAnalyticsDB) {
+    this.database = database;
+  }
+
+  async state() {
+    const db = this.database;
+    return db.transaction("r", db.lgAssets, db.lgMeta, async () => ({
+      assets: await db.lgAssets.toArray(),
+      meta: (await db.lgMeta.get("state")) ?? initial(),
+    }));
+  }
+  async get(id: string) {
+    learningId(id);
+    return this.database.lgAssets.get(id);
+  }
+  async list(offset = 0): Promise<LearningList> {
+    learningInteger(offset);
+    const { assets, meta } = await this.state();
+    assets.sort(
+      (a, b) => b.createdAt - a.createdAt || a.id.localeCompare(b.id),
+    );
+    return {
+      epoch: meta.epoch,
+      total: assets.length,
+      offset,
+      items: assets.slice(offset, offset + 30).map((row) => ({
+        id: row.id,
+        kind: row.kind,
+        title: row.personal.title,
+        preview: row.personal.note.slice(0, 180),
+        videoTitle: row.video.title,
+        page: row.part?.page ?? null,
+        bookmarkMs: row.bookmarkMs,
+        createdAt: row.createdAt,
+      })),
+    };
+  }
+  async save(
+    epoch: number,
+    input: unknown,
+    options: SaveOptions,
+  ): Promise<LearningAsset> {
+    learningInteger(epoch);
+    validateLearningAsset(input);
+    const asset = structuredClone(input);
+    const db = this.database;
+    for (let attempt = 0; attempt < 4; attempt++) {
+      options.onPhase?.("preparing");
+      notCancelled(options.signal);
+      const before = await this.state();
+      learningAssert(before.meta.epoch === epoch, "stale_epoch");
+      const prior = before.assets.find((row) => row.id === asset.id);
+      if (prior) {
+        learningAssert(
+          canonicalLearning(prior) === canonicalLearning(asset),
+          "save_identity_conflict",
+        );
+        return prior;
+      }
+      learningAssert(
+        before.assets.length < LEARNING_MAX_ASSETS,
+        "capacity_count",
+      );
+      learningAssert(
+        learningBytes([...before.assets, asset]) <= LEARNING_MAX_BYTES,
+        "capacity_bytes",
+      );
+      learningAssert(options.assertCurrent, "stale_capture");
+      await options.assertCurrent();
+      notCancelled(options.signal);
+      const applied = await db.transaction(
+        "rw",
+        db.lgAssets,
+        db.lgMeta,
+        async () => {
+          const current = (await db.lgMeta.get("state")) ?? initial();
+          learningAssert(current.epoch === epoch, "stale_epoch");
+          if (current.revision !== before.meta.revision) return false;
+          // A fresh content-page check stays inside the write boundary; it is not an AI/subtitle request.
+          await Dexie.waitFor(options.assertCurrent!());
+          notCancelled(options.signal);
+          learningInteger(current.revision + 1);
+          options.onPhase?.("committing");
+          await db.lgAssets.add(asset);
+          await db.lgMeta.put({ ...current, revision: current.revision + 1 });
+          return true;
+        },
+      );
+      if (applied) {
+        options.onPhase?.("committed");
+        const persisted = await this.get(asset.id);
+        learningAssert(
+          persisted &&
+            canonicalLearning(persisted) === canonicalLearning(asset),
+          "readback",
+        );
+        return persisted;
+      }
+    }
+    throw new Error("busy_retry");
+  }
+  async remove(epoch: number, id: string): Promise<void> {
+    learningInteger(epoch);
+    learningId(id);
+    const db = this.database;
+    await db.transaction("rw", db.lgAssets, db.lgMeta, async () => {
+      const meta = (await db.lgMeta.get("state")) ?? initial();
+      learningAssert(meta.epoch === epoch, "stale_epoch");
+      if (!(await db.lgAssets.get(id))) return;
+      learningInteger(meta.revision + 1);
+      await db.lgAssets.delete(id);
+      await db.lgMeta.put({ ...meta, revision: meta.revision + 1 });
+    });
+    learningAssert(!(await this.get(id)), "delete_readback");
+  }
+}

--- a/src/content/player-monitor/assistant-status.ts
+++ b/src/content/player-monitor/assistant-status.ts
@@ -2,6 +2,7 @@ import type {
   CurrentVideoContext,
   CurrentVideoContextResult,
 } from '../../shared/types/current-video-context';
+import { learningEditorButton } from './learning-editor.ts';
 import type { BiliVizResponse, RequestAction } from '../../shared/types/messages';
 import type {
   CurrentVideoSummaryHighlight,
@@ -1152,6 +1153,7 @@ function renderExpandedPanel(root: HTMLElement): void {
   actions.appendChild(button(assistantState.subtitleRefreshing ? '检测中...' : '重新检测字幕', 'bdc-assistant-button bdc-assistant-button-quiet', () => {
     void refreshSubtitleEvidenceFromPage();
   }, assistantState.subtitleRefreshing || assistantState.context?.kind !== 'video'));
+  if (assistantState.context?.kind === 'video') actions.append(learningEditorButton('note'), learningEditorButton('bookmark'));
   actions.appendChild(button('收起', 'bdc-assistant-button bdc-assistant-button-quiet', () => {
     assistantState.expanded = false;
     renderAssistantShell();

--- a/src/content/player-monitor/current-video-context.ts
+++ b/src/content/player-monitor/current-video-context.ts
@@ -324,7 +324,7 @@ function getInitialStateFromScriptTag(): BiliInitialState | null {
   return null;
 }
 
-async function readPageRuntimeSnapshotFromBridge(): Promise<BiliPageRuntimeSnapshot | null> {
+export async function readPageRuntimeSnapshotFromBridge(): Promise<BiliPageRuntimeSnapshot | null> {
   if (typeof window === 'undefined' || typeof window.postMessage !== 'function') return null;
 
   const requestId = `bili-bill-${Date.now()}-${Math.random().toString(36).slice(2)}`;

--- a/src/content/player-monitor/index.ts
+++ b/src/content/player-monitor/index.ts
@@ -1,6 +1,6 @@
 import { renderCurrentVideoAssistant } from './assistant-status';
-import { LearningCaptureStore } from './learning-capture.ts';
-import { collectCurrentVideoContext, isVideoPage, withVideoElementDuration } from './current-video-context';
+import { LearningCaptureStore, learningRuntimeMatches } from './learning-capture.ts';
+import { collectCurrentVideoContext, isVideoPage, withVideoElementDuration, readPageRuntimeSnapshotFromBridge } from './current-video-context';
 import { attachEventListeners, type VideoContext } from './event-capture';
 import { startHeartbeat } from './heartbeat';
 import {
@@ -157,12 +157,8 @@ async function initializeMonitorForSnapshot(snapshot: NavigationSnapshot): Promi
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   if (message?.action === 'CAPTURE_LEARNING_CONTEXT' || message?.action === 'CHECK_LEARNING_CONTEXT') {
-    handlePossibleNavigation();
-    const state = { context: latestContext, navigationKey: `${navigationEpoch}:${lastUrl}`, video: currentUsableVideoElement(), url: location.href };
-    const capture = message.action === 'CAPTURE_LEARNING_CONTEXT'
-      ? learningCaptures.capture(message.kind, state) : learningCaptures.check(message.token, state);
-    sendResponse({ capture });
-    return false;
+    void handleLearningCapture(message).then(capture => sendResponse({ capture })).catch(() => sendResponse({ capture: null }));
+    return true;
   }
   if (message?.action === 'CURRENT_VIDEO_TIMESTAMP_JUMP') {
     handleCurrentVideoTimestampJump(message.payload).then(sendResponse).catch(() => {
@@ -209,6 +205,20 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
   return false;
 });
+
+async function handleLearningCapture(message: { action: string; kind: 'note' | 'bookmark'; token: string }) {
+  handlePossibleNavigation();
+  const snapshot = currentNavigationSnapshot();
+  const video = currentUsableVideoElement();
+  // Same-URL player updates do not advance the navigation epoch. Read the live bridge for every capture/check.
+  const runtime = await readPageRuntimeSnapshotFromBridge();
+  if (!runtime || !navigationSnapshotIsCurrent(snapshot)) return null;
+  const context = await collectCurrentVideoContext({ readPageRuntime: async () => runtime, fetchViewInfo: async () => null });
+  if (!navigationSnapshotIsCurrent(snapshot) || video !== currentUsableVideoElement() || !learningRuntimeMatches(context, runtime)) return null;
+  const state = { context, navigationKey: `${snapshot.epoch}:${snapshot.href}`, video, url: snapshot.href };
+  return message.action === 'CAPTURE_LEARNING_CONTEXT'
+    ? learningCaptures.capture(message.kind, state) : learningCaptures.check(message.token, state);
+}
 
 async function collectAndPublishCurrentVideoContext(
   snapshot: NavigationSnapshot = currentNavigationSnapshot(),

--- a/src/content/player-monitor/index.ts
+++ b/src/content/player-monitor/index.ts
@@ -1,4 +1,5 @@
 import { renderCurrentVideoAssistant } from './assistant-status';
+import { LearningCaptureStore } from './learning-capture.ts';
 import { collectCurrentVideoContext, isVideoPage, withVideoElementDuration } from './current-video-context';
 import { attachEventListeners, type VideoContext } from './event-capture';
 import { startHeartbeat } from './heartbeat';
@@ -30,6 +31,7 @@ let latestContext: CurrentVideoContextResult | null = null;
 let currentVideoTimestampReturnPoint: CurrentVideoTimestampReturnPoint | null = null;
 let lastUrl = location.href;
 let navigationEpoch = 0;
+const learningCaptures = new LearningCaptureStore();
 let timestampOperationEpoch = 0;
 const monitorInitializationKeys = new Set<string>();
 
@@ -154,6 +156,14 @@ async function initializeMonitorForSnapshot(snapshot: NavigationSnapshot): Promi
 }
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message?.action === 'CAPTURE_LEARNING_CONTEXT' || message?.action === 'CHECK_LEARNING_CONTEXT') {
+    handlePossibleNavigation();
+    const state = { context: latestContext, navigationKey: `${navigationEpoch}:${lastUrl}`, video: currentUsableVideoElement(), url: location.href };
+    const capture = message.action === 'CAPTURE_LEARNING_CONTEXT'
+      ? learningCaptures.capture(message.kind, state) : learningCaptures.check(message.token, state);
+    sendResponse({ capture });
+    return false;
+  }
   if (message?.action === 'CURRENT_VIDEO_TIMESTAMP_JUMP') {
     handleCurrentVideoTimestampJump(message.payload).then(sendResponse).catch(() => {
       sendResponse({

--- a/src/content/player-monitor/learning-capture.ts
+++ b/src/content/player-monitor/learning-capture.ts
@@ -4,6 +4,29 @@ import {
   type LearningCapture,
 } from "../../shared/learning.ts";
 import type { CurrentVideoContextResult } from "../../shared/types/current-video-context.ts";
+import type { BiliPageRuntimeSnapshot } from "./current-video-context.ts";
+
+export function learningRuntimeMatches(
+  context: CurrentVideoContextResult,
+  runtime: BiliPageRuntimeSnapshot,
+): boolean {
+  if (context.kind !== "video") return false;
+  const player = runtime.playerInfo;
+  if (!player) return true;
+  const bvid = player.bvid ?? player.videoData?.bvid;
+  const cid = player.currentPart?.cid ?? player.cid ?? player.videoData?.cid;
+  const page =
+    player.currentPart?.page ??
+    player.page ??
+    player.p ??
+    player.videoData?.page ??
+    player.videoData?.p;
+  return (
+    (!bvid || bvid === context.bvid) &&
+    (cid == null || cid === context.cid) &&
+    (page == null || page === context.currentPart.page)
+  );
+}
 
 export interface LearningPageState {
   context: CurrentVideoContextResult | null;
@@ -18,6 +41,7 @@ export class LearningCaptureStore {
       capture: LearningCapture;
       navigationKey: string;
       video: HTMLVideoElement | null;
+      mediaSource: string | null;
       expiresAt: number;
     }
   >();
@@ -65,6 +89,7 @@ export class LearningCaptureStore {
       capture,
       navigationKey: state.navigationKey,
       video: state.video,
+      mediaSource: state.video?.currentSrc ?? null,
       expiresAt: Date.now() + 600_000,
     });
     return structuredClone(capture);
@@ -87,6 +112,7 @@ export class LearningCaptureStore {
     if (
       saved.capture.kind === "bookmark" &&
       (state.video !== saved.video ||
+        (state.video?.currentSrc ?? null) !== saved.mediaSource ||
         !state.video?.isConnected ||
         !Number.isFinite(state.video.duration) ||
         saved.capture.bookmarkMs! > state.video.duration * 1000)

--- a/src/content/player-monitor/learning-capture.ts
+++ b/src/content/player-monitor/learning-capture.ts
@@ -1,0 +1,114 @@
+import {
+  newLearningId,
+  type LearningAsset,
+  type LearningCapture,
+} from "../../shared/learning.ts";
+import type { CurrentVideoContextResult } from "../../shared/types/current-video-context.ts";
+
+export interface LearningPageState {
+  context: CurrentVideoContextResult | null;
+  navigationKey: string;
+  video: HTMLVideoElement | null;
+  url: string;
+}
+export class LearningCaptureStore {
+  private captures = new Map<
+    string,
+    {
+      capture: LearningCapture;
+      navigationKey: string;
+      video: HTMLVideoElement | null;
+      expiresAt: number;
+    }
+  >();
+  capture(
+    kind: LearningAsset["kind"],
+    state: LearningPageState,
+  ): LearningCapture | null {
+    if (kind !== "note" && kind !== "bookmark") return null;
+    const context = state.context;
+    if (
+      !context ||
+      context.kind !== "video" ||
+      !matchesPage(context, state.url)
+    )
+      return null;
+    const part =
+      Number.isSafeInteger(context.cid) && context.cid! > 0
+        ? { cid: String(context.cid), page: context.currentPart.page }
+        : null;
+    let bookmarkMs: number | null = null;
+    if (kind === "bookmark") {
+      const video = state.video;
+      if (
+        !part ||
+        !video?.isConnected ||
+        !Number.isFinite(video.currentTime) ||
+        !Number.isFinite(video.duration) ||
+        video.duration <= 0 ||
+        video.currentTime < 0 ||
+        video.currentTime > video.duration
+      )
+        return null;
+      bookmarkMs = Math.floor(video.currentTime * 1000);
+    }
+    const capture: LearningCapture = {
+      token: newLearningId(),
+      kind,
+      video: { bvid: context.bvid, title: context.title ?? "" },
+      part,
+      bookmarkMs,
+    };
+    while (this.captures.size >= 16)
+      this.captures.delete(this.captures.keys().next().value!);
+    this.captures.set(capture.token, {
+      capture,
+      navigationKey: state.navigationKey,
+      video: state.video,
+      expiresAt: Date.now() + 600_000,
+    });
+    return structuredClone(capture);
+  }
+  check(token: string, state: LearningPageState): LearningCapture | null {
+    const saved = this.captures.get(token);
+    const context = state.context;
+    if (
+      !saved ||
+      saved.expiresAt < Date.now() ||
+      saved.navigationKey !== state.navigationKey ||
+      context?.kind !== "video" ||
+      !matchesPage(context, state.url) ||
+      context.bvid !== saved.capture.video.bvid ||
+      (saved.capture.part !== null &&
+        (String(context.cid) !== saved.capture.part.cid ||
+          context.currentPart.page !== saved.capture.part.page))
+    )
+      return null;
+    if (
+      saved.capture.kind === "bookmark" &&
+      (state.video !== saved.video ||
+        !state.video?.isConnected ||
+        !Number.isFinite(state.video.duration) ||
+        saved.capture.bookmarkMs! > state.video.duration * 1000)
+    )
+      return null;
+    return structuredClone(saved.capture);
+  }
+}
+function matchesPage(
+  context: Extract<CurrentVideoContextResult, { kind: "video" }>,
+  href: string,
+): boolean {
+  try {
+    const url = new URL(href);
+    return (
+      url.protocol === "https:" &&
+      (url.hostname === "www.bilibili.com" ||
+        url.hostname === "bilibili.com") &&
+      url.pathname.split("/")[2] === context.bvid &&
+      Number(url.searchParams.get("p") ?? 1) === context.currentPart.page
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/content/player-monitor/learning-editor.ts
+++ b/src/content/player-monitor/learning-editor.ts
@@ -1,0 +1,300 @@
+import {
+  newLearningId,
+  learningTime,
+  type LearningAsset,
+  type LearningPrepared,
+} from "../../shared/learning.ts";
+import { learningIcon } from "../../shared/learning-icons.ts";
+import type {
+  BiliVizResponse,
+  RequestAction,
+} from "../../shared/types/messages.ts";
+
+const DIALOG_ID = "bb-learning-editor";
+const drafts = new Map<
+  LearningAsset["kind"],
+  {
+    title: string;
+    note: string;
+    pending?: { prepared: LearningPrepared; asset: LearningAsset };
+  }
+>();
+const CSS = `
+#bb-learning-editor{box-sizing:border-box;position:fixed;inset:0;margin:auto;padding:0;border:1px solid #e3e5e7;border-radius:8px;width:520px;max-width:calc(100vw - 24px);max-height:calc(100dvh - 24px);background:#fff;color:#18191c;font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI","Microsoft YaHei",sans-serif;letter-spacing:0;z-index:2147483647;box-shadow:0 12px 48px #0003;overflow:auto}
+#bb-learning-editor *{box-sizing:border-box;font:inherit;letter-spacing:0}
+#bb-learning-editor::backdrop{background:#0006}
+#bb-learning-editor header,#bb-learning-editor footer{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:16px 20px}
+#bb-learning-editor header{border-bottom:1px solid #e3e5e7}#bb-learning-editor header strong{font-size:16px;font-weight:600}
+#bb-learning-editor button{display:inline-flex;align-items:center;justify-content:center;gap:6px;min-height:34px;border:1px solid #dce0e3;border-radius:6px;padding:6px 12px;background:transparent;color:inherit;cursor:pointer;white-space:normal}
+#bb-learning-editor button:disabled{opacity:.5;cursor:default}#bb-learning-editor button:focus-visible,#bb-learning-editor input:focus-visible,#bb-learning-editor textarea:focus-visible{outline:2px solid #00aeec;outline-offset:2px}
+#bb-learning-editor [hidden]{display:none!important}
+#bb-learning-editor button.primary{background:#00aeec;color:white;border-color:#00aeec}
+#bb-learning-editor .fields{padding:16px 20px 0}#bb-learning-editor label{display:block;margin:12px 0 5px;color:#61666d}
+#bb-learning-editor input,#bb-learning-editor textarea{display:block;width:100%;border:1px solid #dce0e3;border-radius:6px;padding:10px 12px;background:transparent;color:inherit}
+#bb-learning-editor textarea{height:170px;min-height:90px;max-height:35dvh;resize:vertical;line-height:1.7}
+#bb-learning-editor .source{color:#61666d;overflow-wrap:anywhere}#bb-learning-editor .status{padding:0 20px;min-height:24px;color:#61666d;overflow-wrap:anywhere}
+#bb-learning-editor a{color:#00aeec;text-decoration:none}#bb-learning-editor .footer-actions{display:flex;gap:8px}
+#bb-learning-editor[data-theme=dark]{background:#202124;color:#e3e5e7;border-color:#424448}#bb-learning-editor[data-theme=dark] .source,#bb-learning-editor[data-theme=dark] label,#bb-learning-editor[data-theme=dark] .status{color:#b3b6bb}
+@media(max-height:480px){#bb-learning-editor header,#bb-learning-editor footer{padding:10px 16px}#bb-learning-editor .fields{padding:8px 16px 0}#bb-learning-editor textarea{height:90px}}
+`;
+async function request<T>(
+  action: RequestAction,
+  params?: Record<string, unknown>,
+): Promise<T> {
+  const response: BiliVizResponse<T> = await chrome.runtime.sendMessage({
+    action,
+    params,
+  });
+  if (!response?.success)
+    throw Error(response?.error ?? "连接已中断，请重试确认保存结果。");
+  return response.data as T;
+}
+export function learningEditorButton(
+  kind: LearningAsset["kind"],
+): HTMLButtonElement {
+  const button = document.createElement("button");
+  button.className = "bdc-assistant-button bdc-assistant-button-quiet";
+  const label = kind === "note" ? "记笔记" : "存书签";
+  button.type = "button";
+  button.title = label;
+  button.setAttribute("aria-label", label);
+  button.append(learningIcon(kind));
+  button.onclick = () => {
+    void openLearningEditor(kind, button);
+  };
+  return button;
+}
+
+async function openLearningEditor(
+  kind: LearningAsset["kind"],
+  trigger: HTMLElement,
+) {
+  const open = document.getElementById(DIALOG_ID) as HTMLDialogElement | null;
+  if (open) {
+    open.focus();
+    return;
+  }
+  if (!document.getElementById(`${DIALOG_ID}-style`)) {
+    const style = document.createElement("style");
+    style.id = `${DIALOG_ID}-style`;
+    style.textContent = CSS;
+    document.head.append(style);
+  }
+  const dialog = document.createElement("dialog");
+  dialog.id = DIALOG_ID;
+  dialog.setAttribute("aria-label", kind === "note" ? "记笔记" : "存书签");
+  dialog.dataset.theme =
+    document.getElementById("bdc-current-video-assistant")?.dataset.theme ??
+    (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+  const draft = drafts.get(kind) ?? { title: "", note: "" };
+  drafts.set(kind, draft);
+  const header = document.createElement("header");
+  const heading = document.createElement("strong");
+  heading.textContent = kind === "note" ? "记笔记" : "存书签";
+  const close = document.createElement("button");
+  close.title = "关闭并保留草稿";
+  close.setAttribute("aria-label", close.title);
+  close.append(learningIcon("close"));
+  header.append(heading, close);
+  const fields = document.createElement("div");
+  fields.className = "fields";
+  const source = document.createElement("div");
+  source.className = "source";
+  source.textContent = "正在确认当前视频";
+  const titleLabel = document.createElement("label");
+  titleLabel.htmlFor = "bb-learning-title";
+  titleLabel.textContent = "标题";
+  const title = document.createElement("input");
+  title.id = titleLabel.htmlFor;
+  title.maxLength = 4096;
+  title.value = draft.title;
+  const noteLabel = document.createElement("label");
+  noteLabel.htmlFor = "bb-learning-note";
+  noteLabel.textContent = kind === "note" ? "笔记" : "备注（选填）";
+  const note = document.createElement("textarea");
+  note.id = noteLabel.htmlFor;
+  note.value = draft.note;
+  fields.append(source, titleLabel, title, noteLabel, note);
+  const status = document.createElement("p");
+  status.className = "status";
+  status.setAttribute("role", "status");
+  const footer = document.createElement("footer");
+  const link = document.createElement("a");
+  link.textContent = "学习笔记";
+  link.href = chrome.runtime.getURL("dashboard/index.html#learning-notes");
+  link.target = "_blank";
+  link.rel = "noopener noreferrer";
+  const actions = document.createElement("div");
+  actions.className = "footer-actions";
+  const cancel = document.createElement("button");
+  cancel.textContent = "取消保存";
+  cancel.hidden = true;
+  const recheck = document.createElement("button");
+  recheck.title = "重新确认当前视频";
+  recheck.setAttribute("aria-label", recheck.title);
+  recheck.append(learningIcon("refresh"));
+  recheck.hidden = true;
+  const save = document.createElement("button");
+  save.className = "primary";
+  save.textContent = "保存";
+  save.disabled = true;
+  actions.append(recheck, cancel, save);
+  footer.append(link, actions);
+  dialog.append(header, fields, status, footer);
+  document.body.append(dialog);
+  dialog.showModal();
+  note.focus();
+  let busy = false;
+  let prepared: LearningPrepared | undefined;
+  let saved = false;
+  const persistDraft = () => {
+    draft.title = title.value;
+    draft.note = note.value;
+  };
+  const closeDialog = () => {
+    if (busy) return;
+    if (!saved) persistDraft();
+    dialog.close();
+    dialog.remove();
+    trigger.isConnected && trigger.focus();
+  };
+  close.onclick = closeDialog;
+  dialog.addEventListener("cancel", (event) => {
+    event.preventDefault();
+    closeDialog();
+  });
+  const changed = () => {
+    persistDraft();
+    saved = false;
+    if (draft.pending) {
+      status.textContent = "先确认上次保存结果，再开始新的笔记。";
+      return;
+    }
+    save.textContent = "保存";
+    save.disabled = !prepared || (kind === "note" && !note.value.trim());
+  };
+  title.oninput = changed;
+  note.oninput = changed;
+  try {
+    prepared =
+      draft.pending?.prepared ??
+      (await request<LearningPrepared>("LEARNING_PREPARE", { kind }));
+    if (!dialog.isConnected) return;
+    const capture = prepared.capture;
+    source.textContent = `${capture.video.title || "当前视频"}${capture.part ? ` · P${capture.part.page}` : ""}${capture.bookmarkMs !== null ? ` · ${learningTime(capture.bookmarkMs)}` : ""}`;
+    if (!title.value)
+      title.value =
+        kind === "note"
+          ? ""
+          : `${learningTime(capture.bookmarkMs ?? 0)} 的书签`;
+    if (draft.pending) {
+      title.value = draft.pending.asset.personal.title;
+      note.value = draft.pending.asset.personal.note;
+      title.disabled = true;
+      note.disabled = true;
+      save.textContent = "重试确认";
+    }
+    save.disabled = kind === "note" && !note.value.trim();
+  } catch (error) {
+    status.textContent =
+      error instanceof Error ? error.message : "当前视频暂不可用，草稿仍保留。";
+    recheck.hidden = false;
+  }
+  recheck.onclick = async () => {
+    recheck.disabled = true;
+    try {
+      prepared = await request<LearningPrepared>("LEARNING_PREPARE", { kind });
+      const capture = prepared.capture;
+      source.textContent = `${capture.video.title || "当前视频"}${capture.part ? ` · P${capture.part.page}` : ""}${capture.bookmarkMs !== null ? ` · ${learningTime(capture.bookmarkMs)}` : ""}`;
+      status.textContent = "已重新确认，请核对后保存。";
+      recheck.hidden = true;
+      changed();
+    } catch {
+      status.textContent = "当前视频暂不可用，草稿仍保留。";
+    } finally {
+      recheck.disabled = false;
+    }
+  };
+  cancel.onclick = async () => {
+    if (!draft.pending) return;
+    cancel.disabled = true;
+    try {
+      const result = await request<{ phase: string }>("LEARNING_CANCEL", {
+        id: draft.pending.asset.id,
+      });
+      status.textContent =
+        result.phase === "committing"
+          ? "正在提交，等待实际保存结果。"
+          : "正在确认取消结果。";
+    } catch {
+      status.textContent = "连接已中断，等待保存结果后再重试。";
+    }
+  };
+  save.onclick = async () => {
+    if (busy || saved || !prepared) return;
+    persistDraft();
+    if (!draft.pending) {
+      const now = Date.now();
+      draft.pending = {
+        prepared,
+        asset: {
+          id: newLearningId(),
+          kind,
+          createdAt: now,
+          updatedAt: now,
+          video: prepared.capture.video,
+          part: prepared.capture.part,
+          personal: { title: title.value, note: note.value, tags: [] },
+          snapshot: null,
+          bookmarkMs: prepared.capture.bookmarkMs,
+          importedFrom: null,
+        },
+      };
+    }
+    busy = true;
+    save.disabled = true;
+    close.disabled = true;
+    title.disabled = true;
+    note.disabled = true;
+    cancel.hidden = false;
+    cancel.disabled = false;
+    status.textContent = "正在保存；提交后无法取消。";
+    try {
+      await request("LEARNING_SAVE", {
+        epoch: draft.pending.prepared.epoch,
+        token: draft.pending.prepared.capture.token,
+        asset: draft.pending.asset,
+      });
+      status.textContent = "已保存";
+      saved = true;
+      save.textContent = "已保存";
+      draft.pending = undefined;
+      draft.title = "";
+      draft.note = "";
+    } catch (error) {
+      status.textContent =
+        error instanceof Error ? error.message : "保存结果待确认，请重试。";
+      save.textContent = "重试确认";
+      // A transport failure may follow a committed write. Keep the identical ID/content until acknowledged.
+      if (
+        status.textContent.includes("已取消") ||
+        status.textContent.includes("已变化") ||
+        status.textContent.includes("空间已满")
+      ) {
+        draft.pending = undefined;
+        title.disabled = false;
+        note.disabled = false;
+        save.textContent = "保存";
+        if (status.textContent.includes("已变化")) {
+          prepared = undefined;
+          recheck.hidden = false;
+        }
+      }
+    } finally {
+      busy = false;
+      close.disabled = false;
+      cancel.hidden = true;
+      save.disabled = saved || !prepared;
+    }
+  };
+}

--- a/src/content/player-monitor/learning-editor.ts
+++ b/src/content/player-monitor/learning-editor.ts
@@ -5,10 +5,7 @@ import {
   type LearningPrepared,
 } from "../../shared/learning.ts";
 import { learningIcon } from "../../shared/learning-icons.ts";
-import type {
-  BiliVizResponse,
-  RequestAction,
-} from "../../shared/types/messages.ts";
+import { requestLearning as request } from "./learning-request.ts";
 
 const DIALOG_ID = "bb-learning-editor";
 const drafts = new Map<
@@ -37,18 +34,6 @@ const CSS = `
 #bb-learning-editor[data-theme=dark]{background:#202124;color:#e3e5e7;border-color:#424448}#bb-learning-editor[data-theme=dark] .source,#bb-learning-editor[data-theme=dark] label,#bb-learning-editor[data-theme=dark] .status{color:#b3b6bb}
 @media(max-height:480px){#bb-learning-editor header,#bb-learning-editor footer{padding:10px 16px}#bb-learning-editor .fields{padding:8px 16px 0}#bb-learning-editor textarea{height:90px}}
 `;
-async function request<T>(
-  action: RequestAction,
-  params?: Record<string, unknown>,
-): Promise<T> {
-  const response: BiliVizResponse<T> = await chrome.runtime.sendMessage({
-    action,
-    params,
-  });
-  if (!response?.success)
-    throw Error(response?.error ?? "连接已中断，请重试确认保存结果。");
-  return response.data as T;
-}
 export function learningEditorButton(
   kind: LearningAsset["kind"],
 ): HTMLButtonElement {

--- a/src/content/player-monitor/learning-request.ts
+++ b/src/content/player-monitor/learning-request.ts
@@ -1,0 +1,20 @@
+import type {
+  BiliVizResponse,
+  RequestAction,
+} from "../../shared/types/messages.ts";
+
+const CONNECTION_MESSAGE = "连接已中断，请重试确认保存结果。";
+
+export async function requestLearning<T>(
+  action: RequestAction,
+  params?: Record<string, unknown>,
+): Promise<T> {
+  let response: BiliVizResponse<T>;
+  try {
+    response = await chrome.runtime.sendMessage({ action, params });
+  } catch {
+    throw Error(CONNECTION_MESSAGE);
+  }
+  if (!response?.success) throw Error(response?.error ?? CONNECTION_MESSAGE);
+  return response.data as T;
+}

--- a/src/shared/learning-icons.ts
+++ b/src/shared/learning-icons.ts
@@ -1,0 +1,40 @@
+// Lucide 94e4cb9d9db5907053ebf3636a97c45529cf776b; notices in third_party/licenses/Lucide.txt.
+export const learningIconPaths = {
+  note: [
+    "M13.4 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7.4",
+    "M2 6h4",
+    "M2 10h4",
+    "M2 14h4",
+    "M2 18h4",
+    "M21.378 5.626a1 1 0 1 0-3.004-3.004l-5.01 5.012a2 2 0 0 0-.506.854l-.837 2.87a.5.5 0 0 0 .62.62l2.87-.837a2 2 0 0 0 .854-.506z",
+  ],
+  bookmark: [
+    "M17 3a2 2 0 0 1 2 2v15a1 1 0 0 1-1.496.868l-4.512-2.578a2 2 0 0 0-1.984 0l-4.512 2.578A1 1 0 0 1 5 20V5a2 2 0 0 1 2-2z",
+  ],
+  close: ["M18 6 6 18", "m6 6 12 12"],
+  refresh: ["M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8", "M21 3v5h-5"],
+};
+export function learningIcon(
+  name: keyof typeof learningIconPaths,
+): SVGSVGElement {
+  const ns = "http://www.w3.org/2000/svg";
+  const svg = document.createElementNS(ns, "svg");
+  for (const [key, value] of Object.entries({
+    viewBox: "0 0 24 24",
+    width: "18",
+    height: "18",
+    fill: "none",
+    stroke: "currentColor",
+    "stroke-width": "1.8",
+    "stroke-linecap": "round",
+    "stroke-linejoin": "round",
+    "aria-hidden": "true",
+  }))
+    svg.setAttribute(key, value);
+  for (const d of learningIconPaths[name]) {
+    const path = document.createElementNS(ns, "path");
+    path.setAttribute("d", d);
+    svg.append(path);
+  }
+  return svg;
+}

--- a/src/shared/learning.ts
+++ b/src/shared/learning.ts
@@ -1,0 +1,197 @@
+export const LEARNING_MAX_ASSETS = 1_000;
+export const LEARNING_MAX_BYTES = 10_485_760;
+
+export interface LearningAsset {
+  id: string;
+  kind: "note" | "bookmark";
+  createdAt: number;
+  updatedAt: number;
+  video: { bvid: string; title: string };
+  part: { cid: string; page: number } | null;
+  personal: { title: string; note: string; tags: string[] };
+  snapshot: null;
+  bookmarkMs: number | null;
+  importedFrom: null;
+}
+export interface LearningMeta {
+  key: "state";
+  epoch: number;
+  revision: number;
+}
+export interface LearningCapture {
+  token: string;
+  kind: LearningAsset["kind"];
+  video: LearningAsset["video"];
+  part: LearningAsset["part"];
+  bookmarkMs: number | null;
+}
+export interface LearningPrepared {
+  epoch: number;
+  capture: LearningCapture;
+}
+export interface LearningListItem {
+  id: string;
+  kind: LearningAsset["kind"];
+  title: string;
+  preview: string;
+  videoTitle: string;
+  page: number | null;
+  bookmarkMs: number | null;
+  createdAt: number;
+}
+export interface LearningList {
+  epoch: number;
+  total: number;
+  items: LearningListItem[];
+  offset: number;
+}
+
+export function learningAssert(value: unknown, code: string): asserts value {
+  if (!value) throw new Error(code);
+}
+function fields(
+  value: unknown,
+  names: string[],
+): asserts value is Record<string, unknown> {
+  learningAssert(
+    value && typeof value === "object" && !Array.isArray(value),
+    "fields",
+  );
+  learningAssert(
+    Object.keys(value).sort().join(",") === names.sort().join(","),
+    "fields",
+  );
+}
+function text(
+  value: unknown,
+  max = LEARNING_MAX_BYTES,
+): asserts value is string {
+  learningAssert(
+    typeof value === "string" &&
+      value.length <= max &&
+      !/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u.test(
+        value,
+      ),
+    "string",
+  );
+}
+export function learningId(value: unknown): asserts value is string {
+  learningAssert(
+    typeof value === "string" && /^[a-f0-9]{64}$/.test(value),
+    "id",
+  );
+}
+export function learningInteger(
+  value: unknown,
+  min = 0,
+): asserts value is number {
+  learningAssert(
+    Number.isSafeInteger(value) && (value as number) >= min,
+    "integer",
+  );
+}
+
+// Keep the frozen LG-0 wire format. Capture supports only LG-1 asset kinds.
+export function validateLearningAsset(
+  row: unknown,
+): asserts row is LearningAsset {
+  fields(row, [
+    "id",
+    "kind",
+    "createdAt",
+    "updatedAt",
+    "video",
+    "part",
+    "personal",
+    "snapshot",
+    "bookmarkMs",
+    "importedFrom",
+  ]);
+  learningId(row.id);
+  learningAssert(row.kind === "note" || row.kind === "bookmark", "kind");
+  learningInteger(row.createdAt);
+  learningInteger(row.updatedAt, row.createdAt);
+  fields(row.video, ["bvid", "title"]);
+  learningAssert(
+    typeof row.video.bvid === "string" &&
+      /^BV[a-zA-Z0-9]{10}$/.test(row.video.bvid),
+    "bvid",
+  );
+  text(row.video.title, 4096);
+  if (row.part !== null) {
+    fields(row.part, ["cid", "page"]);
+    learningAssert(
+      typeof row.part.cid === "string" &&
+        /^[1-9][0-9]{0,19}$/.test(row.part.cid),
+      "cid",
+    );
+    learningInteger(row.part.page, 1);
+  }
+  fields(row.personal, ["title", "note", "tags"]);
+  text(row.personal.title, 4096);
+  text(row.personal.note);
+  learningAssert(
+    Array.isArray(row.personal.tags) && row.personal.tags.length <= 64,
+    "tags",
+  );
+  for (const tag of row.personal.tags) text(tag, 256);
+  learningAssert(
+    new Set(row.personal.tags).size === row.personal.tags.length,
+    "tags",
+  );
+  learningAssert(
+    row.snapshot === null && row.importedFrom === null,
+    "capture_only",
+  );
+  if (row.kind === "bookmark") {
+    learningAssert(row.part !== null, "bookmark_part");
+    learningInteger(row.bookmarkMs);
+  } else learningAssert(row.bookmarkMs === null, "bookmark");
+}
+
+export function canonicalLearning(value: unknown): string {
+  return JSON.stringify(value, (_key, item) =>
+    item !== null && typeof item === "object" && !Array.isArray(item)
+      ? Object.fromEntries(
+          Object.keys(item)
+            .sort()
+            .map((key) => [key, item[key]]),
+        )
+      : item,
+  );
+}
+export function learningBytes(rows: readonly unknown[]): number {
+  let bytes = 2 + Math.max(0, rows.length - 1);
+  for (const row of rows) {
+    const encoded = canonicalLearning(row);
+    for (let i = 0; i < encoded.length; i++) {
+      const code = encoded.charCodeAt(i);
+      if (code < 0x80) bytes++;
+      else if (code < 0x800) bytes += 2;
+      else if (code >= 0xd800 && code <= 0xdbff) {
+        bytes += 4;
+        i++;
+      } else bytes += 3;
+    }
+  }
+  return bytes;
+}
+export function newLearningId(): string {
+  return Array.from(crypto.getRandomValues(new Uint8Array(32)), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+export function learningTime(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
+}
+export function learningError(error: unknown): string {
+  const code = error instanceof Error ? error.message : "";
+  if (code.includes("capacity")) return "学习笔记空间已满，原有内容未改变。";
+  if (code === "cancelled") return "已取消保存，草稿仍保留。";
+  if (code.includes("stale") || code === "capture_only")
+    return "视频或保存状态已变化，请重新确认；草稿仍保留。";
+  if (code.includes("identity")) return "这次保存的内容已变化，请重新确认。";
+  if (code === "busy_retry") return "另一个保存正在进行，请重试。";
+  return "操作未完成，请重试；原有笔记与草稿仍保留。";
+}

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -57,6 +57,12 @@ import type {
 
 // 弹窗 / 面板 → Service Worker
 export type RequestAction =
+  | 'LEARNING_LIST'
+  | 'LEARNING_GET'
+  | 'LEARNING_DELETE'
+  | 'LEARNING_PREPARE'
+  | 'LEARNING_SAVE'
+  | 'LEARNING_CANCEL'
   | 'GET_QUICK_STATS'
   | 'GET_DASHBOARD_DATA'
   | 'GET_PREFERENCE_DATA'

--- a/tests/current-video-transcript-cache.test.ts
+++ b/tests/current-video-transcript-cache.test.ts
@@ -1495,7 +1495,9 @@ test('real Dexie v9 to current upgrade clears legacy transcript rows and adds 0.
   try {
     await upgraded.open();
 
-    assert.equal(upgraded.verno, 13);
+    assert.equal(upgraded.verno, 14);
+    assert.equal(await upgraded.lgAssets.count(), 0);
+    assert.equal(await upgraded.lgMeta.count(), 0);
     assert.equal(await upgraded.currentVideoTranscriptSources.count(), 0);
     assert.equal(await upgraded.currentVideoTranscriptSegments.count(), 0);
     assert.equal((await upgraded.watchHistory.where('bvid').equals('BV1MigrationKeep').first())?.title, 'Kept history BV1MigrationKeep');

--- a/tests/fixtures/learning-v13.ts
+++ b/tests/fixtures/learning-v13.ts
@@ -1,0 +1,67 @@
+import Dexie from "dexie";
+
+// Frozen production v13 schema from e2a7c5140d6574abc870d547f05eb4b2778a2b69.
+export const V13_STORES = {
+  watchHistory:
+    "++id, kid, &sessionKey, avid, bvid, [avid+cid+viewAt], authorMid, tagName, viewAt, dt",
+  playerEvents: "++id, [bvid+cid], eventType, timestamp, tabId",
+  dailyAggregates: "++id, &date",
+  favoriteFolders: "++id, &mediaId, title, syncedAt",
+  favoriteItems:
+    "++id, &itemKey, mediaId, avid, bvid, authorMid, tagName, favTime, syncedAt",
+  smartFavoriteIndex: "++id, &itemKey, status, indexedAt, contentHash",
+  followedCreators:
+    "++id, &mid, followedAt, followAgeKnown, isActive, firstSeenAt, syncedAt, lastSeenAt",
+  followedVideoUpdates:
+    "++id, &updateKey, dynamicId, bvid, authorMid, dynamicTime, pubtime, syncedAt",
+  dynamicBillItems:
+    "++id, &billKey, column, status, creatorMid, updateKey, generatedAt, localRank",
+  dynamicBillFeedback:
+    "++id, [scope+key], scope, key, creatorMid, billKey, column, createdAt",
+  dynamicBillExplanations:
+    "++id, &billKey, status, generatedAt, model, contentHash",
+  dynamicBillCreatorPauses:
+    "++id, &creatorMid, expiresAt, startedAt, source, actionKey, updatedAt",
+  dynamicBillFeedbackActions:
+    "++id, &actionKey, undoToken, billKey, creatorMid, [billKey+creatorMid], state, undoDeadlineAt, createdAt, finalizedAt",
+  dynamicBillCreatorFeedbackCounts:
+    "++id, &creatorMid, effectiveCount, updatedAt",
+  dynamicBillCreatorReviewPrompts:
+    "++id, &creatorMid, state, createdAt, updatedAt",
+  dynamicBillRotationRecords:
+    "++id, &creatorMid, lastShownAt, lastColumn, updatedAt",
+  dynamicBillMigrations: "++id, &version, completedAt",
+  currentVideoTranscriptSources:
+    "++id, &identityKey, &sourceIdentityKey, partIdentityKey, bvid, [bvid+cid+page], [bvid+cid+page+language], sourceHash, bodyHash, timelineHash, stale, updatedAt, lastAccessedAt",
+  currentVideoTranscriptSegments:
+    "++id, &segmentId, sourceIdentityKey, bvid, [bvid+cid+page], [bvid+cid+page+language], sourceHash, stale, updatedAt",
+  currentVideoSummaryHighlights:
+    "++id, &cacheKey, sourceIdentityKey, [sourceIdentityKey+model], model, bvid, [bvid+cid+page], generatedAt, lastAccessedAt, serializedBytes",
+  currentVideoQaSessions: "++id, &sessionId, lastAccessedAt, updatedAt",
+};
+export async function seedLearningV13(name: string) {
+  if (!/^lg[01]-[a-zA-Z0-9-]+$/.test(name))
+    throw Error("synthetic_database_only");
+  const db = new Dexie(name);
+  db.version(13).stores(V13_STORES);
+  try {
+    await db.open();
+    for (const table of db.tables)
+      await table.put({ id: 1, lg0SyntheticMarker: table.name });
+    const rows: Record<string, unknown[]> = {};
+    for (const name of Object.keys(V13_STORES))
+      rows[name] = await db.table(name).toArray();
+    const before = JSON.stringify(rows, (_key, item) =>
+      item && typeof item === "object" && !Array.isArray(item)
+        ? Object.fromEntries(
+            Object.keys(item)
+              .sort()
+              .map((key) => [key, item[key]]),
+          )
+        : item,
+    );
+    return { stores: V13_STORES, before };
+  } finally {
+    db.close();
+  }
+}

--- a/tests/learning-capture.test.ts
+++ b/tests/learning-capture.test.ts
@@ -2,9 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   LearningCaptureStore,
+  learningRuntimeMatches,
   type LearningPageState,
 } from "../src/content/player-monitor/learning-capture.ts";
 import type { CurrentVideoContext } from "../src/shared/types/current-video-context.ts";
+import { requestLearning } from "../src/content/player-monitor/learning-request.ts";
 
 function state(): LearningPageState {
   return {
@@ -24,6 +26,66 @@ function state(): LearningPageState {
     } as HTMLVideoElement,
   };
 }
+test("learning live player identity and media source changes reject stale bookmarks", () => {
+  const page = state();
+  const context = page.context!;
+  assert.equal(
+    learningRuntimeMatches(context, {
+      playerInfo: { bvid: "BV1234567890", cid: 42, p: 2 },
+    }),
+    true,
+  );
+  assert.equal(
+    learningRuntimeMatches(context, {
+      playerInfo: { bvid: "BV1234567890", cid: 43, p: 2 },
+    }),
+    false,
+  );
+  assert.equal(
+    learningRuntimeMatches(context, {
+      playerInfo: { bvid: "BV1234567890", cid: 42, p: 3 },
+    }),
+    false,
+  );
+  const store = new LearningCaptureStore();
+  Object.defineProperty(page.video, "currentSrc", {
+    value: "blob:original",
+    configurable: true,
+  });
+  const capture = store.capture("bookmark", page)!;
+  Object.defineProperty(page.video, "currentSrc", {
+    value: "blob:replacement",
+    configurable: true,
+  });
+  assert.equal(store.check(capture.token, page), null);
+});
+test("learning transport rejection exposes controlled Chinese copy and leaves caller retry data unchanged", async () => {
+  const previous = globalThis.chrome;
+  const params = { id: "same-action", note: "保留的草稿" };
+  try {
+    globalThis.chrome = {
+      runtime: {
+        sendMessage: async () => {
+          throw Error("Extension context invalidated: secret runtime detail");
+        },
+      },
+    } as unknown as typeof chrome;
+    await assert.rejects(requestLearning("LEARNING_SAVE", params), {
+      message: "连接已中断，请重试确认保存结果。",
+    });
+    assert.deepEqual(params, { id: "same-action", note: "保留的草稿" });
+    globalThis.chrome.runtime.sendMessage = (async () => ({
+      success: true,
+      data: "acknowledged",
+    })) as typeof chrome.runtime.sendMessage;
+    assert.equal(
+      await requestLearning("LEARNING_SAVE", params),
+      "acknowledged",
+    );
+  } finally {
+    globalThis.chrome = previous;
+  }
+});
 test("learning captures real position without subtitle or AI state", () => {
   const store = new LearningCaptureStore();
   const page = state();

--- a/tests/learning-capture.test.ts
+++ b/tests/learning-capture.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  LearningCaptureStore,
+  type LearningPageState,
+} from "../src/content/player-monitor/learning-capture.ts";
+import type { CurrentVideoContext } from "../src/shared/types/current-video-context.ts";
+
+function state(): LearningPageState {
+  return {
+    navigationKey: "0:video-a",
+    url: "https://www.bilibili.com/video/BV1234567890/?p=2",
+    context: {
+      kind: "video",
+      bvid: "BV1234567890",
+      cid: 42,
+      currentPart: { page: 2 },
+      title: "视频",
+    } as CurrentVideoContext,
+    video: {
+      isConnected: true,
+      currentTime: 12.5,
+      duration: 60,
+    } as HTMLVideoElement,
+  };
+}
+test("learning captures real position without subtitle or AI state", () => {
+  const store = new LearningCaptureStore();
+  const page = state();
+  const capture = store.capture("bookmark", page)!;
+  assert.equal(capture.bookmarkMs, 12_500);
+  assert.deepEqual(capture.part, { cid: "42", page: 2 });
+  page.video!.currentTime = 19;
+  assert.equal(store.check(capture.token, page)?.bookmarkMs, 12_500);
+  assert.equal(
+    store.capture("note", { ...page, video: null })?.bookmarkMs,
+    null,
+  );
+});
+test("learning navigation, part change, player replacement and expired captures cannot save late", () => {
+  const store = new LearningCaptureStore();
+  const page = state();
+  const capture = store.capture("bookmark", page)!;
+  assert.equal(
+    store.check(capture.token, { ...page, navigationKey: "1:video-a" }),
+    null,
+  );
+  assert.equal(
+    store.check(capture.token, {
+      ...page,
+      url: "https://www.bilibili.com/video/BV1234567890/?p=1",
+    }),
+    null,
+  );
+  assert.equal(
+    store.check(capture.token, {
+      ...page,
+      video: { ...page.video } as HTMLVideoElement,
+    }),
+    null,
+  );
+  assert.equal(store.check("unknown", page), null);
+  for (let i = 0; i < 16; i++) store.capture("note", page);
+  assert.equal(store.check(capture.token, page), null);
+});
+test("learning rejects guessed or unusable bookmark positions and mismatched pages", () => {
+  for (const currentTime of [NaN, Infinity, -1, 61]) {
+    const page = state();
+    page.video!.currentTime = currentTime;
+    assert.equal(new LearningCaptureStore().capture("bookmark", page), null);
+  }
+  const page = state();
+  (page.context as CurrentVideoContext).cid = null;
+  assert.equal(new LearningCaptureStore().capture("bookmark", page), null);
+  assert.equal(
+    new LearningCaptureStore().capture("note", {
+      ...page,
+      url: "https://example.com/video/BV1234567890/?p=2",
+    }),
+    null,
+  );
+});

--- a/tests/learning-save.mock.html
+++ b/tests/learning-save.mock.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="zh-CN">
+  <meta charset="utf-8" /><meta
+    name="viewport"
+    content="width=device-width,initial-scale=1"
+  />
+  <title>合成演示 · 从想法到可用产品</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      background: #fff;
+      color: #18191c;
+      font:
+        14px/1.6 system-ui,
+        "Microsoft YaHei",
+        sans-serif;
+      letter-spacing: 0;
+    }
+    header {
+      height: 64px;
+      border-bottom: 1px solid #e3e5e7;
+      display: flex;
+      align-items: center;
+      gap: 30px;
+      padding: 0 32px;
+    }
+    header strong {
+      color: #00aeec;
+      font-size: 24px;
+    }
+    header small {
+      margin-left: auto;
+      color: #9499a0;
+    }
+    main {
+      max-width: 1120px;
+      margin: 32px auto;
+      padding: 0 24px;
+    }
+    h1 {
+      font-size: 22px;
+      font-weight: 500;
+      margin: 0 0 8px;
+    }
+    .meta {
+      color: #9499a0;
+      margin-bottom: 20px;
+    }
+    video {
+      display: block;
+      width: 100%;
+      aspect-ratio: 16/9;
+      background: #101820;
+      border-radius: 0;
+    }
+    footer {
+      display: flex;
+      gap: 30px;
+      padding: 20px 0;
+      color: #61666d;
+      border-bottom: 1px solid #e3e5e7;
+    }
+    .description {
+      max-width: 740px;
+      color: #61666d;
+      padding-top: 16px;
+    }
+    [data-theme="dark"] body {
+      background: #18191c;
+      color: #e3e5e7;
+    }
+    canvas {
+      display: none;
+    }
+    @media (max-width: 600px) {
+      header {
+        padding: 0 16px;
+        gap: 12px;
+      }
+      header small {
+        font-size: 10px;
+      }
+      main {
+        padding: 0 14px;
+        margin-top: 20px;
+      }
+      h1 {
+        font-size: 18px;
+      }
+    }
+  </style>
+  <header>
+    <strong>bilibili</strong><span>学习 · 产品实践</span
+    ><small>合成演示页面，无真实账号数据</small>
+  </header>
+  <main>
+    <h1>从想法到可用产品：一个最小闭环</h1>
+    <div class="meta">公开合成样例 · 产品设计 · P1</div>
+    <video controls muted playsinline></video
+    ><canvas width="960" height="540"></canvas>
+    <footer>
+      <span>保存自己的理解</span><span>核对原始出处</span><span>持续改进</span>
+    </footer>
+    <p class="description">
+      此页面仅用于验证扩展的实际保存与重开流程，播放器内容为程序生成的合成素材。
+    </p>
+  </main>
+  <script>
+    window.__INITIAL_STATE__ = {
+      bvid: "BV1xx411c7mD",
+      cid: 123,
+      p: 1,
+      videoData: {
+        aid: 123,
+        bvid: "BV1xx411c7mD",
+        cid: 123,
+        title: "从想法到可用产品：一个最小闭环",
+        duration: 6,
+        desc: "公开合成样例",
+        owner: { mid: 123, name: "合成演示" },
+        pages: [{ page: 1, cid: 123, part: "最小闭环", duration: 6 }],
+      },
+    };
+    (async () => {
+      const canvas = document.querySelector("canvas"),
+        ctx = canvas.getContext("2d");
+      let frame = 0;
+      function draw() {
+        ctx.fillStyle = "#152026";
+        ctx.fillRect(0, 0, 960, 540);
+        ctx.fillStyle = "#e7f4f7";
+        ctx.font = "36px sans-serif";
+        ctx.fillText("从想法到可用产品", 64, 100);
+        ctx.font = "16px sans-serif";
+        ctx.fillStyle = "#9cafb5";
+        ctx.fillText("SYNTHETIC DEMO / LOCAL LEARNING LOOP", 64, 140);
+        ["明确问题", "约束范围", "验证闭环"].forEach((text, i) => {
+          ctx.fillStyle = ["#1e5663", "#285649", "#634451"][i];
+          ctx.fillRect(64 + i * 290, 215, 250, 120);
+          ctx.fillStyle = "#fff";
+          ctx.font = "25px sans-serif";
+          ctx.fillText(text, 100 + i * 290, 285);
+        });
+        ctx.fillStyle = "#00aeec";
+        ctx.fillRect(64, 420, (frame++ % 180) * 4.5, 3);
+      }
+      draw();
+      const stream = canvas.captureStream(30),
+        recorder = new MediaRecorder(stream, { mimeType: "video/webm" }),
+        parts = [];
+      recorder.ondataavailable = (e) => parts.push(e.data);
+      const finished = new Promise((resolve) => (recorder.onstop = resolve));
+      recorder.start();
+      const timer = setInterval(draw, 33);
+      await new Promise((r) => setTimeout(r, 6100));
+      recorder.stop();
+      await finished;
+      clearInterval(timer);
+      stream.getTracks().forEach((t) => t.stop());
+      const video = document.querySelector("video");
+      video.src = URL.createObjectURL(new Blob(parts, { type: "video/webm" }));
+      await new Promise((r) => (video.onloadedmetadata = r));
+      if (!Number.isFinite(video.duration)) {
+        video.currentTime = 1e6;
+        await new Promise((r) => (video.ontimeupdate = r));
+      }
+      video.currentTime = 2;
+      video.pause();
+      document.documentElement.dataset.videoReady = "true";
+    })();
+  </script>
+</html>

--- a/tests/learning-save.real-qa.py
+++ b/tests/learning-save.real-qa.py
@@ -1,0 +1,106 @@
+import json
+import hashlib
+import shutil
+import subprocess
+import uuid
+from pathlib import Path
+from playwright.sync_api import sync_playwright, expect
+
+ROOT = Path(__file__).resolve().parents[1]
+RUN = ROOT / 'release-artifacts' / 'lg1' / ('qa-' + str(uuid.uuid4()))
+PROFILE = ROOT / 'release-artifacts' / 'lg1' / ('p-' + uuid.uuid4().hex[:8])
+URL = 'https://www.bilibili.com/video/BV1xx411c7mD/'
+HTML = (ROOT / 'tests' / 'learning-save.mock.html').read_text(encoding='utf-8')
+RUN.mkdir(parents=True)
+report = {'kind': 'synthetic-host-real-extension', 'checks': [], 'errors': [], 'profileRemoved': False}
+report['sourceCommit'] = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=ROOT, text=True).strip()
+report['workingTreeDirty'] = bool(subprocess.check_output(['git', 'status', '--porcelain', '--untracked-files=normal'], cwd=ROOT, text=True).strip())
+report['distSha256'] = {str(path.relative_to(ROOT / 'dist')).replace('\\', '/'): hashlib.sha256(path.read_bytes()).hexdigest()
+    for path in sorted((ROOT / 'dist').rglob('*')) if path.is_file()}
+
+with sync_playwright() as p:
+    context = None
+    try:
+        context = p.chromium.launch_persistent_context(str(PROFILE), channel='chromium', headless=True,
+            viewport={'width': 1440, 'height': 900}, args=[
+                '--disable-extensions-except=' + str(ROOT / 'dist'), '--load-extension=' + str(ROOT / 'dist'),
+                '--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE localhost', '--no-first-run'])
+        context.set_offline(True)
+        context.route('**/*', lambda route: route.fulfill(status=200, content_type='text/html', body=HTML)
+            if route.request.url.startswith(URL) else route.continue_() if route.request.url.startswith('chrome-extension:') else route.abort())
+        worker = context.service_workers[0] if context.service_workers else context.wait_for_event('serviceworker')
+        extension_id = worker.url.split('/')[2]
+        report['browser'] = context.browser.version
+        page = context.new_page()
+        page.on('pageerror', lambda error: report['errors'].append(str(error)))
+        page.goto(URL, wait_until='domcontentloaded')
+        page.wait_for_selector('html[data-video-ready=true]', timeout=25000)
+        page.wait_for_selector('#bdc-current-video-assistant', timeout=20000)
+        page.get_by_role('button', name='展开助手', exact=True).click()
+        page.get_by_role('button', name='记笔记', exact=True).click()
+        expect(page.locator('#bb-learning-editor .source')).to_contain_text('从想法到可用产品', timeout=15000)
+        page.get_by_label('标题', exact=True).fill('先验证最小闭环')
+        page.get_by_label('笔记', exact=True).fill('先把保存、重开和找回做成可用流程，再增加自动化。\n清晰的边界与失败反馈也是产品的一部分。')
+        page.screenshot(path=str(RUN / 'note-editor-desktop.png'))
+        page.locator('#bb-learning-editor').get_by_role('button', name='保存', exact=True).click()
+        expect(page.locator('#bb-learning-editor .status')).to_have_text('已保存', timeout=15000)
+        page.get_by_role('button', name='关闭并保留草稿').click()
+        report['checks'].append('note_saved_without_subtitle_or_ai')
+        page.get_by_role('button', name='存书签', exact=True).click()
+        expect(page.locator('#bb-learning-editor .source')).to_contain_text('0:02')
+        page.locator('#bb-learning-editor').get_by_role('button', name='保存', exact=True).click()
+        expect(page.locator('#bb-learning-editor .status')).to_have_text('已保存', timeout=15000)
+        page.get_by_role('button', name='关闭并保留草稿').click()
+        report['checks'].append('bookmark_saved_from_real_synthetic_video_position')
+        dashboard = context.new_page()
+        dashboard.goto('chrome-extension://' + extension_id + '/dashboard/index.html#learning-notes')
+        expect(dashboard.locator('.learning-heading')).to_contain_text('2 条记录', timeout=15000)
+        dashboard.get_by_role('button', name='先验证最小闭环', exact=False).click()
+        expect(dashboard.locator('.learning-body')).to_contain_text('清晰的边界')
+        dashboard.screenshot(path=str(RUN / 'learning-desktop.png'))
+        dashboard.set_viewport_size({'width': 390, 'height': 844})
+        dashboard.screenshot(path=str(RUN / 'learning-mobile-detail.png'))
+        assert dashboard.evaluate('document.documentElement.scrollWidth <= innerWidth')
+        dashboard.get_by_role('button', name='关闭详情').click()
+        dashboard.screenshot(path=str(RUN / 'learning-mobile-list.png'))
+        report['checks'].append('desktop_mobile_list_and_detail')
+        page.close()
+        dashboard.close()
+        context.close()
+        context = p.chromium.launch_persistent_context(str(PROFILE), channel='chromium', headless=True,
+            viewport={'width': 1440, 'height': 900}, args=[
+                '--disable-extensions-except=' + str(ROOT / 'dist'), '--load-extension=' + str(ROOT / 'dist'),
+                '--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE localhost', '--no-first-run'])
+        context.set_offline(True)
+        dashboard = context.new_page()
+        dashboard.goto('chrome-extension://' + extension_id + '/dashboard/index.html#learning-notes')
+        expect(dashboard.locator('.learning-heading')).to_contain_text('2 条记录', timeout=15000)
+        dashboard.get_by_role('button', name='先验证最小闭环', exact=False).click()
+        expect(dashboard.locator('.learning-body')).to_contain_text('清晰的边界')
+        report['checks'].append('full_browser_and_extension_restart_persistence')
+        dashboard.get_by_role('button', name='删除', exact=True).click()
+        dashboard.get_by_role('button', name='确认删除', exact=True).click()
+        expect(dashboard.locator('.learning-heading')).to_contain_text('1 条记录')
+        dashboard.reload()
+        expect(dashboard.locator('.learning-heading')).to_contain_text('1 条记录')
+        report['checks'].append('single_delete_and_reload')
+        report['status'] = 'pass'
+    except Exception as error:
+        report['status'] = 'fail'
+        report['errors'].append(str(error))
+        if context:
+            for index, page in enumerate(context.pages):
+                try: print('LG1 failure DOM', page.locator('#bb-learning-editor').inner_text(timeout=1000))
+                except Exception: pass
+                try: page.screenshot(path=str(RUN / ('failure-' + str(index) + '.png')))
+                except Exception: pass
+        raise
+    finally:
+        if context: context.close()
+        target = PROFILE.resolve()
+        assert target.parent == (ROOT / 'release-artifacts' / 'lg1').resolve() and target.name.startswith('p-') and len(target.name) == 10
+        assert RUN.resolve().parent == (ROOT / 'release-artifacts' / 'lg1').resolve()
+        if target.exists(): shutil.rmtree(target)
+        report['profileRemoved'] = not target.exists()
+        (RUN / 'report.json').write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding='utf-8')
+        print(json.dumps({'run': str(RUN), **report}, ensure_ascii=False))

--- a/tests/learning-save.real-qa.py
+++ b/tests/learning-save.real-qa.py
@@ -18,6 +18,17 @@ report['workingTreeDirty'] = bool(subprocess.check_output(['git', 'status', '--p
 report['distSha256'] = {str(path.relative_to(ROOT / 'dist')).replace('\\', '/'): hashlib.sha256(path.read_bytes()).hexdigest()
     for path in sorted((ROOT / 'dist').rglob('*')) if path.is_file()}
 
+def learning_snapshot(page):
+    # This page belongs only to this run's new, synthetic extension profile.
+    return page.evaluate("""async () => {
+        const database = await new Promise((resolve, reject) => { const r = indexedDB.open('BiliAnalyticsDB'); r.onsuccess = () => resolve(r.result); r.onerror = () => reject(r.error); });
+        try {
+            const transaction = database.transaction(['lgAssets', 'lgMeta'], 'readonly');
+            const read = name => new Promise((resolve, reject) => { const r = transaction.objectStore(name).getAll(); r.onsuccess = () => resolve(r.result); r.onerror = () => reject(r.error); });
+            return JSON.stringify(await Promise.all([read('lgAssets'), read('lgMeta')]));
+        } finally { database.close(); }
+    }""")
+
 with sync_playwright() as p:
     context = None
     try:
@@ -39,15 +50,65 @@ with sync_playwright() as p:
         page.get_by_role('button', name='展开助手', exact=True).click()
         page.get_by_role('button', name='记笔记', exact=True).click()
         expect(page.locator('#bb-learning-editor .source')).to_contain_text('从想法到可用产品', timeout=15000)
+        page.get_by_label('笔记', exact=True).fill('取消与草稿验证')
+        page.keyboard.press('Escape')
+        expect(page.locator('#bb-learning-editor')).to_have_count(0)
+        page.get_by_role('button', name='记笔记', exact=True).click()
+        expect(page.get_by_label('笔记', exact=True)).to_have_value('取消与草稿验证')
+        expect(page.locator('#bb-learning-editor').get_by_role('button', name='保存', exact=True)).to_be_enabled()
+        # Only the isolated test worker delays its normal page check, making cancellation observable.
+        worker.evaluate("""() => {
+            globalThis.__lg1Send = chrome.tabs.sendMessage.bind(chrome.tabs);
+            chrome.tabs.sendMessage = async (...args) => {
+                if (args[1]?.action === 'CHECK_LEARNING_CONTEXT') await new Promise(r => setTimeout(r, 1200));
+                return globalThis.__lg1Send(...args);
+            };
+        }""")
+        page.locator('#bb-learning-editor').get_by_role('button', name='保存', exact=True).click()
+        page.get_by_role('button', name='取消保存', exact=True).click()
+        expect(page.locator('#bb-learning-editor .status')).to_contain_text('已取消', timeout=15000)
+        expect(page.get_by_label('笔记', exact=True)).to_have_value('取消与草稿验证')
+        worker.evaluate('() => { chrome.tabs.sendMessage = globalThis.__lg1Send; delete globalThis.__lg1Send; }')
+        probe = context.new_page()
+        probe.goto('chrome-extension://' + extension_id + '/dashboard/index.html#learning-notes')
+        expect(probe.locator('.learning-heading')).to_contain_text('0 条记录', timeout=15000)
+        probe.wait_for_timeout(2100)
+        probe.reload()
+        expect(probe.locator('.learning-heading')).to_contain_text('0 条记录')
+        probe.close()
+        report['checks'].append('cancel_no_write_after_2s_and_escape_preserves_draft')
+        page.evaluate("history.pushState({}, '', '?p=2')")
+        page.locator('#bb-learning-editor').get_by_role('button', name='保存', exact=True).click()
+        expect(page.locator('#bb-learning-editor .status')).to_contain_text('已变化', timeout=15000)
+        expect(page.get_by_label('笔记', exact=True)).to_have_value('取消与草稿验证')
+        expect(page.locator('#bb-learning-editor').get_by_role('button', name='保存', exact=True)).to_be_disabled()
+        page.evaluate("""() => { history.pushState({}, '', location.pathname); document.body.append(document.createElement('hr')); }""")
+        expect(page.locator('#bdc-current-video-assistant').get_by_role('button', name='记笔记', exact=True)).to_be_visible(timeout=15000)
+        page.get_by_role('button', name='重新确认当前视频', exact=True).click()
+        expect(page.locator('#bb-learning-editor .status')).to_contain_text('已重新确认', timeout=15000)
+        report['checks'].append('stale_part_rejected_draft_retained_explicit_recapture')
         page.get_by_label('标题', exact=True).fill('先验证最小闭环')
         page.get_by_label('笔记', exact=True).fill('先把保存、重开和找回做成可用流程，再增加自动化。\n清晰的边界与失败反馈也是产品的一部分。')
         page.screenshot(path=str(RUN / 'note-editor-desktop.png'))
         page.locator('#bb-learning-editor').get_by_role('button', name='保存', exact=True).click()
         expect(page.locator('#bb-learning-editor .status')).to_have_text('已保存', timeout=15000)
+        with context.expect_page() as opened:
+            page.locator('#bb-learning-editor').get_by_role('link', name='学习笔记', exact=True).click()
+        linked = opened.value
+        expect(linked.locator('.learning-heading')).to_contain_text('1 条记录', timeout=15000)
+        linked.close()
+        report['checks'].append('editor_link_opens_real_learning_dashboard')
         page.get_by_role('button', name='关闭并保留草稿').click()
         report['checks'].append('note_saved_without_subtitle_or_ai')
         page.get_by_role('button', name='存书签', exact=True).click()
         expect(page.locator('#bb-learning-editor .source')).to_contain_text('0:02')
+        page.evaluate("window.player = { getVideoInfo: () => ({ bvid: 'BV1xx411c7mD', cid: 456, p: 1 }) }")
+        page.locator('#bb-learning-editor').get_by_role('button', name='保存', exact=True).click()
+        expect(page.locator('#bb-learning-editor .status')).to_contain_text('已变化', timeout=15000)
+        page.evaluate('delete window.player')
+        page.get_by_role('button', name='重新确认当前视频', exact=True).click()
+        expect(page.locator('#bb-learning-editor .status')).to_contain_text('已重新确认', timeout=15000)
+        report['checks'].append('same_url_same_element_live_player_cid_change_rejected')
         page.locator('#bb-learning-editor').get_by_role('button', name='保存', exact=True).click()
         expect(page.locator('#bb-learning-editor .status')).to_have_text('已保存', timeout=15000)
         page.get_by_role('button', name='关闭并保留草稿').click()
@@ -55,10 +116,15 @@ with sync_playwright() as p:
         dashboard = context.new_page()
         dashboard.goto('chrome-extension://' + extension_id + '/dashboard/index.html#learning-notes')
         expect(dashboard.locator('.learning-heading')).to_contain_text('2 条记录', timeout=15000)
+        expect(dashboard.locator('.bb-export-actions')).to_have_count(0)
         dashboard.get_by_role('button', name='先验证最小闭环', exact=False).click()
         expect(dashboard.locator('.learning-body')).to_contain_text('清晰的边界')
         dashboard.screenshot(path=str(RUN / 'learning-desktop.png'))
         dashboard.set_viewport_size({'width': 390, 'height': 844})
+        dashboard.reload()
+        expect(dashboard.locator('.learning-heading')).to_contain_text('2 条记录', timeout=15000)
+        dashboard.get_by_role('button', name='先验证最小闭环', exact=False).click()
+        expect(dashboard.locator('.bb-nav-item[aria-current=page]')).to_be_in_viewport()
         dashboard.screenshot(path=str(RUN / 'learning-mobile-detail.png'))
         assert dashboard.evaluate('document.documentElement.scrollWidth <= innerWidth')
         dashboard.get_by_role('button', name='关闭详情').click()
@@ -78,6 +144,21 @@ with sync_playwright() as p:
         dashboard.get_by_role('button', name='先验证最小闭环', exact=False).click()
         expect(dashboard.locator('.learning-body')).to_contain_text('清晰的边界')
         report['checks'].append('full_browser_and_extension_restart_persistence')
+        before_clear = learning_snapshot(dashboard)
+        result = dashboard.evaluate("() => chrome.runtime.sendMessage({action: 'CLEAR_CURRENT_VIDEO_SUBTITLE_CACHE'})")
+        assert result['success'] and result['data']['status'] == 'completed', result
+        assert learning_snapshot(dashboard) == before_clear
+        result = dashboard.evaluate("() => chrome.runtime.sendMessage({action: 'CANCEL_SYNC'})")
+        assert result['success'], result
+        for attempt in range(50):
+            sync = dashboard.evaluate("() => chrome.runtime.sendMessage({action: 'GET_SYNC_STATUS'})")
+            if sync['success'] and not sync['data']['syncProgress']['syncing']: break
+            dashboard.wait_for_timeout(200)
+        else: raise AssertionError('Synthetic startup sync did not stop before the ordinary reset test')
+        result = dashboard.evaluate("() => chrome.runtime.sendMessage({action: 'CLEAR_ALL_LOCAL_DATA', params: {confirmation: '清理本地数据'}})")
+        assert result['success'] and result['data']['status'] == 'completed', result
+        assert learning_snapshot(dashboard) == before_clear
+        report['checks'].append('ordinary_cache_clear_and_settings_reset_preserve_full_learning_tables')
         dashboard.get_by_role('button', name='删除', exact=True).click()
         dashboard.get_by_role('button', name='确认删除', exact=True).click()
         expect(dashboard.locator('.learning-heading')).to_contain_text('1 条记录')
@@ -103,4 +184,4 @@ with sync_playwright() as p:
         if target.exists(): shutil.rmtree(target)
         report['profileRemoved'] = not target.exists()
         (RUN / 'report.json').write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding='utf-8')
-        print(json.dumps({'run': str(RUN), **report}, ensure_ascii=False))
+        print(json.dumps({'run': str(RUN), **{key: report[key] for key in ['status', 'checks', 'errors', 'profileRemoved', 'sourceCommit', 'workingTreeDirty']}}, ensure_ascii=False))

--- a/tests/learning-save.test.ts
+++ b/tests/learning-save.test.ts
@@ -1,0 +1,221 @@
+import "fake-indexeddb/auto";
+import assert from "node:assert/strict";
+import test from "node:test";
+import { BiliAnalyticsDB } from "../src/background/storage/db.ts";
+import { LearningRepository } from "../src/background/storage/learning-repo.ts";
+import {
+  canonicalLearning,
+  learningBytes,
+  validateLearningAsset,
+  type LearningAsset,
+} from "../src/shared/learning.ts";
+import {
+  canonical,
+  logicalBytes,
+  validateAsset,
+} from "../scripts/lg0/learning-lab.mjs";
+import { seedLearningV13, V13_STORES } from "./fixtures/learning-v13.ts";
+import { legacySnapshot } from "../scripts/lg0/legacy-fixture.mjs";
+import Dexie from "dexie";
+
+const note = (n = 1): LearningAsset => ({
+  id: n.toString(16).padStart(64, "0"),
+  kind: "note",
+  createdAt: 1,
+  updatedAt: 1,
+  video: { bvid: "BV1234567890", title: "合成视频" },
+  part: null,
+  personal: { title: "我的笔记", note: "已保存的内容", tags: [] },
+  snapshot: null,
+  bookmarkMs: null,
+  importedFrom: null,
+});
+
+test("learning production v14 upgrades all 21 v13 tables without changing schema or content", async () => {
+  const name = "lg1-upgrade-" + crypto.randomUUID();
+  const legacy = await seedLearningV13(name);
+  const db = new BiliAnalyticsDB(name);
+  try {
+    await db.open();
+    assert.equal(db.verno, 14);
+    assert.equal(db.tables.length, 23);
+    assert.equal(
+      await legacySnapshot(db, Object.keys(V13_STORES)),
+      legacy.before,
+    );
+    for (const [name, spec] of Object.entries(V13_STORES)) {
+      const table = db.table(name);
+      assert.equal(
+        [
+          table.schema.primKey.src,
+          ...table.schema.indexes.map((index) => index.src),
+        ].join(", "),
+        spec,
+      );
+    }
+  } finally {
+    await db.delete();
+  }
+});
+
+test("learning production upgrade failure leaves the v13 database and every old row intact", async () => {
+  const name = "lg1-upgrade-fail-" + crypto.randomUUID();
+  const legacy = await seedLearningV13(name);
+  const current = new BiliAnalyticsDB(name);
+  current.version(14).upgrade(() => {
+    throw Error("synthetic_upgrade_abort");
+  });
+  await assert.rejects(current.open(), /synthetic_upgrade_abort/);
+  current.close();
+  const previous = new Dexie(name);
+  try {
+    await previous.open();
+    assert.equal(previous.verno, 13);
+    assert.equal(
+      await legacySnapshot(previous, Object.keys(V13_STORES)),
+      legacy.before,
+    );
+  } finally {
+    await previous.delete();
+  }
+});
+
+async function database(
+  run: (repo: LearningRepository, db: BiliAnalyticsDB) => Promise<void>,
+) {
+  const db = new BiliAnalyticsDB("lg1-test-" + crypto.randomUUID());
+  try {
+    await db.open();
+    await run(new LearningRepository(db), db);
+  } finally {
+    await db.delete();
+  }
+}
+
+test("learning notes and bookmarks preserve LG-0 canonical format and bytes", () => {
+  const rows = [
+    note(),
+    {
+      ...note(2),
+      kind: "bookmark",
+      part: { cid: "123", page: 2 },
+      bookmarkMs: 3000,
+    },
+  ];
+  for (const row of rows) {
+    validateLearningAsset(row);
+    validateAsset(row);
+  }
+  assert.equal(canonicalLearning(rows), canonical(rows));
+  assert.equal(learningBytes(rows), logicalBytes(rows));
+  assert.throws(() => validateLearningAsset({ ...note(), extra: true }));
+  assert.throws(() =>
+    validateLearningAsset({
+      ...note(),
+      personal: { ...note().personal, tags: ["a", , "c"] },
+    }),
+  );
+});
+
+test("learning save is persistent, idempotent, isolated from caller and deletes exactly one item", async () =>
+  database(async (repo, db) => {
+    const row = note();
+    await repo.save(0, row, { assertCurrent: async () => {} });
+    const revision = (await repo.state()).meta.revision;
+    await repo.save(0, row, {
+      assertCurrent: async () => {
+        throw Error("source unavailable");
+      },
+    });
+    assert.equal((await repo.state()).meta.revision, revision);
+    await assert.rejects(
+      repo.save(
+        0,
+        { ...row, personal: { ...row.personal, note: "changed" } },
+        {},
+      ),
+      /identity/,
+    );
+    row.personal.note = "local draft changed";
+    db.close();
+    await db.open();
+    assert.equal((await repo.get(row.id))?.personal.note, "已保存的内容");
+    await repo.save(0, note(2), { assertCurrent: async () => {} });
+    await repo.remove(0, row.id);
+    assert.equal(await repo.get(row.id), undefined);
+    assert.equal((await repo.state()).assets.length, 1);
+  }));
+
+test("learning cancellation and stale epochs do not mutate the database", async () =>
+  database(async (repo) => {
+    const controller = new AbortController();
+    await assert.rejects(
+      repo.save(0, note(), {
+        signal: controller.signal,
+        assertCurrent: async () => {
+          controller.abort();
+        },
+      }),
+      /cancelled/,
+    );
+    await assert.rejects(
+      repo.save(1, note(), { assertCurrent: async () => {} }),
+      /stale_epoch/,
+    );
+    await assert.rejects(
+      repo.save(0, note(), {
+        assertCurrent: async () => {
+          throw Error("stale_capture");
+        },
+      }),
+      /stale_capture/,
+    );
+    assert.equal((await repo.state()).assets.length, 0);
+  }));
+
+test("learning rechecks capture inside the transaction and reports true outcome after late cancellation", async () =>
+  database(async (repo) => {
+    let checks = 0;
+    await assert.rejects(
+      repo.save(0, note(), {
+        assertCurrent: async () => {
+          if (++checks === 2) throw Error("stale_capture");
+        },
+      }),
+      /stale_capture/,
+    );
+    assert.equal((await repo.state()).assets.length, 0);
+    const controller = new AbortController();
+    await repo.save(0, note(), {
+      signal: controller.signal,
+      assertCurrent: async () => {},
+      onPhase: (phase) => {
+        if (phase === "committing") controller.abort();
+      },
+    });
+    assert.equal((await repo.state()).assets.length, 1);
+  }));
+
+test("learning concurrent saves enforce count and exact byte capacity atomically", async () =>
+  database(async (repo, db) => {
+    const rows = Array.from({ length: 999 }, (_, i) => note(i + 1));
+    await db.lgAssets.bulkAdd(rows);
+    const results = await Promise.allSettled(
+      [1000, 1001].map((i) =>
+        repo.save(0, note(i), { assertCurrent: async () => {} }),
+      ),
+    );
+    assert.equal(results.filter((r) => r.status === "fulfilled").length, 1);
+    assert.equal((await repo.state()).assets.length, 1000);
+    await db.lgAssets.clear();
+    const row = note();
+    row.personal.note = "";
+    row.personal.note = "x".repeat(10_485_760 - learningBytes([row]));
+    await repo.save(0, row, { assertCurrent: async () => {} });
+    assert.equal(learningBytes((await repo.state()).assets), 10_485_760);
+    await assert.rejects(
+      repo.save(0, note(2), { assertCurrent: async () => {} }),
+      /capacity/,
+    );
+    assert.equal((await repo.state()).assets.length, 1);
+  }));

--- a/tests/learning-save.test.ts
+++ b/tests/learning-save.test.ts
@@ -1,6 +1,7 @@
 import "fake-indexeddb/auto";
 import assert from "node:assert/strict";
 import test from "node:test";
+import { createHash } from "node:crypto";
 import { BiliAnalyticsDB } from "../src/background/storage/db.ts";
 import { LearningRepository } from "../src/background/storage/learning-repo.ts";
 import {
@@ -108,6 +109,12 @@ test("learning notes and bookmarks preserve LG-0 canonical format and bytes", ()
   }
   assert.equal(canonicalLearning(rows), canonical(rows));
   assert.equal(learningBytes(rows), logicalBytes(rows));
+  // Frozen LG-0 wire-format receipt for the two public synthetic records above.
+  assert.equal(learningBytes(rows), 645);
+  assert.equal(
+    createHash("sha256").update(canonicalLearning(rows)).digest("hex"),
+    "9bb2a151fab778115bb2b88fd9ff1c977ea05a32de763ec5f653ace3525360a9",
+  );
   assert.throws(() => validateLearningAsset({ ...note(), extra: true }));
   assert.throws(() =>
     validateLearningAsset({

--- a/tests/lg0-learning-contract.test.ts
+++ b/tests/lg0-learning-contract.test.ts
@@ -22,7 +22,8 @@ import {
   restore,
 } from "../scripts/lg0/learning-lab.mjs";
 import { asset, fixture } from "../scripts/lg0/fixtures.mjs";
-import { seedLegacy, legacySnapshot } from "../scripts/lg0/legacy-fixture.mjs";
+import { legacySnapshot } from "../scripts/lg0/legacy-fixture.mjs";
+import { seedLearningV13 as seedLegacy } from './fixtures/learning-v13.ts';
 import Dexie from "dexie";
 
 test("LG-0 export observes queued cancellation and keeps canonical output", async () => {
@@ -493,7 +494,7 @@ test("LG-0 search uses saved fields, AND terms, filters and current committed st
   }
 });
 
-test("LG-0 actual v13 schema fixture survives additive upgrade and failed upgrade", async () => {
+test("LG-0 frozen production v13 schema fixture survives additive upgrade and failed upgrade", async () => {
   const name = "lg0-test-upgrade";
   const legacy = await seedLegacy(name);
   await assert.rejects(

--- a/third_party/licenses/Lucide.txt
+++ b/third_party/licenses/Lucide.txt
@@ -1,0 +1,43 @@
+ISC License
+
+Copyright (c) 2026 Lucide Icons and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---
+
+The following Lucide icons are derived from the Feather project:
+
+airplay, alert-circle, alert-octagon, alert-triangle, aperture, arrow-down-circle, arrow-down-left, arrow-down-right, arrow-down, arrow-left-circle, arrow-left, arrow-right-circle, arrow-right, arrow-up-circle, arrow-up-left, arrow-up-right, arrow-up, at-sign, calendar, cast, check, chevron-down, chevron-left, chevron-right, chevron-up, chevrons-down, chevrons-left, chevrons-right, chevrons-up, circle, clipboard, clock, code, columns, command, compass, corner-down-left, corner-down-right, corner-left-down, corner-left-up, corner-right-down, corner-right-up, corner-up-left, corner-up-right, crosshair, database, divide-circle, divide-square, dollar-sign, download, external-link, feather, frown, hash, headphones, help-circle, info, italic, key, layout, life-buoy, link-2, link, loader, lock, log-in, log-out, maximize, meh, minimize, minimize-2, minus-circle, minus-square, minus, monitor, moon, more-horizontal, more-vertical, move, music, navigation-2, navigation, octagon, pause-circle, percent, plus-circle, plus-square, plus, power, radio, rss, search, server, share, shopping-bag, sidebar, smartphone, smile, square, table-2, tablet, target, terminal, trash-2, trash, triangle, tv, type, upload, x-circle, x-octagon, x-square, x, zoom-in, zoom-out
+
+The MIT License (MIT) (for the icons listed above)
+
+Copyright (c) 2013-present Cole Bemis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## 范围

Closes #277。基线 main `e2a7c5140d6574abc870d547f05eb4b2778a2b69`。

- 生产 Dexie 增量 v14，仅新增学习资产与协调表；稳定 ID、CAS/epoch、1000 项 / 10 MiB 精确容量。
- 无字幕/无 AI 的个人笔记与真实分 P / 播放位置书签；每次提交检查重读当前页 runtime，同 URL 播放器身份或媒体源改变也拒绝迟到保存。
- 中文保存弹窗、草稿保留、取消预检、确认重试、独立学习列表/详情/删除；学习页隐藏不相关的历史导出，窄屏导航露出当前页。
- 普通清理/设置重置保留学习资产及协调元数据。
- 本地离线演示启动器、冻结构建与截图指南；不进入生产 bundle。

## 关键复核与验证

- Terra/xhigh Standards、Spec 两轴复核初始候选；指出的实时身份 P1 和运行时错误文案 P2 均已修复并由主 Agent 验证。详情见本 PR 验收评论。
- focused 34/34、全量 674/674、typecheck、build、diff-check 通过；所有 JS chunk <500000 bytes。
- 干净本地候选 `e9cadafc1843ce087268cd8050d13853e5b58039` 通过实际 Chromium 147 扩展十项交互检查：取消/草稿/失效上下文、真实保存与链接、桌面窄屏、完整浏览器+扩展重启、普通清理完整回读和删除。
- 冻结演示包的实际扩展再次保存、完整重启、读回通过；指南图片与桌面/窄屏溢出检查通过。
- 最终远端 `ae1f4b33b03e62a85f564eed2b914628cc76ebab` CI [34144585157](https://github.com/LittleNuB/BiliBili-DataViz-Plugin/actions/runs/34144585157)：validate、fixture receipts、B1 artifact verification 全部成功。后者不改判历史性能结果。

## 提交等价性

Git smart-HTTP 连续连接重置，最终通过 Git data API 快进同步。远端 `ae1f4b3` 与本地测量候选 `e9cadaf` 的完整代码树均为 `f5a301d6571b51e4b18e62821237bd1a4d89fad6`；无强推，无覆盖他人提交。本地原始提交历史保留。

## 边界

这是 LG-1 完成，不是 V0.14.0 发布。宿主页与视频均为合成素材；真实 B 站 smoke 限制保留。未包含 UX-014 #274、LG-2~LG-5；完整重置/生命周期故障矩阵仍归 LG-4/LG-5。LG-0 实验脚本与绑定产物保持原样，旧 A2/#239/#240 不启动。未读取 Cookie/profile/login-state/key/credentials/个人数据库/npm debug logs，未改权限、release/tag/package version。