### PR TITLE
feat(assistant): 支持浮层四边四角拖拽缩放

### DIFF
--- a/docs/qa/assistant-resize-284.md
+++ b/docs/qa/assistant-resize-284.md
@@ -1,0 +1,17 @@
+# 页内助手缩放 #284
+
+2026-09-08，基线 main 16bffdf。
+
+支持四边、四角指针拖拽；宽高下限 320/360px，小视口以下限可用空间为准；窗口保留 12px 安全边距。拖动不重建正文。Esc、指针取消、失焦会恢复拖动前尺寸。键盘方向键可调整边缘。
+
+仅持久化 `currentVideoAssistantWindowSize` 的宽高两个数字到扩展本地设置。不读写个人资产、不发送 AI 请求、不修改跳转。收起恢复原紧凑布局，重新展开保持尺寸；新页面恢复已保存尺寸并限制到可视范围。窗口位置只保留在当前页面。
+
+## 验证
+
+- 三项几何单测：八方向、相对固定边、最小尺寸、大幅越界和小视口。
+- 新增 `tests/assistant-resize.mock-qa.mjs`：真实 content 构建配合合成宿主页，八方向拖拽、Esc 回滚、草稿保留、收起重开、保存尺寸重载、键盘与三个窄视口通过。
+- 既有 UX 五视口、亮暗主题、原生全屏遮挡、待响应重入、字幕预览/确认/返回回归通过。
+- typecheck/build/release-dist/diff-check 通过。布局改动不重跑存储矩阵。
+- 截图和构建绑定记录：`release-artifacts/resize-284/`。真实站点整版验收仍由 #281 跟进；本记录不冒充真实站点 PASS。
+
+本地候选更新至此前的 `release-artifacts/popup-282/extension`，原构建备份在 `release-artifacts/resize-284/previous-extension`，面试冻结包不变。无版本号、tag 或正式发布变动；未读取 Cookie、个人浏览器文件、登录态或凭据。

--- a/src/content/player-monitor/assistant-resize.ts
+++ b/src/content/player-monitor/assistant-resize.ts
@@ -1,0 +1,122 @@
+export interface AssistantRect { left: number; top: number; width: number; height: number }
+export type ResizeEdge = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
+const KEY = 'currentVideoAssistantWindowSize';
+const GAP = 12;
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+export function fitAssistantRect(rect: AssistantRect, vw: number, vh: number): AssistantRect {
+  const width = clamp(rect.width, Math.min(320, vw - GAP * 2), Math.max(1, vw - GAP * 2));
+  const height = clamp(rect.height, Math.min(360, vh - GAP * 2), Math.max(1, vh - GAP * 2));
+  return { width, height, left: clamp(rect.left, GAP, Math.max(GAP, vw - GAP - width)), top: clamp(rect.top, GAP, Math.max(GAP, vh - GAP - height)) };
+}
+
+export function resizeAssistantRect(start: AssistantRect, edge: ResizeEdge, dx: number, dy: number, vw: number, vh: number): AssistantRect {
+  const rect = fitAssistantRect(start, vw, vh);
+  const right = rect.left + rect.width;
+  const bottom = rect.top + rect.height;
+  const minWidth = Math.min(320, vw - GAP * 2);
+  const minHeight = Math.min(360, vh - GAP * 2);
+  if (edge.includes('w')) { rect.left = clamp(rect.left + dx, GAP, right - minWidth); rect.width = right - rect.left; }
+  if (edge.includes('e')) rect.width = clamp(rect.width + dx, minWidth, vw - GAP - rect.left);
+  if (edge.includes('n')) { rect.top = clamp(rect.top + dy, GAP, bottom - minHeight); rect.height = bottom - rect.top; }
+  if (edge.includes('s')) rect.height = clamp(rect.height + dy, minHeight, vh - GAP - rect.top);
+  return rect;
+}
+
+let preferred: { width: number; height: number } | null = null;
+let rect: AssistantRect | null = null;
+let root: HTMLElement | null = null;
+let initialized = false;
+let revision = 0;
+let cancelDrag: (() => void) | null = null;
+let saveQueue = Promise.resolve();
+
+function applyRect(): void {
+  if (!root?.isConnected || !root.classList.contains('bdc-assistant-expanded') || !rect) return;
+  rect = fitAssistantRect(rect, window.innerWidth, window.innerHeight);
+  Object.assign(root.style, { left: `${rect.left}px`, top: `${rect.top}px`, width: `${rect.width}px`, height: `${rect.height}px`, right: 'auto', bottom: 'auto' });
+}
+
+function saveSize(): void {
+  if (!rect) return;
+  revision += 1;
+  const size = { width: Math.round(rect.width), height: Math.round(rect.height) };
+  preferred = size;
+  saveQueue = saveQueue.then(() => chrome.storage.local.set({ [KEY]: size })).catch(() => {});
+}
+
+export function syncAssistantResize(element: HTMLElement, expanded: boolean): void {
+  cancelDrag?.();
+  root = element;
+  if (!initialized) {
+    initialized = true;
+    const loadRevision = revision;
+    void chrome.storage.local.get(KEY).then(values => {
+      const value = values[KEY];
+      if (revision !== loadRevision || !value || typeof value !== 'object' || !('width' in value) || !('height' in value)
+        || typeof value.width !== 'number' || typeof value.height !== 'number'
+        || !Number.isFinite(value.width) || !Number.isFinite(value.height) || value.width < 1 || value.height < 1) return;
+      preferred = { width: value.width, height: value.height };
+      if (rect) {
+        rect = { ...rect, left: rect.left + rect.width - value.width, top: rect.top + rect.height - value.height, ...preferred };
+        applyRect();
+      }
+    }).catch(() => {});
+    window.addEventListener('resize', () => { cancelDrag?.(); applyRect(); });
+  }
+  if (!expanded) {
+    for (const property of ['left', 'top', 'width', 'height', 'right', 'bottom']) element.style.removeProperty(property);
+    return;
+  }
+  if (!rect) {
+    const initial = element.getBoundingClientRect();
+    rect = { left: initial.left, top: initial.top, width: initial.width, height: initial.height };
+    if (preferred) rect = { ...rect, left: initial.right - preferred.width, top: initial.bottom - preferred.height, ...preferred };
+  }
+  applyRect();
+  const names: Record<ResizeEdge, string> = { n: '上', s: '下', e: '右', w: '左', ne: '右上', nw: '左上', se: '右下', sw: '左下' };
+  for (const edge of Object.keys(names) as ResizeEdge[]) {
+    const handle = document.createElement('button');
+    handle.type = 'button';
+    handle.className = `bdc-assistant-resize bdc-assistant-resize-${edge}`;
+    handle.dataset.edge = edge;
+    handle.setAttribute('aria-label', `调整窗口${names[edge]}边缘`);
+    handle.title = `拖动调整窗口${names[edge]}边缘`;
+    handle.addEventListener('keydown', event => {
+      const step = event.shiftKey ? 40 : 10;
+      const delta = { ArrowLeft: [-step, 0], ArrowRight: [step, 0], ArrowUp: [0, -step], ArrowDown: [0, step] }[event.key];
+      if (!delta || !rect) return;
+      event.preventDefault(); event.stopPropagation();
+      rect = resizeAssistantRect(rect, edge, delta[0], delta[1], innerWidth, innerHeight);
+      applyRect(); saveSize();
+    });
+    handle.addEventListener('pointerdown', event => {
+      if (event.button !== 0 || !rect) return;
+      event.preventDefault(); event.stopPropagation();
+      cancelDrag?.();
+      revision += 1;
+      const start = { ...rect };
+      const x = event.clientX; const y = event.clientY; const id = event.pointerId;
+      const controller = new AbortController();
+      handle.setPointerCapture(id);
+      element.dataset.resizing = 'true';
+      const finish = (cancel: boolean) => {
+        controller.abort(); cancelDrag = null; delete element.dataset.resizing;
+        if (handle.hasPointerCapture(id)) handle.releasePointerCapture(id);
+        if (cancel) { rect = start; applyRect(); } else saveSize();
+      };
+      cancelDrag = () => finish(true);
+      window.addEventListener('pointermove', move => {
+        if (move.pointerId !== id) return;
+        rect = resizeAssistantRect(start, edge, move.clientX - x, move.clientY - y, innerWidth, innerHeight);
+        applyRect();
+      }, { signal: controller.signal });
+      window.addEventListener('pointerup', up => { if (up.pointerId === id) finish(false); }, { signal: controller.signal });
+      window.addEventListener('pointercancel', cancelled => { if (cancelled.pointerId === id) finish(true); }, { signal: controller.signal });
+      handle.addEventListener('lostpointercapture', () => finish(true), { signal: controller.signal });
+      window.addEventListener('blur', () => finish(true), { signal: controller.signal });
+      window.addEventListener('keydown', key => { if (key.key === 'Escape') { key.preventDefault(); key.stopPropagation(); finish(true); } }, { capture: true, signal: controller.signal });
+    });
+    element.appendChild(handle);
+  }
+}

--- a/src/content/player-monitor/assistant-status.ts
+++ b/src/content/player-monitor/assistant-status.ts
@@ -1,3 +1,4 @@
+import { syncAssistantResize } from './assistant-resize';
 import type {
   CurrentVideoContext,
   CurrentVideoContextResult,
@@ -436,6 +437,7 @@ function renderAssistantShell(): void {
   if (!existing) {
     document.body.appendChild(root);
   }
+  syncAssistantResize(root, assistantState.expanded);
   if (restoreActiveTabFocus && assistantState.expanded) {
     document.getElementById(assistantTabId(assistantState.activeTab))?.focus({ preventScroll: true });
   }

--- a/src/content/player-monitor/assistant-styles.ts
+++ b/src/content/player-monitor/assistant-styles.ts
@@ -13,6 +13,22 @@ export function assistantStyles(CARD_ID: string): string {
 #${CARD_ID} * {
   box-sizing: border-box;
 }
+#${CARD_ID} .bdc-assistant-resize {
+  position: absolute; z-index: 5; display: block; padding: 0; margin: 0;
+  min-width: 0; min-height: 0; border: 0; border-radius: 0; background: transparent;
+  touch-action: none; user-select: none; box-shadow: none;
+}
+#${CARD_ID} .bdc-assistant-resize:is(:hover, :focus-visible) { background: rgba(251, 114, 153, .22); }
+#${CARD_ID} .bdc-assistant-resize:focus-visible { outline: 2px solid var(--bb-accent); outline-offset: -2px; }
+#${CARD_ID} .bdc-assistant-resize-n { top: 0; left: 12px; right: 12px; height: 8px; cursor: ns-resize; }
+#${CARD_ID} .bdc-assistant-resize-s { bottom: 0; left: 12px; right: 12px; height: 8px; cursor: ns-resize; }
+#${CARD_ID} .bdc-assistant-resize-e { right: 0; top: 12px; bottom: 12px; width: 8px; cursor: ew-resize; }
+#${CARD_ID} .bdc-assistant-resize-w { left: 0; top: 12px; bottom: 12px; width: 8px; cursor: ew-resize; }
+#${CARD_ID} .bdc-assistant-resize-ne { right: 0; top: 0; width: 16px; height: 16px; cursor: nesw-resize; }
+#${CARD_ID} .bdc-assistant-resize-nw { left: 0; top: 0; width: 16px; height: 16px; cursor: nwse-resize; }
+#${CARD_ID} .bdc-assistant-resize-se { right: 0; bottom: 0; width: 16px; height: 16px; cursor: nwse-resize; }
+#${CARD_ID} .bdc-assistant-resize-sw { left: 0; bottom: 0; width: 16px; height: 16px; cursor: nesw-resize; }
+#${CARD_ID}[data-resizing] { user-select: none; }
 #${CARD_ID}.bdc-assistant-collapsed {
   width: min(300px, calc(100vw - 32px));
 }

--- a/tests/assistant-resize.mock-qa.mjs
+++ b/tests/assistant-resize.mock-qa.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { readFile, mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createHash } from 'node:crypto';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+const { chromium } = await import(pathToFileURL(process.env.UX014_PLAYWRIGHT_MODULE).href);
+const html = await readFile(path.join(root,'tests/current-video-assistant-shell.mock.html'));
+const bundle = await readFile(path.join(root,'dist/content/player-monitor.js'));
+const out = path.join(root,'release-artifacts/resize-284');
+await mkdir(out,{recursive:true});
+const browser = await chromium.launch({executablePath:process.env.UX014_CHROME_EXECUTABLE,headless:true});
+const report = { syntheticOnly:true, bundleSha256:createHash('sha256').update(bundle).digest('hex'), cases:[] };
+try {
+  const page = await browser.newPage({viewport:{width:1440,height:1000}});
+  const errors = [];
+  let saved = null;
+  page.on('pageerror', error => errors.push(error.message));
+  await page.route('**/*', route => route.fulfill({contentType:'text/html',body:html}));
+  async function load() {
+    await page.goto('https://www.bilibili.com/video/BV1ShellMock9');
+    if (saved) await page.evaluate(size => chrome.storage.local.set({currentVideoAssistantWindowSize:size}),saved);
+    await page.addScriptTag({content:bundle.toString()});
+    await page.getByRole('button',{name:'展开助手',exact:true}).click();
+  }
+  const card = page.locator('#bdc-current-video-assistant');
+  async function bounds() {
+    const b = await card.boundingBox(); const v = page.viewportSize();
+    assert.ok(b.x>=0 && b.y>=0 && b.x+b.width<=v.width && b.y+b.height<=v.height);
+    assert.equal(await card.evaluate(el=>el.scrollWidth>el.clientWidth),false);
+    return b;
+  }
+  async function drag(edge,dx,dy,cancel=false) {
+    const b = await card.locator(`[data-edge="${edge}"]`).boundingBox();
+    const x=b.x+b.width/2,y=b.y+b.height/2;
+    await page.mouse.move(x,y); await page.mouse.down(); await page.mouse.move(x+dx,y+dy,{steps:8});
+    if(cancel) await page.keyboard.press('Escape');
+    await page.mouse.up();
+    return bounds();
+  }
+  await load();
+  await page.getByRole('tab',{name:'问答',exact:true}).click();
+  const draft = page.getByRole('textbox',{name:'向当前视频提问',exact:true});
+  await draft.fill('缩放时保留的草稿');
+  const initial = await bounds();
+  let large = await drag('nw',-240,-160);
+  assert.ok(large.width>initial.width+200 && large.height>initial.height+100);
+  assert.equal(await draft.inputValue(),'缩放时保留的草稿');
+  for(const [edge,dx,dy] of [['n',0,30],['s',0,-30],['e',-30,0],['w',30,0],['ne',-20,20],['nw',20,20],['se',-20,-20],['sw',20,-20]]) {
+    const before=await bounds(),after=await drag(edge,dx,dy);
+    assert.ok(after.width!==before.width || after.height!==before.height,edge);
+  }
+  const beforeCancel=await bounds();
+  assert.deepEqual(await drag('nw',-50,-50,true),beforeCancel);
+  saved=(await page.evaluate(()=>chrome.storage.local.get('currentVideoAssistantWindowSize'))).currentVideoAssistantWindowSize;
+  await page.getByRole('button',{name:'收起',exact:true}).click();
+  assert.equal(await card.locator('[data-edge]').count(),0);
+  await page.getByRole('button',{name:'展开助手',exact:true}).click();
+  assert.deepEqual(await bounds(),beforeCancel);
+  assert.equal(await draft.inputValue(),'缩放时保留的草稿');
+  await page.screenshot({path:path.join(out,'desktop.png')});
+  await load();
+  assert.equal((await bounds()).width,saved.width);
+  assert.equal((await bounds()).height,saved.height);
+  await card.locator('[data-edge="w"]').focus();
+  const beforeKey=await bounds(); await page.keyboard.press('ArrowLeft');
+  assert.equal((await bounds()).width,beforeKey.width+10);
+  for(const [width,height] of [[390,480],[320,400],[844,390]]) {
+    await page.setViewportSize({width,height}); await bounds();
+    await drag('nw',-2000,-2000); await bounds();
+    await page.screenshot({path:path.join(out,`${width}x${height}.png`)});
+  }
+  const ai=await page.evaluate(()=>window.__assistantMockMessages.filter(m=>['GENERATE_CURRENT_VIDEO_SUMMARY_HIGHLIGHTS','ASK_CURRENT_VIDEO_FULL_TEXT'].includes(m.action)));
+  assert.equal(ai.length,0); assert.deepEqual(errors,[]);
+  report.cases=['eight edges','draft preserved','escape rollback','collapse/reopen','saved size reload','keyboard','three narrow viewports','no implicit AI'];
+  report.status='pass';
+} catch(error) {report.status='fail';report.error=error.stack;process.exitCode=1;}
+finally { await browser.close(); await writeFile(path.join(out,'report.json'),JSON.stringify(report,null,2)); console.log(JSON.stringify({out,...report})); }

--- a/tests/assistant-resize.test.ts
+++ b/tests/assistant-resize.test.ts
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fitAssistantRect, resizeAssistantRect, type ResizeEdge } from '../src/content/player-monitor/assistant-resize.ts';
+
+test('all eight edges resize without moving the opposite edges', () => {
+  const start = { left: 300, top: 200, width: 420, height: 620 };
+  for (const edge of ['n','s','e','w','ne','nw','se','sw'] as ResizeEdge[]) {
+    const next = resizeAssistantRect(start, edge, 30, 25, 1440, 1000);
+    assert.equal(next.left, edge.includes('w') ? 330 : 300);
+    assert.equal(next.top, edge.includes('n') ? 225 : 200);
+    assert.equal(next.width, 420 + (edge.includes('e') ? 30 : edge.includes('w') ? -30 : 0));
+    assert.equal(next.height, 620 + (edge.includes('s') ? 25 : edge.includes('n') ? -25 : 0));
+  }
+});
+test('resizing respects minimum size and viewport bounds in every direction', () => {
+  for (const [vw,vh] of [[1440,900],[390,480],[280,240]]) {
+    for (const edge of ['n','s','e','w','ne','nw','se','sw'] as ResizeEdge[]) {
+      for (const delta of [-10000,10000]) {
+        const next = resizeAssistantRect({left:700,top:400,width:600,height:800},edge,delta,delta,vw,vh);
+        assert.ok(next.left >= 12 && next.top >= 12);
+        assert.ok(next.left + next.width <= vw - 12);
+        assert.ok(next.top + next.height <= vh - 12);
+        assert.ok(next.width >= Math.min(320,vw-24));
+        assert.ok(next.height >= Math.min(360,vh-24));
+      }
+    }
+  }
+});
+test('saved large size is fitted into a smaller viewport', () => {
+  assert.deepEqual(fitAssistantRect({left:900,top:300,width:800,height:700},390,480),{left:12,top:12,width:366,height:456});
+});


### PR DESCRIPTION
Closes #284

用户已确认并授权实施整个页内浮层的宽高调整。

- 四边四角拖拽，最小尺寸和可视区域约束，正文随尺寸布局，拖拽不重建正文。
- 本地仅保存宽高两个数字；收起重开/新页面恢复尺寸；Esc/指针取消/失焦回滚；支持键盘方向键。
- 不改 AI、视频证据、资产存储或跳转合同，无新增权限。

验证：3 项几何单测，typecheck/build/release-dist/diff-check；8 类专项浏览器检查（八方向、草稿、回滚、重开、刷新、键盘、小视口、无自动 AI）；既有 UX 五视口与全屏/主题/字幕跳转返回回归通过。均为实际构建+合成宿主，不冒充真实站点验收。

本地已更新此前 popup-282/extension 目录，保留原包备份和原扩展身份；面试冻结包不变。未读取个人浏览器文件、Cookie、登录态或凭据。未改版本、tag 或正式发布。